### PR TITLE
Apply minimal changes for building on Ubuntu 18.04

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,4 +28,13 @@ EXTRA_DIST =                   \
 	$(Productivity_DATA)        \
 	$(top_srcdir)/omf.make      \
 	$(top_srcdir)/xmldocs.make
-	
+
+
+# Satisfy automake strictness check (README must be present).
+# The existance of rule (line 1) is enough to satisfy the strictness
+# check, but `make dist` actually needs the file, so we just copy it.
+# Note that automake 1.16.4 (from 2021) natively allows .md extension
+# for README and a few others.
+README: README.md
+	cp $< $@
+

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Building
 
 ### Required packages:
 ```
-guile-3.0-dev
+guile-2.0-dev
 libgtk2.0-dev
 libglade2-dev
 libgconf2-dev
@@ -120,7 +120,7 @@ sudo make install
 
 ### Build steps:
 ```
-./autogen.sh --no-configure
+NOCONFIGURE=true ./autogen.sh
 mkdir build; cd build
 ../configure
 ```

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -139,7 +139,8 @@ gnotime_LDADD =          \
 	${GUILE_LIBS}         \
 	$(INTLLIBS) \
 	${GUILE_LDFLAGS} \
-    ${X11_LIBS}
+	${X11_LIBS} \
+	-lm
 
 EXTRA_DIST =         \
 	down.xpm          \


### PR DESCRIPTION
With these changes, I got building on Ubuntu 18.04 to work.

Mostly based on standard packages. Apart from qof, I had to build gtkhtml 3.32 from source (with one small tweak), as that is no longer available prepackaged.
