### PR TITLE
Bump version to 2.99.0 to highlight development

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(src)
-AM_INIT_AUTOMAKE(gnotime, 2.4.1)
+AM_INIT_AUTOMAKE(gnotime, 2.99.0)
 
 dnl AC_PROG_INTLTOOL
 

--- a/redhat/gnotime.spec
+++ b/redhat/gnotime.spec
@@ -1,5 +1,5 @@
 %define name gnotime
-%define ver 2.3.0
+%define ver 2.99.0
 %define rel 1
 %define prefix /usr
 


### PR DESCRIPTION
According to the discussions In #7 I'm going to split it up into multiple disjunct topics. This pull request realizes the version bump. `3.0.0` still feels a bit bold to me (especially since it's quite a way until then). Normally I prefer to add a suffix to the version (as done in the CMake and Meson drafts), but I do not know how to realize this with Autotools. To have a similar effect I did it like Gnome when developing `3.0` and bumped the version to `2.99.0`. This shows that something major is in the making without signaling completion too early ahead ;-)