### PR TITLE
Refactor/unify formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,215 @@
+---
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: BlockIndent
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: Always
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: true
+  BeforeCatch:     true
+  BeforeElse:      true
+  BeforeLambdaBody: false
+  BeforeWhile:     true
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: All
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     96
+CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: BinPack
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: false
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequiresClause: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Right
+PPIndentWidth:   -1
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+RequiresClausePosition: OwnLine
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: false
+  AfterForeachMacros: false
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   false
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        c++03
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        4
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...
+

--- a/src/active-dialog.c
+++ b/src/active-dialog.c
@@ -24,153 +24,144 @@
 
 #include <qof.h>
 
-#include "cur-proj.h"
 #include "active-dialog.h"
-#include "proj.h"
-#include "proj-query.h"
-#include "util.h"
+#include "cur-proj.h"
 #include "dialog.h"
-
+#include "proj-query.h"
+#include "proj.h"
+#include "util.h"
 
 int config_no_project_timeout;
 
 struct GttActiveDialog_s
 {
-	GladeXML    *gtxml;
-	GtkDialog   *dlg;
-	GtkButton   *yes_btn;
-	GtkButton   *no_btn;
-	GtkButton   *help_btn;
-	GtkLabel    *active_label;
-	GtkLabel    *credit_label;
-	GtkOptionMenu  *project_menu;
-	guint        timeout_event_source;
+    GladeXML *gtxml;
+    GtkDialog *dlg;
+    GtkButton *yes_btn;
+    GtkButton *no_btn;
+    GtkButton *help_btn;
+    GtkLabel *active_label;
+    GtkLabel *credit_label;
+    GtkOptionMenu *project_menu;
+    guint timeout_event_source;
 };
 
+void show_active_dialog(GttActiveDialog *ad);
 
-void show_active_dialog (GttActiveDialog *ad);
-
-static gboolean
-active_timeout_func (gpointer data)
+static gboolean active_timeout_func(gpointer data)
 {
-	GttActiveDialog *active_dialog = (GttActiveDialog *) data;
-	show_active_dialog (active_dialog);
+    GttActiveDialog *active_dialog = (GttActiveDialog *) data;
+    show_active_dialog(active_dialog);
 
-	/* Mark the timer as inactive */
-	active_dialog->timeout_event_source = 0;
+    /* Mark the timer as inactive */
+    active_dialog->timeout_event_source = 0;
 
-	/* deactivate the timer */
-	return FALSE;
+    /* deactivate the timer */
+    return FALSE;
 }
 
 /* =========================================================== */
 
-static void
-schedule_active_timeout (gint timeout, GttActiveDialog *active_dialog)
+static void schedule_active_timeout(gint timeout, GttActiveDialog *active_dialog)
 {
-	if (timeout > 0)
-	{
-		if (active_dialog->timeout_event_source)
-		{
-			g_source_remove (active_dialog->timeout_event_source);
-		}
-		active_dialog->timeout_event_source = g_timeout_add_seconds (timeout, active_timeout_func, active_dialog);
-	}
+    if (timeout > 0)
+    {
+        if (active_dialog->timeout_event_source)
+        {
+            g_source_remove(active_dialog->timeout_event_source);
+        }
+        active_dialog->timeout_event_source
+            = g_timeout_add_seconds(timeout, active_timeout_func, active_dialog);
+    }
 }
 
 /* =========================================================== */
 
-static void
-dialog_help (GObject *obj, GttActiveDialog *dlg)
+static void dialog_help(GObject *obj, GttActiveDialog *dlg)
 {
-	gtt_help_popup (GTK_WIDGET(dlg->dlg), "idletimer");
+    gtt_help_popup(GTK_WIDGET(dlg->dlg), "idletimer");
 }
 
 /* =========================================================== */
 
-static void
-dialog_close (GObject *obj, GttActiveDialog *dlg)
+static void dialog_close(GObject *obj, GttActiveDialog *dlg)
 {
-	dlg->dlg = NULL;
-	dlg->gtxml = NULL;
+    dlg->dlg = NULL;
+    dlg->gtxml = NULL;
 
-	if (!cur_proj)
-	{
-		schedule_active_timeout (config_no_project_timeout, dlg);
-	}
-
+    if (!cur_proj)
+    {
+        schedule_active_timeout(config_no_project_timeout, dlg);
+    }
 }
 
 /* =========================================================== */
 
-static void
-dialog_kill (GObject *obj, GttActiveDialog *dlg)
+static void dialog_kill(GObject *obj, GttActiveDialog *dlg)
 {
-	gtk_widget_destroy (GTK_WIDGET(dlg->dlg));
-	dlg->dlg = NULL;
-	dlg->gtxml = NULL;
-	if (!cur_proj)
-	{
-		schedule_active_timeout (config_no_project_timeout, dlg);
-	}
+    gtk_widget_destroy(GTK_WIDGET(dlg->dlg));
+    dlg->dlg = NULL;
+    dlg->gtxml = NULL;
+    if (!cur_proj)
+    {
+        schedule_active_timeout(config_no_project_timeout, dlg);
+    }
 }
 
 /* =========================================================== */
 
-static void
-start_proj (GObject *obj, GttActiveDialog *dlg)
+static void start_proj(GObject *obj, GttActiveDialog *dlg)
 {
-	GtkMenu *menu;
-	GtkWidget *w;
-	GttProject *prj;
-	
-	/* Start the project that the user has selected from the menu */
-	menu = GTK_MENU (gtk_option_menu_get_menu (dlg->project_menu));
-	w = gtk_menu_get_active (menu);
-	prj = g_object_get_data (G_OBJECT (w), "prj");
+    GtkMenu *menu;
+    GtkWidget *w;
+    GttProject *prj;
 
-	cur_proj_set (prj);
-	dialog_kill (obj, dlg);
+    /* Start the project that the user has selected from the menu */
+    menu = GTK_MENU(gtk_option_menu_get_menu(dlg->project_menu));
+    w = gtk_menu_get_active(menu);
+    prj = g_object_get_data(G_OBJECT(w), "prj");
+
+    cur_proj_set(prj);
+    dialog_kill(obj, dlg);
 }
 
 /* =========================================================== */
 
-static void
-setup_menus (GttActiveDialog *dlg)
+static void setup_menus(GttActiveDialog *dlg)
 {
-	GtkMenuShell *menushell;
-	GList *prjlist, *node;
-	char * msg;
+    GtkMenuShell *menushell;
+    GList *prjlist, *node;
+    char *msg;
 
-	msg = _("No project timer is currently running in GnoTime.  "
-	        "Do you want to start a project timer running?  "
-	        "If so, you can select a project from the menu below, "
-	        "and click 'Start' to start the project running.  "
-	        "Otherwise, just click 'Cancel' to do nothing.");
+    msg = _("No project timer is currently running in GnoTime.  "
+            "Do you want to start a project timer running?  "
+            "If so, you can select a project from the menu below, "
+            "and click 'Start' to start the project running.  "
+            "Otherwise, just click 'Cancel' to do nothing.");
 
-	gtk_label_set_text (dlg->active_label, msg);
+    gtk_label_set_text(dlg->active_label, msg);
 
-	msg = _("You can credit this project with the time that you worked "
-	        "on it but were away from the keyboard.  Enter a time below, "
-	        "the project will be credited when you click 'Start'");
+    msg = _("You can credit this project with the time that you worked "
+            "on it but were away from the keyboard.  Enter a time below, "
+            "the project will be credited when you click 'Start'");
 
-	gtk_label_set_text (dlg->credit_label, msg);
+    gtk_label_set_text(dlg->credit_label, msg);
 
-	menushell = GTK_MENU_SHELL (gtk_menu_new());
+    menushell = GTK_MENU_SHELL(gtk_menu_new());
 
-	/* Give user a list only of the unfinished projects,
-	 * so that there isn't too much clutter ... */
-	prjlist = gtt_project_get_unfinished ();
-	for (node = prjlist; node; node=node->next)
-	{
-		GttProject *prj = node->data;
-		GtkWidget *item;
-		item = gtk_menu_item_new_with_label (gtt_project_get_title (prj));
-		g_object_set_data (G_OBJECT(item), "prj", prj);
-		gtk_menu_shell_append (menushell, item);
-		gtk_widget_show (item);
-	}
-	gtk_option_menu_set_menu (dlg->project_menu, GTK_WIDGET(menushell));
+    /* Give user a list only of the unfinished projects,
+     * so that there isn't too much clutter ... */
+    prjlist = gtt_project_get_unfinished();
+    for (node = prjlist; node; node = node->next)
+    {
+        GttProject *prj = node->data;
+        GtkWidget *item;
+        item = gtk_menu_item_new_with_label(gtt_project_get_title(prj));
+        g_object_set_data(G_OBJECT(item), "prj", prj);
+        gtk_menu_shell_append(menushell, item);
+        gtk_widget_show(item);
+    }
+    gtk_option_menu_set_menu(dlg->project_menu, GTK_WIDGET(menushell));
 }
 
 /* =========================================================== */
@@ -179,108 +170,96 @@ setup_menus (GttActiveDialog *dlg)
  * do a heavyweight re-initialization each time.  Urgh.
  */
 
-static void
-active_dialog_realize (GttActiveDialog * id)
+static void active_dialog_realize(GttActiveDialog *id)
 {
-	GtkWidget *w;
-	GladeXML *gtxml;
+    GtkWidget *w;
+    GladeXML *gtxml;
 
-	gtxml = gtt_glade_xml_new ("glade/active.glade", "Active Dialog");
-	id->gtxml = gtxml;
+    gtxml = gtt_glade_xml_new("glade/active.glade", "Active Dialog");
+    id->gtxml = gtxml;
 
-	id->dlg = GTK_DIALOG (glade_xml_get_widget (gtxml, "Active Dialog"));
+    id->dlg = GTK_DIALOG(glade_xml_get_widget(gtxml, "Active Dialog"));
 
-	id->yes_btn = GTK_BUTTON(glade_xml_get_widget (gtxml, "yes button"));
-	id->no_btn  = GTK_BUTTON(glade_xml_get_widget (gtxml, "no button"));
-	id->help_btn = GTK_BUTTON(glade_xml_get_widget (gtxml, "helpbutton1"));
-	id->active_label = GTK_LABEL (glade_xml_get_widget (gtxml, "active label"));
-	id->credit_label = GTK_LABEL (glade_xml_get_widget (gtxml, "credit label"));
-	w = glade_xml_get_widget (gtxml, "project option menu");
-	id->project_menu = GTK_OPTION_MENU (w);
+    id->yes_btn = GTK_BUTTON(glade_xml_get_widget(gtxml, "yes button"));
+    id->no_btn = GTK_BUTTON(glade_xml_get_widget(gtxml, "no button"));
+    id->help_btn = GTK_BUTTON(glade_xml_get_widget(gtxml, "helpbutton1"));
+    id->active_label = GTK_LABEL(glade_xml_get_widget(gtxml, "active label"));
+    id->credit_label = GTK_LABEL(glade_xml_get_widget(gtxml, "credit label"));
+    w = glade_xml_get_widget(gtxml, "project option menu");
+    id->project_menu = GTK_OPTION_MENU(w);
 
-	g_signal_connect(G_OBJECT(id->dlg), "destroy",
-	          G_CALLBACK(dialog_close), id);
+    g_signal_connect(G_OBJECT(id->dlg), "destroy", G_CALLBACK(dialog_close), id);
 
-	g_signal_connect(G_OBJECT(id->yes_btn), "clicked",
-	          G_CALLBACK(start_proj), id);
+    g_signal_connect(G_OBJECT(id->yes_btn), "clicked", G_CALLBACK(start_proj), id);
 
-	g_signal_connect(G_OBJECT(id->no_btn), "clicked",
-	          G_CALLBACK(dialog_kill), id);
+    g_signal_connect(G_OBJECT(id->no_btn), "clicked", G_CALLBACK(dialog_kill), id);
 
-	g_signal_connect(G_OBJECT(id->help_btn), "clicked",
-	          G_CALLBACK(dialog_help), id);
-
+    g_signal_connect(G_OBJECT(id->help_btn), "clicked", G_CALLBACK(dialog_help), id);
 }
 
 /* =========================================================== */
 
-GttActiveDialog *
-active_dialog_new (void)
+GttActiveDialog *active_dialog_new(void)
 {
-	GttActiveDialog *ad;
+    GttActiveDialog *ad;
 
-	ad = g_new0 (GttActiveDialog, 1);
-	ad->gtxml = NULL;
+    ad = g_new0(GttActiveDialog, 1);
+    ad->gtxml = NULL;
 
-	return ad;
+    return ad;
 }
 
 /* =========================================================== */
 
-void
-show_active_dialog (GttActiveDialog *ad)
+void show_active_dialog(GttActiveDialog *ad)
 {
-	g_return_if_fail(ad);
+    g_return_if_fail(ad);
 
-	g_return_if_fail(!cur_proj);
+    g_return_if_fail(!cur_proj);
 
-	/* Due to GtkDialog broken-ness, re-realize the GUI */
-	if (NULL == ad->gtxml)
-	{
-		active_dialog_realize (ad);
-		setup_menus (ad);
-	
-		gtk_widget_show (GTK_WIDGET(ad->dlg));
-	}
-	else
-	{
-		raise_active_dialog (ad);
-	}
+    /* Due to GtkDialog broken-ness, re-realize the GUI */
+    if (NULL == ad->gtxml)
+    {
+        active_dialog_realize(ad);
+        setup_menus(ad);
+
+        gtk_widget_show(GTK_WIDGET(ad->dlg));
+    }
+    else
+    {
+        raise_active_dialog(ad);
+    }
 }
 
 /* =========================================================== */
 
-void
-raise_active_dialog (GttActiveDialog *ad)
+void raise_active_dialog(GttActiveDialog *ad)
 {
 
-	g_return_if_fail(ad);
-	g_return_if_fail(ad->gtxml);
+    g_return_if_fail(ad);
+    g_return_if_fail(ad->gtxml);
 
-	/* The following will raise the window, and put it on the current
-	 * workspace, at least if the metacity WM is used. Haven't tried
-	 * other window managers.
-	 */
-	gtk_window_present (GTK_WINDOW (ad->dlg));
+    /* The following will raise the window, and put it on the current
+     * workspace, at least if the metacity WM is used. Haven't tried
+     * other window managers.
+     */
+    gtk_window_present(GTK_WINDOW(ad->dlg));
 }
 
 /* =========================================================== */
 
-void
-active_dialog_activate_timer (GttActiveDialog *active_dialog)
+void active_dialog_activate_timer(GttActiveDialog *active_dialog)
 {
-	schedule_active_timeout (config_no_project_timeout, active_dialog);
+    schedule_active_timeout(config_no_project_timeout, active_dialog);
 }
 
-void
-active_dialog_deactivate_timer (GttActiveDialog *active_dialog)
+void active_dialog_deactivate_timer(GttActiveDialog *active_dialog)
 {
-	if (active_dialog->timeout_event_source)
-	{
-		g_source_remove (active_dialog->timeout_event_source);
-		active_dialog->timeout_event_source = 0;
-	}
+    if (active_dialog->timeout_event_source)
+    {
+        g_source_remove(active_dialog->timeout_event_source);
+        active_dialog->timeout_event_source = 0;
+    }
 }
 
 /* =========================== END OF FILE ============================== */
-

--- a/src/active-dialog.h
+++ b/src/active-dialog.h
@@ -37,12 +37,12 @@
 
 typedef struct GttActiveDialog_s GttActiveDialog;
 
-GttActiveDialog * active_dialog_new (void);
+GttActiveDialog *active_dialog_new(void);
 
 /** This routine will display the active dialog, but only
  *  if the keyboard/mouse has been idle for some amount of time.
  */
-void show_active_dialog (GttActiveDialog *id);
+void show_active_dialog(GttActiveDialog *id);
 
 /** This routine will raise the active dialog to the top of the
  *  current screen. But it will do this only if the active dialog
@@ -52,9 +52,9 @@ void show_active_dialog (GttActiveDialog *id);
  *  another window, or it ends up on a different workspace than the
  *  current workspace, and so the user can't see it, can't find it.
  */
-void raise_active_dialog (GttActiveDialog *id);
+void raise_active_dialog(GttActiveDialog *id);
 
-void active_dialog_activate_timer (GttActiveDialog *id);
-void active_dialog_deactivate_timer (GttActiveDialog *id);
+void active_dialog_activate_timer(GttActiveDialog *id);
+void active_dialog_deactivate_timer(GttActiveDialog *id);
 
 #endif /* GTT_ACTIVITY_DIALOG_H_ */

--- a/src/app.c
+++ b/src/app.c
@@ -38,12 +38,12 @@
 #include "menus.h"
 #include "notes-area.h"
 #include "prefs.h"
+#include "proj.h"
+#include "projects-tree.h"
 #include "props-proj.h"
 #include "timer.h"
 #include "toolbar.h"
 #include "util.h"
-#include "projects-tree.h"
-#include "proj.h"
 
 /* XXX Most of the globals below should be placed into a single
  * application-wide top-level structure, rather than being allowed
@@ -56,7 +56,6 @@ NotesArea *global_na = NULL;
 GtkWidget *app_window = NULL;
 GtkWidget *status_bar = NULL;
 
-
 static GtkLabel *status_project = NULL;
 static GtkLabel *status_day_time = NULL;
 static GtkWidget *status_timer = NULL;
@@ -67,491 +66,501 @@ char *config_shell_stop = NULL;
 gboolean geom_place_override = FALSE;
 gboolean geom_size_override = FALSE;
 
-
 extern GttActiveDialog *act;
 
-static void
-projects_tree_row_activated (GtkTreeView *tree_view, GtkTreePath *path, GtkTreeViewColumn *column, gpointer user_data)
+static void projects_tree_row_activated(
+    GtkTreeView *tree_view, GtkTreePath *path, GtkTreeViewColumn *column, gpointer user_data
+)
 {
-	GttProjectsTree *gpt = GTT_PROJECTS_TREE (tree_view);
-	GttProject *prj = gtt_projects_tree_get_selected_project (gpt);
-	if (cur_proj == prj)
-	{
-		cur_proj_set (NULL);
-	}
-	else
-	{
-		cur_proj_set (prj);
-	}
+    GttProjectsTree *gpt = GTT_PROJECTS_TREE(tree_view);
+    GttProject *prj = gtt_projects_tree_get_selected_project(gpt);
+    if (cur_proj == prj)
+    {
+        cur_proj_set(NULL);
+    }
+    else
+    {
+        cur_proj_set(prj);
+    }
 }
 
-typedef void (*sort_function) (GttProjectList *);
+typedef void (*sort_function)(GttProjectList *);
 
-static void
-column_clicked (GtkTreeViewColumn *column, gpointer user_data)
+static void column_clicked(GtkTreeViewColumn *column, gpointer user_data)
 {
-	sort_function f = (sort_function) user_data;
+    sort_function f = (sort_function) user_data;
 
-	f (global_plist);
-	gchar *expander_state = gtt_projects_tree_get_expander_state (projects_tree);
-	gtt_projects_tree_populate (projects_tree, gtt_project_list_get_list (global_plist), TRUE);
-	gtt_projects_tree_set_expander_state (projects_tree, expander_state);
-	gtt_projects_tree_set_sorted_column (projects_tree, column);
-
+    f(global_plist);
+    gchar *expander_state = gtt_projects_tree_get_expander_state(projects_tree);
+    gtt_projects_tree_populate(projects_tree, gtt_project_list_get_list(global_plist), TRUE);
+    gtt_projects_tree_set_expander_state(projects_tree, expander_state);
+    gtt_projects_tree_set_sorted_column(projects_tree, column);
 }
 
-static void
-projects_tree_columns_setup_done (GttProjectsTree *projects_tree, gpointer user_data)
+static void projects_tree_columns_setup_done(GttProjectsTree *projects_tree, gpointer user_data)
 {
 
-	GtkTreeViewColumn *column = NULL;
+    GtkTreeViewColumn *column = NULL;
 
-	column = gtt_projects_tree_get_column_by_name (projects_tree, "time_ever");
-	if (column)
-	{
-		g_signal_connect (column, "clicked", G_CALLBACK (column_clicked), project_list_sort_ever);
-	}
+    column = gtt_projects_tree_get_column_by_name(projects_tree, "time_ever");
+    if (column)
+    {
+        g_signal_connect(column, "clicked", G_CALLBACK(column_clicked), project_list_sort_ever);
+    }
 
-	column = gtt_projects_tree_get_column_by_name (projects_tree, "time_year");
-	if (column)
-	{
-		g_signal_connect (column, "clicked", G_CALLBACK (column_clicked), project_list_sort_year);
+    column = gtt_projects_tree_get_column_by_name(projects_tree, "time_year");
+    if (column)
+    {
+        g_signal_connect(column, "clicked", G_CALLBACK(column_clicked), project_list_sort_year);
+    }
 
-	}
+    column = gtt_projects_tree_get_column_by_name(projects_tree, "time_month");
+    if (column)
+    {
+        g_signal_connect(
+            column, "clicked", G_CALLBACK(column_clicked), project_list_sort_month
+        );
+    }
 
-	column = gtt_projects_tree_get_column_by_name (projects_tree, "time_month");
-	if (column)
-	{
-		g_signal_connect (column, "clicked", G_CALLBACK (column_clicked), project_list_sort_month);
-	}
+    column = gtt_projects_tree_get_column_by_name(projects_tree, "time_week");
+    if (column)
+    {
+        g_signal_connect(column, "clicked", G_CALLBACK(column_clicked), project_list_sort_week);
+    }
 
-	column = gtt_projects_tree_get_column_by_name (projects_tree, "time_week");
-	if (column)
-	{
-		g_signal_connect (column, "clicked", G_CALLBACK (column_clicked), project_list_sort_week);
-	}
+    column = gtt_projects_tree_get_column_by_name(projects_tree, "time_lastweek");
+    if (column)
+    {
+        g_signal_connect(
+            column, "clicked", G_CALLBACK(column_clicked), project_list_sort_lastweek
+        );
+    }
 
-	column = gtt_projects_tree_get_column_by_name (projects_tree, "time_lastweek");
-	if (column)
-	{
-		g_signal_connect (column, "clicked", G_CALLBACK (column_clicked), project_list_sort_lastweek);
-	}
+    column = gtt_projects_tree_get_column_by_name(projects_tree, "time_yesterday");
+    if (column)
+    {
+        g_signal_connect(
+            column, "clicked", G_CALLBACK(column_clicked), project_list_sort_yesterday
+        );
+    }
 
-	column = gtt_projects_tree_get_column_by_name (projects_tree, "time_yesterday");
-	if (column)
-	{
-		g_signal_connect (column, "clicked", G_CALLBACK (column_clicked), project_list_sort_yesterday);
-	}
+    column = gtt_projects_tree_get_column_by_name(projects_tree, "time_today");
+    if (column)
+    {
+        g_signal_connect(column, "clicked", G_CALLBACK(column_clicked), project_list_sort_day);
+    }
 
-	column = gtt_projects_tree_get_column_by_name (projects_tree, "time_today");
-	if (column)
-	{
-		g_signal_connect (column, "clicked", G_CALLBACK (column_clicked), project_list_sort_day);
-	}
+    column = gtt_projects_tree_get_column_by_name(projects_tree, "time_task");
+    if (column)
+    {
+        g_signal_connect(
+            column, "clicked", G_CALLBACK(column_clicked), project_list_sort_current
+        );
+    }
 
-	column = gtt_projects_tree_get_column_by_name (projects_tree, "time_task");
-	if (column)
-	{
-		g_signal_connect (column, "clicked", G_CALLBACK (column_clicked), project_list_sort_current);
-	}
+    column = gtt_projects_tree_get_column_by_name(projects_tree, "title");
+    if (column)
+    {
+        g_signal_connect(
+            column, "clicked", G_CALLBACK(column_clicked), project_list_sort_title
+        );
+    }
 
-	column = gtt_projects_tree_get_column_by_name (projects_tree, "title");
-	if (column)
-	{
-		g_signal_connect (column, "clicked", G_CALLBACK (column_clicked), project_list_sort_title);
-	}
+    column = gtt_projects_tree_get_column_by_name(projects_tree, "description");
+    if (column)
+    {
+        g_signal_connect(column, "clicked", G_CALLBACK(column_clicked), project_list_sort_desc);
+    }
 
-	column = gtt_projects_tree_get_column_by_name (projects_tree, "description");
-	if (column)
-	{
-		g_signal_connect (column, "clicked", G_CALLBACK (column_clicked), project_list_sort_desc);
-	}
+    column = gtt_projects_tree_get_column_by_name(projects_tree, "estimated_start");
+    if (column)
+    {
+        g_signal_connect(
+            column, "clicked", G_CALLBACK(column_clicked), project_list_sort_start
+        );
+    }
 
-	column = gtt_projects_tree_get_column_by_name (projects_tree, "estimated_start");
-	if (column)
-	{
-		g_signal_connect (column, "clicked", G_CALLBACK (column_clicked), project_list_sort_start);
-	}
+    column = gtt_projects_tree_get_column_by_name(projects_tree, "estimated_end");
+    if (column)
+    {
+        g_signal_connect(column, "clicked", G_CALLBACK(column_clicked), project_list_sort_end);
+    }
 
-	column = gtt_projects_tree_get_column_by_name (projects_tree, "estimated_end");
-	if (column)
-	{
-		g_signal_connect (column, "clicked", G_CALLBACK (column_clicked), project_list_sort_end);
-	}
+    column = gtt_projects_tree_get_column_by_name(projects_tree, "due_date");
+    if (column)
+    {
+        g_signal_connect(column, "clicked", G_CALLBACK(column_clicked), project_list_sort_due);
+    }
 
-	column = gtt_projects_tree_get_column_by_name (projects_tree, "due_date");
-	if (column)
-	{
-		g_signal_connect (column, "clicked", G_CALLBACK (column_clicked), project_list_sort_due);
-	}
+    column = gtt_projects_tree_get_column_by_name(projects_tree, "sizing");
+    if (column)
+    {
+        g_signal_connect(
+            column, "clicked", G_CALLBACK(column_clicked), project_list_sort_sizing
+        );
+    }
 
-	column = gtt_projects_tree_get_column_by_name (projects_tree, "sizing");
-	if (column)
-	{
-		g_signal_connect (column, "clicked", G_CALLBACK (column_clicked), project_list_sort_sizing);
-	}
+    column = gtt_projects_tree_get_column_by_name(projects_tree, "percent_done");
+    if (column)
+    {
+        g_signal_connect(
+            column, "clicked", G_CALLBACK(column_clicked), project_list_sort_percent
+        );
+    }
 
-	column = gtt_projects_tree_get_column_by_name (projects_tree, "percent_done");
-	if (column)
-	{
-		g_signal_connect (column, "clicked", G_CALLBACK (column_clicked), project_list_sort_percent);
-	}
+    column = gtt_projects_tree_get_column_by_name(projects_tree, "urgency");
+    if (column)
+    {
+        g_signal_connect(
+            column, "clicked", G_CALLBACK(column_clicked), project_list_sort_urgency
+        );
+    }
 
-	column = gtt_projects_tree_get_column_by_name (projects_tree, "urgency");
-	if (column)
-	{
-		g_signal_connect (column, "clicked", G_CALLBACK (column_clicked), project_list_sort_urgency);
-	}
+    column = gtt_projects_tree_get_column_by_name(projects_tree, "importance");
+    if (column)
+    {
+        g_signal_connect(
+            column, "clicked", G_CALLBACK(column_clicked), project_list_sort_importance
+        );
+    }
 
-	column = gtt_projects_tree_get_column_by_name (projects_tree, "importance");
-	if (column)
-	{
-		g_signal_connect (column, "clicked", G_CALLBACK (column_clicked), project_list_sort_importance);
-	}
-
-	column = gtt_projects_tree_get_column_by_name (projects_tree, "status");
-	if (column)
-	{
-		g_signal_connect (column, "clicked", G_CALLBACK (column_clicked), project_list_sort_status);
-	}
+    column = gtt_projects_tree_get_column_by_name(projects_tree, "status");
+    if (column)
+    {
+        g_signal_connect(
+            column, "clicked", G_CALLBACK(column_clicked), project_list_sort_status
+        );
+    }
 }
 
 /* ============================================================= */
 
-void
-update_status_bar(void)
+void update_status_bar(void)
 {
-	char day_total_str[25];
-	char *s;
+    char day_total_str[25];
+    char *s;
 
-	if (!status_bar) return;
+    if (!status_bar)
+        return;
 
-	/* Make the little clock item appear/disappear
-	 * when the project is started/stopped */
-	if (status_timer)
-	{
-		if (timer_is_running())
-			gtk_widget_show(status_timer);
-		else
-			gtk_widget_hide(status_timer);
-	}
+    /* Make the little clock item appear/disappear
+     * when the project is started/stopped */
+    if (status_timer)
+    {
+        if (timer_is_running())
+            gtk_widget_show(status_timer);
+        else
+            gtk_widget_hide(status_timer);
+    }
 
-	/* update timestamp */
-	xxxqof_print_hours_elapsed_buff (day_total_str, 25,
-	                                 gtt_project_list_total_secs_day(),
-	                                 config_show_secs);
+    /* update timestamp */
+    xxxqof_print_hours_elapsed_buff(
+        day_total_str, 25, gtt_project_list_total_secs_day(), config_show_secs
+    );
 
-	if (0 != strcmp(day_total_str, gtk_label_get_text(status_day_time)))
-	{
-		gtk_label_set_text(status_day_time, day_total_str);
-	}
+    if (0 != strcmp(day_total_str, gtk_label_get_text(status_day_time)))
+    {
+        gtk_label_set_text(status_day_time, day_total_str);
+    }
 
-	/* Display the project title */
-	if (cur_proj)
-	{
-		s = g_strdup_printf ("%s - %s",
-	                       gtt_project_get_title(cur_proj),
-	                       gtt_project_get_desc(cur_proj));
-	}
-	else
-	{
-		s = g_strdup(_("Timer is not running"));
-	}
+    /* Display the project title */
+    if (cur_proj)
+    {
+        s = g_strdup_printf(
+            "%s - %s", gtt_project_get_title(cur_proj), gtt_project_get_desc(cur_proj)
+        );
+    }
+    else
+    {
+        s = g_strdup(_("Timer is not running"));
+    }
 
-	if (0 != strcmp(s, gtk_label_get_text(status_project)))
-	{
-		gtk_label_set_text(status_project, s);
-	}
-	g_free(s);
+    if (0 != strcmp(s, gtk_label_get_text(status_project)))
+    {
+        gtk_label_set_text(status_project, s);
+    }
+    g_free(s);
 }
-
 
 /* ============================================================= */
 /* Handle shell commands */
 
-void
-do_run_shell_command (const char * str)
+void do_run_shell_command(const char *str)
 {
-	pid_t pid;
-	char *shell_path;
-	int rc;
-	struct stat shat;
+    pid_t pid;
+    char *shell_path;
+    int rc;
+    struct stat shat;
 
-	/* XXX This whole thing needs to be reviewewed for security */
+    /* XXX This whole thing needs to be reviewewed for security */
 
-	 /* Provide minimal security by using only system shells */
-	shell_path = "/bin/sh";
-	rc = stat (shell_path, &shat);
-	if ((0 == rc) && S_ISREG (shat.st_mode) && (S_IXUSR & shat.st_mode))
-	{
-		goto do_run_shell;
-	}
+    /* Provide minimal security by using only system shells */
+    shell_path = "/bin/sh";
+    rc = stat(shell_path, &shat);
+    if ((0 == rc) && S_ISREG(shat.st_mode) && (S_IXUSR & shat.st_mode))
+    {
+        goto do_run_shell;
+    }
 
-	shell_path = "/usr/bin/sh";
-	rc = stat (shell_path, &shat);
-	if ((0 == rc) && S_ISREG (shat.st_mode) && (S_IXUSR & shat.st_mode))
-	{
-		goto do_run_shell;
-	}
-	g_warning("%s: %d: do_run_shell_command: can't find shell\n", __FILE__, __LINE__);
-	return;
+    shell_path = "/usr/bin/sh";
+    rc = stat(shell_path, &shat);
+    if ((0 == rc) && S_ISREG(shat.st_mode) && (S_IXUSR & shat.st_mode))
+    {
+        goto do_run_shell;
+    }
+    g_warning("%s: %d: do_run_shell_command: can't find shell\n", __FILE__, __LINE__);
+    return;
 
 do_run_shell:
-	pid = fork();
-	if (pid == 0)
-	{
-		execlp(shell_path, shell_path, "-c", str, NULL);
-		g_warning("%s: %d: do_run_shell_command: couldn't exec\n", __FILE__, __LINE__);
-		exit(1);
-	}
-	if (pid < 0)
-	{
-		g_warning("%s: %d: do_run_shell_command: couldn't fork\n", __FILE__, __LINE__);
-	}
+    pid = fork();
+    if (pid == 0)
+    {
+        execlp(shell_path, shell_path, "-c", str, NULL);
+        g_warning("%s: %d: do_run_shell_command: couldn't exec\n", __FILE__, __LINE__);
+        exit(1);
+    }
+    if (pid < 0)
+    {
+        g_warning("%s: %d: do_run_shell_command: couldn't fork\n", __FILE__, __LINE__);
+    }
 
-	/* Note that the forked processes might be scheduled by the operating
-	 * system 'out of order', if we've made rapid successive calls to this
-	 * routine.  So we try to ensure in-order execution by trying to let
-	 * the child process at least start running.  And we can do this by
-	 * yielding our time-slice ... */
-	sched_yield();
+    /* Note that the forked processes might be scheduled by the operating
+     * system 'out of order', if we've made rapid successive calls to this
+     * routine.  So we try to ensure in-order execution by trying to let
+     * the child process at least start running.  And we can do this by
+     * yielding our time-slice ... */
+    sched_yield();
 }
 
-void
-run_shell_command (GttProject *proj, gboolean do_start)
+void run_shell_command(GttProject *proj, gboolean do_start)
 {
-	char *cmd;
-	const char *str;
+    char *cmd;
+    const char *str;
 
-	cmd = (do_start) ? config_shell_start : config_shell_stop;
+    cmd = (do_start) ? config_shell_start : config_shell_stop;
 
-	if (!cmd) return;
+    if (!cmd)
+        return;
 
-	/* Sometimes, we are called to stop a NULL project.
-	 * We don't really want that (its a result be being called twice).
-	 */
-	if (!proj) return;
+    /* Sometimes, we are called to stop a NULL project.
+     * We don't really want that (its a result be being called twice).
+     */
+    if (!proj)
+        return;
 
-	str = printf_project (cmd, proj);
-	 do_run_shell_command (str);
-	g_free ((gchar *) str);
+    str = printf_project(cmd, proj);
+    do_run_shell_command(str);
+    g_free((gchar *) str);
 }
 
 /* ============================================================= */
 
-void
-cur_proj_set (GttProject *proj)
+void cur_proj_set(GttProject *proj)
 {
-	/* Due to the way the widget callbacks work,
-	 * we may be called recursively ... */
-	if (cur_proj == proj) return;
+    /* Due to the way the widget callbacks work,
+     * we may be called recursively ... */
+    if (cur_proj == proj)
+        return;
 
-	log_proj(NULL);
-	gtt_project_timer_stop (cur_proj);
-	gtt_status_icon_stop_timer (proj);
-	run_shell_command (cur_proj, FALSE);
+    log_proj(NULL);
+    gtt_project_timer_stop(cur_proj);
+    gtt_status_icon_stop_timer(proj);
+    run_shell_command(cur_proj, FALSE);
 
-	GttProject *old_prj = cur_proj;
-	if (proj)
-	{
-		if (timer_is_running ())
-		{
-			stop_main_timer ();
-		}
-		cur_proj = proj;
-		gtt_project_timer_start (proj);
-		gtt_status_icon_start_timer (proj);
-		run_shell_command (cur_proj, TRUE);
-		start_idle_timer ();
-		start_main_timer ();
-	}
-	else
-	{
-		if (timer_is_running ())
-		{
-			stop_main_timer ();
-		}
-		cur_proj = NULL;
-		start_no_project_timer ();
-	}
-	log_proj(proj);
+    GttProject *old_prj = cur_proj;
+    if (proj)
+    {
+        if (timer_is_running())
+        {
+            stop_main_timer();
+        }
+        cur_proj = proj;
+        gtt_project_timer_start(proj);
+        gtt_status_icon_start_timer(proj);
+        run_shell_command(cur_proj, TRUE);
+        start_idle_timer();
+        start_main_timer();
+    }
+    else
+    {
+        if (timer_is_running())
+        {
+            stop_main_timer();
+        }
+        cur_proj = NULL;
+        start_no_project_timer();
+    }
+    log_proj(proj);
 
-	if (old_prj)
-	{
-		gtt_projects_tree_update_project_data (projects_tree, old_prj);
-	}
+    if (old_prj)
+    {
+        gtt_projects_tree_update_project_data(projects_tree, old_prj);
+    }
 
-	if (cur_proj)
-	{
-		gtt_projects_tree_update_project_data (projects_tree, cur_proj);
-	}
+    if (cur_proj)
+    {
+        gtt_projects_tree_update_project_data(projects_tree, cur_proj);
+    }
 
-	/* update GUI elements */
-	menu_set_states();
-	toolbar_set_states();
-	if (proj)
-	{
-		prop_dialog_set_project(proj);
-		notes_area_set_project (global_na, proj);
-	}
-	update_status_bar();
+    /* update GUI elements */
+    menu_set_states();
+    toolbar_set_states();
+    if (proj)
+    {
+        prop_dialog_set_project(proj);
+        notes_area_set_project(global_na, proj);
+    }
+    update_status_bar();
 }
-
 
 /* ============================================================= */
 
-void
-focus_row_set (GttProject *proj)
+void focus_row_set(GttProject *proj)
 {
-	/* update GUI elements */
+    /* update GUI elements */
 
-	prop_dialog_set_project(proj);
-	notes_area_set_project (global_na, proj);
+    prop_dialog_set_project(proj);
+    notes_area_set_project(global_na, proj);
 }
-
 
 /* ============================================================= */
 
-void
-app_new(int argc, char *argv[], const char *geometry_string)
+void app_new(int argc, char *argv[], const char *geometry_string)
 {
-	GtkWidget *vbox;
-	GtkWidget *widget;
-	GtkWidget *vpane;
-	GtkWidget *separator;
-	GtkLabel *filler;
-	GtkHBox *labels;
-	GtkVBox *status_vbox;
-	GtkStatusbar *grip;
+    GtkWidget *vbox;
+    GtkWidget *widget;
+    GtkWidget *vpane;
+    GtkWidget *separator;
+    GtkLabel *filler;
+    GtkHBox *labels;
+    GtkVBox *status_vbox;
+    GtkStatusbar *grip;
 
-	app_window = gnome_app_new(GTT_APP_NAME, GTT_APP_TITLE " " VERSION);
-	gtk_window_set_wmclass(GTK_WINDOW(app_window),
-	                         GTT_APP_NAME, GTT_APP_PROPER_NAME);
+    app_window = gnome_app_new(GTT_APP_NAME, GTT_APP_TITLE " " VERSION);
+    gtk_window_set_wmclass(GTK_WINDOW(app_window), GTT_APP_NAME, GTT_APP_PROPER_NAME);
 
-	/* 485 x 272 seems to be a good size to default to */
-	gtk_window_set_default_size(GTK_WINDOW(app_window), 485, 272);
-	gtk_window_set_resizable (GTK_WINDOW(app_window), TRUE);
+    /* 485 x 272 seems to be a good size to default to */
+    gtk_window_set_default_size(GTK_WINDOW(app_window), 485, 272);
+    gtk_window_set_resizable(GTK_WINDOW(app_window), TRUE);
 
-	/* build menus */
-	menus_create(GNOME_APP(app_window));
+    /* build menus */
+    menus_create(GNOME_APP(app_window));
 
-	/* build toolbar */
-	widget = build_toolbar();
-	gtk_widget_show(widget);
-	gnome_app_set_toolbar(GNOME_APP(app_window), GTK_TOOLBAR(widget));
+    /* build toolbar */
+    widget = build_toolbar();
+    gtk_widget_show(widget);
+    gnome_app_set_toolbar(GNOME_APP(app_window), GTK_TOOLBAR(widget));
 
-	/* container holds status bar, main ctree widget */
-	vbox = gtk_vbox_new(FALSE, 0);
+    /* container holds status bar, main ctree widget */
+    vbox = gtk_vbox_new(FALSE, 0);
 
-	/* build statusbar */
+    /* build statusbar */
 
-	status_vbox = GTK_VBOX(gtk_vbox_new(FALSE, 0));
-	gtk_widget_show(GTK_WIDGET(status_vbox));
+    status_vbox = GTK_VBOX(gtk_vbox_new(FALSE, 0));
+    gtk_widget_show(GTK_WIDGET(status_vbox));
 
-	labels = GTK_HBOX(gtk_hbox_new(FALSE, 0));
-	gtk_widget_show(GTK_WIDGET(labels));
+    labels = GTK_HBOX(gtk_hbox_new(FALSE, 0));
+    gtk_widget_show(GTK_WIDGET(labels));
 
-	status_bar = gtk_hbox_new(FALSE, 0);
-	gtk_widget_show(status_bar);
-	separator = gtk_hseparator_new();
-	gtk_widget_show(separator);
-	gtk_box_pack_start(GTK_BOX(status_vbox), separator, FALSE, FALSE, 0);
-	gtk_box_pack_start(GTK_BOX(status_vbox), GTK_WIDGET (labels), TRUE, TRUE, 0);
-	gtk_box_pack_start(GTK_BOX(status_bar), GTK_WIDGET (status_vbox), TRUE, TRUE, 0);
+    status_bar = gtk_hbox_new(FALSE, 0);
+    gtk_widget_show(status_bar);
+    separator = gtk_hseparator_new();
+    gtk_widget_show(separator);
+    gtk_box_pack_start(GTK_BOX(status_vbox), separator, FALSE, FALSE, 0);
+    gtk_box_pack_start(GTK_BOX(status_vbox), GTK_WIDGET(labels), TRUE, TRUE, 0);
+    gtk_box_pack_start(GTK_BOX(status_bar), GTK_WIDGET(status_vbox), TRUE, TRUE, 0);
 
-	grip = GTK_STATUSBAR(gtk_statusbar_new());
-	gtk_statusbar_set_has_resize_grip(grip, TRUE);
-	gtk_widget_show(GTK_WIDGET(grip));
-	gtk_box_pack_start(GTK_BOX(status_bar), GTK_WIDGET(grip), FALSE, FALSE, 0);
+    grip = GTK_STATUSBAR(gtk_statusbar_new());
+    gtk_statusbar_set_has_resize_grip(grip, TRUE);
+    gtk_widget_show(GTK_WIDGET(grip));
+    gtk_box_pack_start(GTK_BOX(status_bar), GTK_WIDGET(grip), FALSE, FALSE, 0);
 
-	/* put elapsed time into statusbar */
-	status_day_time = GTK_LABEL(gtk_label_new(_("00:00")));
-	gtk_widget_show(GTK_WIDGET(status_day_time));
+    /* put elapsed time into statusbar */
+    status_day_time = GTK_LABEL(gtk_label_new(_("00:00")));
+    gtk_widget_show(GTK_WIDGET(status_day_time));
 
-	gtk_box_pack_start(GTK_BOX(labels), GTK_WIDGET(status_day_time),
-	                     FALSE, TRUE, 0);
+    gtk_box_pack_start(GTK_BOX(labels), GTK_WIDGET(status_day_time), FALSE, TRUE, 0);
 
-	/* put project name into statusbar */
-	status_project = GTK_LABEL(gtk_label_new( _("Timer is not running")));
-	gtk_widget_show(GTK_WIDGET(status_project));
+    /* put project name into statusbar */
+    status_project = GTK_LABEL(gtk_label_new(_("Timer is not running")));
+    gtk_widget_show(GTK_WIDGET(status_project));
 
-	gtk_box_pack_start(GTK_BOX(labels), GTK_WIDGET(status_project),
-	                     FALSE, TRUE, 10);
+    gtk_box_pack_start(GTK_BOX(labels), GTK_WIDGET(status_project), FALSE, TRUE, 10);
 
-	filler = GTK_LABEL(gtk_label_new(""));
-	gtk_widget_show(GTK_WIDGET(filler));
-	gtk_box_pack_start(GTK_BOX(labels), GTK_WIDGET(filler), TRUE, TRUE, 1);
+    filler = GTK_LABEL(gtk_label_new(""));
+    gtk_widget_show(GTK_WIDGET(filler));
+    gtk_box_pack_start(GTK_BOX(labels), GTK_WIDGET(filler), TRUE, TRUE, 1);
 
-	/* put timer icon into statusbar */
-	status_timer = gtk_image_new_from_stock (GNOME_STOCK_TIMER,
-	                                           GTK_ICON_SIZE_MENU);
-	gtk_widget_show(status_timer);
-	gtk_box_pack_end(GTK_BOX(status_bar), GTK_WIDGET(status_timer),
-	                   FALSE, FALSE, 1);
+    /* put timer icon into statusbar */
+    status_timer = gtk_image_new_from_stock(GNOME_STOCK_TIMER, GTK_ICON_SIZE_MENU);
+    gtk_widget_show(status_timer);
+    gtk_box_pack_end(GTK_BOX(status_bar), GTK_WIDGET(status_timer), FALSE, FALSE, 1);
 
-	/* create the main columned tree for showing projects */
-	projects_tree = gtt_projects_tree_new ();
+    /* create the main columned tree for showing projects */
+    projects_tree = gtt_projects_tree_new();
 
-	g_signal_connect (projects_tree, "columns-setup-done", G_CALLBACK (projects_tree_columns_setup_done), NULL);
+    g_signal_connect(
+        projects_tree, "columns-setup-done", G_CALLBACK(projects_tree_columns_setup_done), NULL
+    );
 
-	gtk_tree_view_set_reorderable (GTK_TREE_VIEW (projects_tree), TRUE);
+    gtk_tree_view_set_reorderable(GTK_TREE_VIEW(projects_tree), TRUE);
 
-	g_signal_connect (projects_tree, "row-activated", G_CALLBACK (projects_tree_row_activated), NULL);
+    g_signal_connect(
+        projects_tree, "row-activated", G_CALLBACK(projects_tree_row_activated), NULL
+    );
 
-	/* create the notes area */
-	global_na = notes_area_new();
-	vpane = notes_area_get_widget (global_na);
+    /* create the notes area */
+    global_na = notes_area_new();
+    vpane = notes_area_get_widget(global_na);
 
-	/* Need to reparent, to get rid of glade parent-window hack.
-	 * But gtk_widget_reparent (vpane); causes  a "Gtk-CRITICAL"
-	 * to occur.  So we need a fancier move.
-	 */
-	gtk_widget_ref (vpane);
-	gtk_container_remove(GTK_CONTAINER(vpane->parent), vpane);
-	gtk_box_pack_start(GTK_BOX(vbox), vpane, TRUE, TRUE, 0);
-	gtk_widget_unref (vpane);
+    /* Need to reparent, to get rid of glade parent-window hack.
+     * But gtk_widget_reparent (vpane); causes  a "Gtk-CRITICAL"
+     * to occur.  So we need a fancier move.
+     */
+    gtk_widget_ref(vpane);
+    gtk_container_remove(GTK_CONTAINER(vpane->parent), vpane);
+    gtk_box_pack_start(GTK_BOX(vbox), vpane, TRUE, TRUE, 0);
+    gtk_widget_unref(vpane);
 
-	gtk_box_pack_end(GTK_BOX(vbox), status_bar, FALSE, FALSE, 2);
+    gtk_box_pack_end(GTK_BOX(vbox), status_bar, FALSE, FALSE, 2);
 
-	notes_area_add_projects_tree (global_na, projects_tree);
+    notes_area_add_projects_tree(global_na, projects_tree);
 
-	/* we are done building it, make it visible */
-	gtk_widget_show(vbox);
-	gnome_app_set_contents(GNOME_APP(app_window), vbox);
+    /* we are done building it, make it visible */
+    gtk_widget_show(vbox);
+    gnome_app_set_contents(GNOME_APP(app_window), vbox);
 
-	gtt_status_icon_create();
-	if (!geometry_string) return;
+    gtt_status_icon_create();
+    if (!geometry_string)
+        return;
 
-	if (gtk_window_parse_geometry(GTK_WINDOW(app_window),geometry_string))
-	{
-		geom_size_override=TRUE;
-	}
-	else
-	{
-		gnome_app_error(GNOME_APP(app_window),
-			_("Couldn't understand geometry (position and size)\n"
-			  " specified on command line"));
-	}
+    if (gtk_window_parse_geometry(GTK_WINDOW(app_window), geometry_string))
+    {
+        geom_size_override = TRUE;
+    }
+    else
+    {
+        gnome_app_error(
+            GNOME_APP(app_window), _("Couldn't understand geometry (position and size)\n"
+                                     " specified on command line")
+        );
+    }
 }
 
-void
-app_show (void)
+void app_show(void)
 {
-	if (!GTK_WIDGET_MAPPED(app_window))
-	{
-		gtk_widget_show(app_window);
-	}
+    if (!GTK_WIDGET_MAPPED(app_window))
+    {
+        gtk_widget_show(app_window);
+    }
 }
 
-
-
-void
-app_quit(GtkWidget *w, gpointer data)
+void app_quit(GtkWidget *w, gpointer data)
 {
-	save_properties ();
-	save_projects ();
-	gtt_status_icon_destroy ();
-	gtk_main_quit();
+    save_properties();
+    save_projects();
+    gtt_status_icon_destroy();
+    gtk_main_quit();
 }
 
 /* ============================== END OF FILE ===================== */

--- a/src/app.h
+++ b/src/app.h
@@ -20,16 +20,15 @@
 #ifndef __GTT_APP_H__
 #define __GTT_APP_H__
 
-#include <gnome.h>
 #include "notes-area.h"
 #include "proj.h"
 #include "status-icon.h"
+#include <gnome.h>
 
-
-extern NotesArea *global_na;        /* global ptr to notes GUI area */
+extern NotesArea *global_na; /* global ptr to notes GUI area */
 extern GttProjectsTree *projects_tree;
 
-extern GtkWidget *app_window;  /* global top-level window */
+extern GtkWidget *app_window; /* global top-level window */
 extern GtkWidget *status_bar;
 
 /* true if command line over-rides geometry */
@@ -48,15 +47,15 @@ void app_quit(GtkWidget *w, gpointer data);
  * to other subsystems.  Should be replaced ultimately by g_signals.
  */
 
-void focus_row_set (GttProject *);
+void focus_row_set(GttProject *);
 
 /** Run the start/stop shell command for the indicated project.
  *  boolean is true for start, false for stop.  We export this
  *  function only to handle application shutdown when getting signal.
  */
-void run_shell_command (GttProject *, gboolean do_start);
+void run_shell_command(GttProject *, gboolean do_start);
 
 /** Run the shell command. */
-void do_run_shell_command (const char * str);
+void do_run_shell_command(const char *str);
 
 #endif /* __GTT_APP_H__ */

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -30,152 +30,150 @@
  */
 #if WITH_DBUS
 
+#include "dbus.h"
 #include <stdio.h>
 #include <string.h>
-#include "dbus.h"
 
 #include <dbus/dbus-glib.h>
 
-#include "timer.h"
 #include "gtt.h"
+#include "timer.h"
 
-typedef struct GnotimeDbus  GnotimeDbus;
+typedef struct GnotimeDbus GnotimeDbus;
 typedef struct GnotimeDbusClass GnotimeDbusClass;
 
-GType gnotime_dbus_get_type (void);
+GType gnotime_dbus_get_type(void);
 
 struct GnotimeDbus
 {
-  GObject parent;
+    GObject parent;
 };
 
 struct GnotimeDbusClass
 {
-	GObjectClass parent;
+    GObjectClass parent;
 };
 
-#define GNOTIME_TYPE_DBUS              (gnotime_dbus_get_type ())
-#define GNOTIME_DBUS(object)           (G_TYPE_CHECK_INSTANCE_CAST ((object), GNOTIME_TYPE_DBUS, GnotimeDbus))
-#define GNOTIME_DBUS_CLASS(klass)      (G_TYPE_CHECK_CLASS_CAST ((klass), GNOTIME_TYPE_DBUS, GnotimeDbusClass))
-#define GNOTIME_IS_DBUS(object)        (G_TYPE_CHECK_INSTANCE_TYPE ((object), GNOTIME_TYPE_DBUS))
-#define GNOTIME_IS_DBUS_CLASS(klass)   (G_TYPE_CHECK_CLASS_TYPE ((klass), GNOTIME_TYPE_DBUS))
-#define GNOTIME_DBUS_GET_CLASS(obj)    (G_TYPE_INSTANCE_GET_CLASS ((obj), GNOTIME_TYPE_DBUS, GnotimeDbusClass))
+#define GNOTIME_TYPE_DBUS (gnotime_dbus_get_type())
+#define GNOTIME_DBUS(object) \
+    (G_TYPE_CHECK_INSTANCE_CAST((object), GNOTIME_TYPE_DBUS, GnotimeDbus))
+#define GNOTIME_DBUS_CLASS(klass) \
+    (G_TYPE_CHECK_CLASS_CAST((klass), GNOTIME_TYPE_DBUS, GnotimeDbusClass))
+#define GNOTIME_IS_DBUS(object) (G_TYPE_CHECK_INSTANCE_TYPE((object), GNOTIME_TYPE_DBUS))
+#define GNOTIME_IS_DBUS_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), GNOTIME_TYPE_DBUS))
+#define GNOTIME_DBUS_GET_CLASS(obj) \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), GNOTIME_TYPE_DBUS, GnotimeDbusClass))
 
 G_DEFINE_TYPE(GnotimeDbus, gnotime_dbus, G_TYPE_OBJECT)
 
-gboolean gnotime_dbus_timer(GnotimeDbus *obj, char *action,
-			    guint32 *ret, GError **error);
-gboolean gnotime_dbus_file(GnotimeDbus *obj, char *action,
-			    guint32 *ret, GError **error);
+gboolean gnotime_dbus_timer(GnotimeDbus *obj, char *action, guint32 *ret, GError **error);
+gboolean gnotime_dbus_file(GnotimeDbus *obj, char *action, guint32 *ret, GError **error);
 
 #include "dbus-glue.h"
 
-static void
-gnotime_dbus_init (GnotimeDbus *obj)
+static void gnotime_dbus_init(GnotimeDbus *obj)
 {
 }
 
-static void
-gnotime_dbus_class_init (GnotimeDbusClass *klass)
+static void gnotime_dbus_class_init(GnotimeDbusClass *klass)
 {
 }
 
-gboolean
-gnotime_dbus_timer(GnotimeDbus *obj, char *action,
-		   guint32 *ret, GError **error)
+gboolean gnotime_dbus_timer(GnotimeDbus *obj, char *action, guint32 *ret, GError **error)
 {
 #if 1
-	/* def DEBUGDBUS */
-  printf( "gnotime_dbus_timer()\n  Got action = '%s'\n", action);
+    /* def DEBUGDBUS */
+    printf("gnotime_dbus_timer()\n  Got action = '%s'\n", action);
 #endif
 
-  if(strcasecmp(action, "start")==0) {
-	  gen_start_timer();
-  } else if(strcasecmp(action, "stop")==0) {
-	  gen_stop_timer();
-  } else {
-	  (*ret)=1;
-	  return TRUE;
-  }
+    if (strcasecmp(action, "start") == 0)
+    {
+        gen_start_timer();
+    }
+    else if (strcasecmp(action, "stop") == 0)
+    {
+        gen_stop_timer();
+    }
+    else
+    {
+        (*ret) = 1;
+        return TRUE;
+    }
 
-  (*ret) = 0;
+    (*ret) = 0;
 
-  return TRUE;
+    return TRUE;
 }
 
-gboolean
-gnotime_dbus_file(GnotimeDbus *obj, char *action,
-		   guint32 *ret, GError **error)
+gboolean gnotime_dbus_file(GnotimeDbus *obj, char *action, guint32 *ret, GError **error)
 {
 #if 1
-	/* def DEBUGDBUS */
-  printf( "gnotime_dbus_file()\n  Got action = '%s'\n", action);
+    /* def DEBUGDBUS */
+    printf("gnotime_dbus_file()\n  Got action = '%s'\n", action);
 #endif
 
-  if(strcasecmp(action, "save")==0) {
-	  save_projects();
-  } else if(strcasecmp(action, "reload")==0) {
-	  read_data(TRUE);
-  } else {
-	  (*ret)=1;
-	  return TRUE;
-  }
+    if (strcasecmp(action, "save") == 0)
+    {
+        save_projects();
+    }
+    else if (strcasecmp(action, "reload") == 0)
+    {
+        read_data(TRUE);
+    }
+    else
+    {
+        (*ret) = 1;
+        return TRUE;
+    }
 
-  (*ret) = 0;
+    (*ret) = 0;
 
-  return TRUE;
+    return TRUE;
 }
 
-
-void
-gnotime_dbus_setup ( void )
+void gnotime_dbus_setup(void)
 {
-  DBusGConnection *bus;
-  GError *error = NULL;
-  DBusGProxy *bus_proxy;
-  GnotimeDbus *obj;
-  guint request_name_result;
+    DBusGConnection *bus;
+    GError *error = NULL;
+    DBusGProxy *bus_proxy;
+    GnotimeDbus *obj;
+    guint request_name_result;
 
-  dbus_g_object_type_install_info (GNOTIME_TYPE_DBUS,
-				   &dbus_glib_gnotime_dbus_object_info);
+    dbus_g_object_type_install_info(GNOTIME_TYPE_DBUS, &dbus_glib_gnotime_dbus_object_info);
 
-  bus = dbus_g_bus_get (DBUS_BUS_SESSION, &error);
-  if (!bus)
+    bus = dbus_g_bus_get(DBUS_BUS_SESSION, &error);
+    if (!bus)
     {
-      g_message ("Couldn't connect to session bus: %s", error->message );
-      g_error_free (error);
-      return;
+        g_message("Couldn't connect to session bus: %s", error->message);
+        g_error_free(error);
+        return;
     }
 
-  bus_proxy = dbus_g_proxy_new_for_name (bus, "org.freedesktop.DBus",
-					 "/org/freedesktop/DBus",
-					 "org.freedesktop.DBus");
+    bus_proxy = dbus_g_proxy_new_for_name(
+        bus, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus"
+    );
 
-  if (!dbus_g_proxy_call (bus_proxy, "RequestName", &error,
-			  G_TYPE_STRING, "net.sourceforge.gttr.gnotime",
-			  G_TYPE_UINT, 0,
-			  G_TYPE_INVALID,
-			  G_TYPE_UINT, &request_name_result,
-			  G_TYPE_INVALID))
+    if (!dbus_g_proxy_call(
+            bus_proxy, "RequestName", &error, G_TYPE_STRING, "net.sourceforge.gttr.gnotime",
+            G_TYPE_UINT, 0, G_TYPE_INVALID, G_TYPE_UINT, &request_name_result, G_TYPE_INVALID
+        ))
     {
-      g_message ("Failed to acquire net.sourceforge.gttr.gnotime: %s", error->message );
-      g_error_free (error);
-      g_object_unref( bus_proxy );
-      dbus_g_connection_unref( bus );
-      return;
+        g_message("Failed to acquire net.sourceforge.gttr.gnotime: %s", error->message);
+        g_error_free(error);
+        g_object_unref(bus_proxy);
+        dbus_g_connection_unref(bus);
+        return;
     }
-  g_object_unref( bus_proxy );
+    g_object_unref(bus_proxy);
 
-  obj = g_object_new (GNOTIME_TYPE_DBUS, NULL);
+    obj = g_object_new(GNOTIME_TYPE_DBUS, NULL);
 
-  dbus_g_connection_register_g_object(bus,
-				      "/net/sourceforge/gttr/gnotime",
-				      G_OBJECT (obj));
+    dbus_g_connection_register_g_object(bus, "/net/sourceforge/gttr/gnotime", G_OBJECT(obj));
 
-  // TODO: Find out if this is needed
-  dbus_g_connection_unref( bus );
+    // TODO: Find out if this is needed
+    dbus_g_connection_unref(bus);
 
-  return;
+    return;
 }
 
-#endif //WITH_DBUS
+#endif // WITH_DBUS

--- a/src/dbus.h
+++ b/src/dbus.h
@@ -25,8 +25,6 @@
 /* Carry out all actions to setup the D-Bus and register signal handlers */
 void gnotime_dbus_setup();
 
-
 #endif /* !_DBUS_H */
-
 
 #endif // WITH_DBUS

--- a/src/dialog.c
+++ b/src/dialog.c
@@ -24,29 +24,25 @@
 
 /* ================================================================= */
 
-void
-gtt_help_popup(GtkWidget *widget, gpointer data)
+void gtt_help_popup(GtkWidget *widget, gpointer data)
 {
-	GError *err = NULL;
-	char * section = data;
-	if ((section != NULL) && !strcmp ("", section)) section = NULL;
-	gnome_help_display ("gnotime", section, &err);
-	if (err)
-	{
-		GtkWidget *mb;
-		mb = gtk_message_dialog_new (
-		         GTK_IS_WINDOW(widget) ? GTK_WINDOW (widget) : NULL,
-		         GTK_DIALOG_MODAL,
-		         GTK_MESSAGE_ERROR,
-		         GTK_BUTTONS_CLOSE,
-				 "%s",
-		         err->message);
-		g_signal_connect (G_OBJECT(mb), "response",
-		         G_CALLBACK (gtk_widget_destroy), mb);
-		gtk_widget_show (mb);
+    GError *err = NULL;
+    char *section = data;
+    if ((section != NULL) && !strcmp("", section))
+        section = NULL;
+    gnome_help_display("gnotime", section, &err);
+    if (err)
+    {
+        GtkWidget *mb;
+        mb = gtk_message_dialog_new(
+            GTK_IS_WINDOW(widget) ? GTK_WINDOW(widget) : NULL, GTK_DIALOG_MODAL,
+            GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE, "%s", err->message
+        );
+        g_signal_connect(G_OBJECT(mb), "response", G_CALLBACK(gtk_widget_destroy), mb);
+        gtk_widget_show(mb);
 
-		printf ("duude gnome help err msg: %s\n", err->message);
-	}
+        printf("duude gnome help err msg: %s\n", err->message);
+    }
 }
 
 /* ==================== END OF FILE ================================ */

--- a/src/err-throw.c
+++ b/src/err-throw.c
@@ -19,86 +19,79 @@
 #include "config.h"
 
 #include <glib.h>
-#include <gnome.h>  /* needed only to define the _() macro */
+#include <gnome.h> /* needed only to define the _() macro */
 
 #include "err-throw.h"
 
-
 static GttErrCode err = GTT_NO_ERR;
 
-void
-gtt_err_set_code (GttErrCode code)
+void gtt_err_set_code(GttErrCode code)
 {
-	/* clear the error if requested. */
-	if (GTT_NO_ERR == code)
-	{
-		err = GTT_NO_ERR;
-		return;
-	}
+    /* clear the error if requested. */
+    if (GTT_NO_ERR == code)
+    {
+        err = GTT_NO_ERR;
+        return;
+    }
 
-	/* if the error code is already set, don't over-write it */
-	if (GTT_NO_ERR != err) return;
+    /* if the error code is already set, don't over-write it */
+    if (GTT_NO_ERR != err)
+        return;
 
-	/* Otherwise set it. */
-	err = code;
+    /* Otherwise set it. */
+    err = code;
 }
 
-GttErrCode
-gtt_err_get_code (void)
+GttErrCode gtt_err_get_code(void)
 {
-	return err;
+    return err;
 }
 
 /* ================================================================ */
 
-char *
-gtt_err_to_string (GttErrCode code, const char * filename)
+char *gtt_err_to_string(GttErrCode code, const char *filename)
 {
-	char * ret = NULL;
-	switch (code)
-	{
-		case GTT_NO_ERR:
-			ret = g_strdup (_("No Error"));
-			break;
-		case GTT_CANT_OPEN_FILE:
-			ret = g_strdup_printf (
-				_("Cannot open the project data file\n\t%s\n"),
-				filename);
-			break;
-		case GTT_CANT_WRITE_FILE:
-			ret = g_strdup_printf (
-				_("Cannot write the project data file\n\t%s\n"),
-				filename);
-			break;
-		case GTT_NOT_A_GTT_FILE:
-			ret = g_strdup_printf (
-				_("The file\n\t%s\n"
-				  "doesn't seem to be a GnoTime project data file\n"),
-				filename);
-			break;
-		case GTT_FILE_CORRUPT:
-			ret = g_strdup_printf (
-				_("The file\n\t%s\n"
-				  "seems to be corrupt\n"),
-				filename);
-			break;
-		case GTT_UNKNOWN_TOKEN:
-			ret = g_strdup_printf (
-				_("An unknown token was found during the parsing of\n\t%s\n"),
-				filename);
-			break;
-		case GTT_UNKNOWN_VALUE:
-			ret = g_strdup_printf (
-				_("An unknown value was found during the parsing of\n\t%s\n"),
-				filename);
-			break;
-		case GTT_CANT_WRITE_CONFIG:
-			ret = g_strdup_printf (
-				_("Cannot write the config file\n\t%s\n"),
-				filename);
-			break;
-	}
-	return ret;
+    char *ret = NULL;
+    switch (code)
+    {
+    case GTT_NO_ERR:
+        ret = g_strdup(_("No Error"));
+        break;
+    case GTT_CANT_OPEN_FILE:
+        ret = g_strdup_printf(_("Cannot open the project data file\n\t%s\n"), filename);
+        break;
+    case GTT_CANT_WRITE_FILE:
+        ret = g_strdup_printf(_("Cannot write the project data file\n\t%s\n"), filename);
+        break;
+    case GTT_NOT_A_GTT_FILE:
+        ret = g_strdup_printf(
+            _("The file\n\t%s\n"
+              "doesn't seem to be a GnoTime project data file\n"),
+            filename
+        );
+        break;
+    case GTT_FILE_CORRUPT:
+        ret = g_strdup_printf(
+            _("The file\n\t%s\n"
+              "seems to be corrupt\n"),
+            filename
+        );
+        break;
+    case GTT_UNKNOWN_TOKEN:
+        ret = g_strdup_printf(
+            _("An unknown token was found during the parsing of\n\t%s\n"), filename
+        );
+        break;
+    case GTT_UNKNOWN_VALUE:
+        ret = g_strdup_printf(
+            _("An unknown value was found during the parsing of\n\t%s\n"), filename
+        );
+        break;
+    case GTT_CANT_WRITE_CONFIG:
+        ret = g_strdup_printf(_("Cannot write the config file\n\t%s\n"), filename);
+        break;
+    }
+    return ret;
 }
 
 /* =========================== END OF FILE ======================== */

--- a/src/err-throw.h
+++ b/src/err-throw.h
@@ -16,18 +16,17 @@
  *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-
-typedef enum {
-	GTT_NO_ERR = 0,
-	GTT_CANT_OPEN_FILE,
-	GTT_CANT_WRITE_FILE,
-	GTT_NOT_A_GTT_FILE,
-	GTT_FILE_CORRUPT,
-	GTT_UNKNOWN_TOKEN,
-	GTT_UNKNOWN_VALUE,
-	GTT_CANT_WRITE_CONFIG
+typedef enum
+{
+    GTT_NO_ERR = 0,
+    GTT_CANT_OPEN_FILE,
+    GTT_CANT_WRITE_FILE,
+    GTT_NOT_A_GTT_FILE,
+    GTT_FILE_CORRUPT,
+    GTT_UNKNOWN_TOKEN,
+    GTT_UNKNOWN_VALUE,
+    GTT_CANT_WRITE_CONFIG
 } GttErrCode;
-
 
 /*
  * These two routines can be used to implement a poor-man's
@@ -41,17 +40,15 @@ typedef enum {
  *  }
  */
 
-GttErrCode gtt_err_get_code (void);
+GttErrCode gtt_err_get_code(void);
 
-void gtt_err_set_code (GttErrCode);
-
+void gtt_err_set_code(GttErrCode);
 
 /* The gtt_err_to_string() routine returns a handy-dandy human-readable
  *    error message, suitable for framing.  Be sure to free the returned
  *    string using g_free when done.
  */
 
-char * gtt_err_to_string (GttErrCode code, const char * filename);
-
+char *gtt_err_to_string(GttErrCode code, const char *filename);
 
 /* =========================== END OF FILE ======================== */

--- a/src/err.c
+++ b/src/err.c
@@ -25,60 +25,56 @@
 #include <X11/Xlib.h>
 #include <signal.h>
 
-
 #undef DIE_ON_NORMAL_ERROR
-
 
 /* =================================================== */
 /* error handlers for 'unavoidable' system errors */
 
 static void die(void)
 {
-	fprintf(stderr, " - saving and dying\n");
-	save_all();
-	unlock_gtt();
-	exit(1);
+    fprintf(stderr, " - saving and dying\n");
+    save_all();
+    unlock_gtt();
+    exit(1);
 }
-
-
 
 static void sig_handler(int signum)
 {
-	fprintf(stderr, "%s: Signal %d caught", GTT_APP_NAME, signum);
-	die();
+    fprintf(stderr, "%s: Signal %d caught", GTT_APP_NAME, signum);
+    die();
 }
-
 
 #ifdef DIE_ON_NORMAL_ERROR
 static int x11_error_handler(Display *d, XErrorEvent *e)
 {
-	fprintf(stderr, "%s: X11 error caight", GTT_APP_NAME);
-	die();
-	return 0; /* keep the compiler happy */
+    fprintf(stderr, "%s: X11 error caight", GTT_APP_NAME);
+    die();
+    return 0; /* keep the compiler happy */
 }
 #endif
 
 static int x11_io_error_handler(Display *d)
 {
-	fprintf(stderr, "%s: fatal X11 io error caight", GTT_APP_NAME);
-	die();
-	return 0; /* keep the compiler happy */
+    fprintf(stderr, "%s: fatal X11 io error caight", GTT_APP_NAME);
+    die();
+    return 0; /* keep the compiler happy */
 }
 
 void err_init(void)
 {
-	static int inited = 0;
-	
-	if (inited) return;
+    static int inited = 0;
+
+    if (inited)
+        return;
 #ifdef DIE_ON_NORMAL_ERROR
-	XSetErrorHandler(x11_error_handler);
+    XSetErrorHandler(x11_error_handler);
 #endif
-	signal(SIGINT, sig_handler);
-	signal(SIGKILL, sig_handler);
-	signal(SIGTERM, sig_handler);
-	signal(SIGHUP, sig_handler);
-	signal(SIGPIPE, sig_handler);
-	XSetIOErrorHandler(x11_io_error_handler);
+    signal(SIGINT, sig_handler);
+    signal(SIGKILL, sig_handler);
+    signal(SIGTERM, sig_handler);
+    signal(SIGHUP, sig_handler);
+    signal(SIGPIPE, sig_handler);
+    XSetIOErrorHandler(x11_io_error_handler);
 }
 
 /* =========================== END OF FILE ======================== */

--- a/src/export.c
+++ b/src/export.c
@@ -19,8 +19,8 @@
 
 #include <config.h>
 #include <gnome.h>
-#include <string.h>
 #include <libgnomevfs/gnome-vfs.h>
+#include <string.h>
 
 #include "app.h"
 #include "export.h"
@@ -29,7 +29,7 @@
 
 /* Project data export */
 
-#define gtt_sure_string(x) ((x)?(x):"")
+#define gtt_sure_string(x) ((x) ? (x) : "")
 
 /* ======================================================= */
 
@@ -37,40 +37,37 @@ typedef struct export_format_s export_format_t;
 
 struct export_format_s
 {
-	GtkFileChooser *picker;    /* URI picker (file selection) */
-	const char       *uri;       /* aka filename */
-	GnomeVFSHandle   *handle;    /* file handle */
-	GttGhtml         *ghtml;     /* output device */
-	const char       *template;  /* output template */
+    GtkFileChooser *picker; /* URI picker (file selection) */
+    const char *uri;        /* aka filename */
+    GnomeVFSHandle *handle; /* file handle */
+    GttGhtml *ghtml;        /* output device */
+    const char *template;   /* output template */
 };
 
-static export_format_t *
-export_format_new (void)
+static export_format_t *export_format_new(void)
 {
-	export_format_t * rc;
-	rc = g_new0 (export_format_t, 1);
-	rc->picker = NULL;
-	rc->uri = NULL;
-	rc->ghtml = NULL;
-	rc->template = NULL;
-	return rc;
+    export_format_t *rc;
+    rc = g_new0(export_format_t, 1);
+    rc->picker = NULL;
+    rc->uri = NULL;
+    rc->ghtml = NULL;
+    rc->template = NULL;
+    return rc;
 }
 
 /*
  * Displays an error message dialog
  *
  */
-static void
-export_show_error_message(GtkWindow *parent, char *msg)
+static void export_show_error_message(GtkWindow *parent, char *msg)
 {
-	GtkWidget *dialog = gtk_message_dialog_new_with_markup (parent,
-															GTK_DIALOG_MODAL,
-															GTK_MESSAGE_ERROR,
-															GTK_BUTTONS_OK,
-															_("<b>Gnotime export error</b>"));
-	gtk_message_dialog_format_secondary_text (GTK_MESSAGE_DIALOG (dialog), "%s", msg);
-	gtk_dialog_run (GTK_DIALOG (dialog));
-	gtk_widget_destroy (dialog);
+    GtkWidget *dialog = gtk_message_dialog_new_with_markup(
+        parent, GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR, GTK_BUTTONS_OK,
+        _("<b>Gnotime export error</b>")
+    );
+    gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "%s", msg);
+    gtk_dialog_run(GTK_DIALOG(dialog));
+    gtk_widget_destroy(dialog);
 }
 
 /* ======================================================= */
@@ -79,122 +76,105 @@ export_show_error_message(GtkWindow *parent, char *msg)
  * printing infrastructure.
  */
 
-static void
-export_write (GttGhtml *gxp, const char *str, size_t len,
-			  export_format_t *xp)
+static void export_write(GttGhtml *gxp, const char *str, size_t len, export_format_t *xp)
 {
-	GnomeVFSFileSize buflen	 = len;
-	GnomeVFSFileSize bytes_written = 0;
-	GnomeVFSResult result = GNOME_VFS_OK;
-	size_t off = 0;
+    GnomeVFSFileSize buflen = len;
+    GnomeVFSFileSize bytes_written = 0;
+    GnomeVFSResult result = GNOME_VFS_OK;
+    size_t off = 0;
 
-	while ((buflen > 0) && (result == GNOME_VFS_OK))
-	{
-		result = gnome_vfs_write (xp->handle,
-								  &str[off],
-								  buflen,
-								  &bytes_written);
-		off += bytes_written;
-		buflen -= bytes_written;
-	}
+    while ((buflen > 0) && (result == GNOME_VFS_OK))
+    {
+        result = gnome_vfs_write(xp->handle, &str[off], buflen, &bytes_written);
+        off += bytes_written;
+        buflen -= bytes_written;
+    }
 }
 
-static void
-export_err (GttGhtml *gxp, int errcode, const char *msg,
-			export_format_t *xp)
+static void export_err(GttGhtml *gxp, int errcode, const char *msg, export_format_t *xp)
 {
-	char *message = g_strdup_printf (_("Error exporting data: %s"), msg);
-	export_show_error_message (GTK_WINDOW (xp->picker), message);
-	g_free (message);
+    char *message = g_strdup_printf(_("Error exporting data: %s"), msg);
+    export_show_error_message(GTK_WINDOW(xp->picker), message);
+    g_free(message);
 }
 
-static gint
-export_projects (export_format_t *xp)
+static gint export_projects(export_format_t *xp)
 {
-	GttProject *prj;
+    GttProject *prj;
 
-	/* Get the currently selected project */
-	prj = gtt_projects_tree_get_selected_project (projects_tree);
-	if (!prj) return 0;
+    /* Get the currently selected project */
+    prj = gtt_projects_tree_get_selected_project(projects_tree);
+    if (!prj)
+        return 0;
 
-	xp->ghtml = gtt_ghtml_new();
-	gtt_ghtml_set_stream (xp->ghtml, xp,
-						 NULL,
-						 (GttGhtmlWriteStream) export_write,
-						 NULL,
-						 (GttGhtmlError) export_err);
+    xp->ghtml = gtt_ghtml_new();
+    gtt_ghtml_set_stream(
+        xp->ghtml, xp, NULL, (GttGhtmlWriteStream) export_write, NULL,
+        (GttGhtmlError) export_err
+    );
 
-	gtt_ghtml_display (xp->ghtml, xp->template, prj);
+    gtt_ghtml_display(xp->ghtml, xp->template, prj);
 
-	gtt_ghtml_destroy (xp->ghtml);
-	xp->ghtml = NULL;
+    gtt_ghtml_destroy(xp->ghtml);
+    xp->ghtml = NULL;
 
-	g_free((char *) xp->template);
-	xp->template = NULL;
+    g_free((char *) xp->template);
+    xp->template = NULL;
 
-	return 0;
+    return 0;
 }
 
 /* ======================================================= */
 
-static void
-export_really (GtkWidget *widget, export_format_t *xp)
+static void export_really(GtkWidget *widget, export_format_t *xp)
 {
-	gboolean rc;
+    gboolean rc;
 
-	xp->uri = gtk_file_chooser_get_filename (xp->picker);
+    xp->uri = gtk_file_chooser_get_filename(xp->picker);
 
+    GnomeVFSResult result;
+    result = gnome_vfs_create(&xp->handle, xp->uri, GNOME_VFS_OPEN_WRITE, FALSE, 0644);
+    if (GNOME_VFS_OK != result)
+    {
+        char *msg = g_strdup_printf(_("File %s could not be opened"), xp->uri);
+        export_show_error_message(GTK_WINDOW(xp->picker), msg);
+        g_free(msg);
+        return;
+    }
 
-	GnomeVFSResult result;
-	result = gnome_vfs_create (&xp->handle, xp->uri, GNOME_VFS_OPEN_WRITE,
-							   FALSE, 0644);
-	if (GNOME_VFS_OK != result)
-	{
-		char *msg = g_strdup_printf (_("File %s could not be opened"),
-									 xp->uri);
-		export_show_error_message (GTK_WINDOW (xp->picker), msg);
-		g_free (msg);
-		return;
-	}
-
-	rc = export_projects (xp);
-	if (rc)
-	{
-		export_show_error_message (GTK_WINDOW (xp->picker), _("Error occured during export"));
-		return;
-	}
-	gnome_vfs_close (xp->handle);
+    rc = export_projects(xp);
+    if (rc)
+    {
+        export_show_error_message(GTK_WINDOW(xp->picker), _("Error occured during export"));
+        return;
+    }
+    gnome_vfs_close(xp->handle);
 }
 
 /* ======================================================= */
 
-void
-export_file_picker (GtkWidget *widget, gpointer data)
+void export_file_picker(GtkWidget *widget, gpointer data)
 {
-	export_format_t *xp;
-	GtkWidget *dialog;
-	const char * template_filename = data;
+    export_format_t *xp;
+    GtkWidget *dialog;
+    const char *template_filename = data;
 
-	dialog = gtk_file_chooser_dialog_new (_("Tab-Delimited Export"),
-										  GTK_WINDOW(app_window),
-										  GTK_FILE_CHOOSER_ACTION_SAVE,
-										  GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-										  GTK_STOCK_SAVE, GTK_RESPONSE_ACCEPT,
-										  NULL);
+    dialog = gtk_file_chooser_dialog_new(
+        _("Tab-Delimited Export"), GTK_WINDOW(app_window), GTK_FILE_CHOOSER_ACTION_SAVE,
+        GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL, GTK_STOCK_SAVE, GTK_RESPONSE_ACCEPT, NULL
+    );
 
-	gtk_file_chooser_set_do_overwrite_confirmation (GTK_FILE_CHOOSER (dialog), TRUE);
+    gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(dialog), TRUE);
 
-	if (gtk_dialog_run (GTK_DIALOG (dialog)) == GTK_RESPONSE_ACCEPT)
-	{
-		xp = export_format_new ();
-		xp->picker = GTK_FILE_CHOOSER (dialog);
-		xp->template = gtt_ghtml_resolve_path (template_filename, NULL);
-		export_really (dialog, xp);
-		g_free (xp);
-	}
-	gtk_widget_destroy (GTK_WIDGET (dialog));
-
-
+    if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT)
+    {
+        xp = export_format_new();
+        xp->picker = GTK_FILE_CHOOSER(dialog);
+        xp->template = gtt_ghtml_resolve_path(template_filename, NULL);
+        export_really(dialog, xp);
+        g_free(xp);
+    }
+    gtk_widget_destroy(GTK_WIDGET(dialog));
 }
 
 /* ======================= END OF FILE ======================= */

--- a/src/export.h
+++ b/src/export.h
@@ -21,6 +21,6 @@
 #define __GTT_EXPORT_H__
 
 /* bring up dialog for picking the export format, file, etc. */
-void export_file_picker (GtkWidget *widget, gpointer data);
+void export_file_picker(GtkWidget *widget, gpointer data);
 
 #endif /* __GTT_EXPORT_H__ */

--- a/src/file-io.c
+++ b/src/file-io.c
@@ -22,8 +22,8 @@
 #include <errno.h>
 #include <glib.h>
 #include <gnome.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "app.h"
@@ -46,12 +46,12 @@
 #define GTT_CONF "/" GTT_APP_NAME
 #endif /* not DEBUG */
 
-static const char * gtt_config_filepath = NULL;
+static const char *gtt_config_filepath = NULL;
 
 int cur_proj_id = -1;
 int run_timer = FALSE;
 time_t last_timer = -1;
-extern char *first_proj_title;	/* command line flag */
+extern char *first_proj_title; /* command line flag */
 int save_count = 0;
 
 /* ============================================================= */
@@ -76,578 +76,626 @@ int save_count = 0;
 /* RC_NAME is old, depricated; stays here for backwards compat. */
 #define RC_NAME ".gtimetrackerrc"
 
-static const char *
-build_rc_name_old(void)
+static const char *build_rc_name_old(void)
 {
-	static char *buf = NULL;
+    static char *buf = NULL;
 
-	if (g_getenv("HOME") != NULL) {
-		buf = g_concat_dir_and_file (g_getenv ("HOME"), RC_NAME);
-	} else {
-		buf = g_strdup (RC_NAME);
-	}
-	return buf;
+    if (g_getenv("HOME") != NULL)
+    {
+        buf = g_concat_dir_and_file(g_getenv("HOME"), RC_NAME);
+    }
+    else
+    {
+        buf = g_strdup(RC_NAME);
+    }
+    return buf;
 }
 
-
-
-static void
-read_tb_sects_old(char *s)
+static void read_tb_sects_old(char *s)
 {
-	if (s[2] == 'n') {
-		config_show_tb_new = (s[5] == 'n');
-	} else if (s[2] == 'c') {
-		config_show_tb_ccp = (s[5] == 'n');
-	} else if (s[2] == 'p') {
-		config_show_tb_prop = (s[5] == 'n');
-	} else if (s[2] == 't') {
-		config_show_tb_timer = (s[5] == 'n');
-	} else if (s[2] == 'o') {
-		config_show_tb_pref = (s[5] == 'n');
-	} else if (s[2] == 'h') {
-		config_show_tb_help = (s[5] == 'n');
-	} else if (s[2] == 'e') {
-		config_show_tb_exit = (s[5] == 'n');
-	}
+    if (s[2] == 'n')
+    {
+        config_show_tb_new = (s[5] == 'n');
+    }
+    else if (s[2] == 'c')
+    {
+        config_show_tb_ccp = (s[5] == 'n');
+    }
+    else if (s[2] == 'p')
+    {
+        config_show_tb_prop = (s[5] == 'n');
+    }
+    else if (s[2] == 't')
+    {
+        config_show_tb_timer = (s[5] == 'n');
+    }
+    else if (s[2] == 'o')
+    {
+        config_show_tb_pref = (s[5] == 'n');
+    }
+    else if (s[2] == 'h')
+    {
+        config_show_tb_help = (s[5] == 'n');
+    }
+    else if (s[2] == 'e')
+    {
+        config_show_tb_exit = (s[5] == 'n');
+    }
 }
 
-static void
-project_list_load_old(void)
+static void project_list_load_old(void)
 {
-	FILE *f;
-	const char *realname;
-	GttProject *proj = NULL;
-	char s[1024];
-	int i;
-	int _n, _c, _p, _t, _o, _h, _e;
+    FILE *f;
+    const char *realname;
+    GttProject *proj = NULL;
+    char s[1024];
+    int i;
+    int _n, _c, _p, _t, _o, _h, _e;
 
-	realname = build_rc_name_old();
-	gtt_config_filepath = realname;
+    realname = build_rc_name_old();
+    gtt_config_filepath = realname;
 
-	if (NULL == (f = fopen(realname, "rt")))
-	{
-		gtt_err_set_code(GTT_CANT_OPEN_FILE);
-		gtt_config_filepath = ""; /* Don't spew obsolete filename to new users */
+    if (NULL == (f = fopen(realname, "rt")))
+    {
+        gtt_err_set_code(GTT_CANT_OPEN_FILE);
+        gtt_config_filepath = ""; /* Don't spew obsolete filename to new users */
 #ifdef ENOENT
-		if (errno == ENOENT) return;
+        if (errno == ENOENT)
+            return;
 #endif
-		g_warning("could not open %s\n", realname);
-		return;
-	}
-	printf ("GTT: Info: Importing .gtimetrackerrc config file\n");
+        g_warning("could not open %s\n", realname);
+        return;
+    }
+    printf("GTT: Info: Importing .gtimetrackerrc config file\n");
 
-	_n = config_show_tb_new;
-	_c = config_show_tb_ccp;
-	_p = config_show_tb_prop;
-	_t = config_show_tb_timer;
-	_o = config_show_tb_pref;
-	_h = config_show_tb_help;
-	_e = config_show_tb_exit;
-	errno = 0;
-	while ((!feof(f)) && (!errno)) {
-		if (!fgets(s, 1023, f)) continue;
-		if (s[0] == '#') continue;
-		if (s[0] == '\n') continue;
-		if (s[0] == ' ') {
-			/* desc for last project */
-			while (s[strlen(s) - 1] == '\n')
-				s[strlen(s) - 1] = 0;
-			gtt_project_set_desc(proj, &s[1]);
-		} else if (s[0] == 't') {
-			/* last_timer */
-			last_timer = (time_t)atol(&s[1]);
-		} else if (s[0] == 's') {
-			/* show seconds? */
-			config_show_secs = (s[3] == 'n');
-		} else if (s[0] == 'b') {
-			if (s[1] == 'p') {
-				/* show tooltips */
-				config_show_tb_tips = (s[4] == 'n');
-			} else if (s[1] == 'h') {
-				/* show clist titles */
-				config_show_clist_titles = (s[4] == 'n');
-			} else if (s[1] == 's') {
-				/* show status bar */
-				if (s[4] == 'n') {
-					config_show_statusbar = 1;
-				} else {
-					config_show_statusbar = 0;
-				}
-			} else if (s[1] == '_') {
-				read_tb_sects_old(s);
-			}
-		} else if (s[0] == 'c') {
-			/* start project command */
-			while (s[strlen(s) - 1] == '\n')
-				s[strlen(s) - 1] = 0;
-			if (config_shell_start) g_free(config_shell_start);
-			config_shell_start = g_strdup(&s[2]);
-		} else if (s[0] == 'n') {
-			/* stop project command */
-			while (s[strlen(s) - 1] == '\n')
-				s[strlen(s) - 1] = 0;
-			if (config_shell_stop) g_free(config_shell_stop);
-			config_shell_stop = g_strdup(&s[2]);
-		} else if (s[0] == 'l') {
-			if (s[1] == 'u') {
-				/* use logfile? */
-				config_logfile_use = (s[4] == 'n');
-			} else if (s[1] == 'n') {
-				/* logfile name */
-				while (s[strlen(s) - 1] == '\n')
-					s[strlen(s) - 1] = 0;
-				if (config_logfile_name) g_free(config_logfile_name);
-				config_logfile_name = g_strdup(&s[3]);
-			} else if (s[1] == 's') {
-				/* minimum time for a project to get logged */
-				config_logfile_min_secs = atoi(&s[3]);
-			}
-		} else if ((s[0] >= '0') && (s[0] <='9')) {
-			time_t day_secs, ever_secs;
+    _n = config_show_tb_new;
+    _c = config_show_tb_ccp;
+    _p = config_show_tb_prop;
+    _t = config_show_tb_timer;
+    _o = config_show_tb_pref;
+    _h = config_show_tb_help;
+    _e = config_show_tb_exit;
+    errno = 0;
+    while ((!feof(f)) && (!errno))
+    {
+        if (!fgets(s, 1023, f))
+            continue;
+        if (s[0] == '#')
+            continue;
+        if (s[0] == '\n')
+            continue;
+        if (s[0] == ' ')
+        {
+            /* desc for last project */
+            while (s[strlen(s) - 1] == '\n')
+                s[strlen(s) - 1] = 0;
+            gtt_project_set_desc(proj, &s[1]);
+        }
+        else if (s[0] == 't')
+        {
+            /* last_timer */
+            last_timer = (time_t) atol(&s[1]);
+        }
+        else if (s[0] == 's')
+        {
+            /* show seconds? */
+            config_show_secs = (s[3] == 'n');
+        }
+        else if (s[0] == 'b')
+        {
+            if (s[1] == 'p')
+            {
+                /* show tooltips */
+                config_show_tb_tips = (s[4] == 'n');
+            }
+            else if (s[1] == 'h')
+            {
+                /* show clist titles */
+                config_show_clist_titles = (s[4] == 'n');
+            }
+            else if (s[1] == 's')
+            {
+                /* show status bar */
+                if (s[4] == 'n')
+                {
+                    config_show_statusbar = 1;
+                }
+                else
+                {
+                    config_show_statusbar = 0;
+                }
+            }
+            else if (s[1] == '_')
+            {
+                read_tb_sects_old(s);
+            }
+        }
+        else if (s[0] == 'c')
+        {
+            /* start project command */
+            while (s[strlen(s) - 1] == '\n')
+                s[strlen(s) - 1] = 0;
+            if (config_shell_start)
+                g_free(config_shell_start);
+            config_shell_start = g_strdup(&s[2]);
+        }
+        else if (s[0] == 'n')
+        {
+            /* stop project command */
+            while (s[strlen(s) - 1] == '\n')
+                s[strlen(s) - 1] = 0;
+            if (config_shell_stop)
+                g_free(config_shell_stop);
+            config_shell_stop = g_strdup(&s[2]);
+        }
+        else if (s[0] == 'l')
+        {
+            if (s[1] == 'u')
+            {
+                /* use logfile? */
+                config_logfile_use = (s[4] == 'n');
+            }
+            else if (s[1] == 'n')
+            {
+                /* logfile name */
+                while (s[strlen(s) - 1] == '\n')
+                    s[strlen(s) - 1] = 0;
+                if (config_logfile_name)
+                    g_free(config_logfile_name);
+                config_logfile_name = g_strdup(&s[3]);
+            }
+            else if (s[1] == 's')
+            {
+                /* minimum time for a project to get logged */
+                config_logfile_min_secs = atoi(&s[3]);
+            }
+        }
+        else if ((s[0] >= '0') && (s[0] <= '9'))
+        {
+            time_t day_secs, ever_secs;
 
-			/* new project */
-			proj = gtt_project_new();
-			gtt_project_list_append(master_list, proj);
-			ever_secs = atol(s);
-			for (i = 0; s[i] != ' '; i++) ;
-			i++;
-			day_secs = atol(&s[i]);
-			gtt_project_compat_set_secs (proj, ever_secs, day_secs, last_timer);
-			for (; s[i] != ' '; i++) ;
-			i++;
-			while (s[strlen(s) - 1] == '\n')
-				s[strlen(s) - 1] = 0;
-			gtt_project_set_title(proj, &s[i]);
-		}
-	}
-	if ((errno) && (!feof(f))) goto err;
-	fclose(f);
+            /* new project */
+            proj = gtt_project_new();
+            gtt_project_list_append(master_list, proj);
+            ever_secs = atol(s);
+            for (i = 0; s[i] != ' '; i++)
+                ;
+            i++;
+            day_secs = atol(&s[i]);
+            gtt_project_compat_set_secs(proj, ever_secs, day_secs, last_timer);
+            for (; s[i] != ' '; i++)
+                ;
+            i++;
+            while (s[strlen(s) - 1] == '\n')
+                s[strlen(s) - 1] = 0;
+            gtt_project_set_title(proj, &s[i]);
+        }
+    }
+    if ((errno) && (!feof(f)))
+        goto err;
+    fclose(f);
 
-	gtt_project_list_compute_secs();
+    gtt_project_list_compute_secs();
 
-	if (config_show_statusbar)
-	{
-		gtk_widget_show(status_bar);
-	}
-	else
-	{
-		gtk_widget_hide(status_bar);
-	}
+    if (config_show_statusbar)
+    {
+        gtk_widget_show(status_bar);
+    }
+    else
+    {
+        gtk_widget_hide(status_bar);
+    }
 
-	update_status_bar();
-	if ((_n != config_show_tb_new) ||
-	    (_c != config_show_tb_ccp) ||
-	    (_p != config_show_tb_prop) ||
-	    (_t != config_show_tb_timer) ||
-	    (_o != config_show_tb_pref) ||
-	    (_h != config_show_tb_help) ||
-	    (_e != config_show_tb_exit)) {
-		update_toolbar_sections();
-	}
-	return;
+    update_status_bar();
+    if ((_n != config_show_tb_new) || (_c != config_show_tb_ccp) || (_p != config_show_tb_prop)
+        || (_t != config_show_tb_timer) || (_o != config_show_tb_pref)
+        || (_h != config_show_tb_help) || (_e != config_show_tb_exit))
+    {
+        update_toolbar_sections();
+    }
+    return;
 
 err:
-	fclose(f);
-	gtt_err_set_code (GTT_FILE_CORRUPT);
-	g_warning("error reading %s\n", realname);
-}
-
-
-/* ======================================================= */
-
-#define GET_INT(str) ({        \
-	strcpy (p, str);            \
-   gnome_config_get_int(s);    \
-	})
-
-#define GET_BOOL(str) ({       \
-	strcpy (p, str);            \
-   gnome_config_get_bool(s);   \
-	})
-
-#define GET_STR(str) ({        \
-	strcpy (p, str);            \
-   gnome_config_get_string(s); \
-	})
-
-static void
-gtt_load_gnome_config (const char *prefix)
-{
-	char *s, *p;
-	int prefix_len;
-	int i, num;
-	int _n, _c, _j, _p, _t, _o, _h, _e;
-
-#define TOKLEN  120
-	prefix_len = 0;
-	if (prefix) prefix_len = strlen (prefix);
-	s = g_new (char, prefix_len + TOKLEN);
-	if (!s) return;
-	s[0] = 0;
-	if (prefix) strcpy (s, prefix);
-	p = &s[prefix_len];
-
-	/* If already running, and we are over-loading a new file,
-	 * then save the currently running project, and try to set it
-	 * running again ... */
-	if (gtt_project_get_title(cur_proj) && (!first_proj_title))
-	{
-		/* we need to strdup because title is freed when
-		 * the project list is destroyed ... */
-		first_proj_title = g_strdup (gtt_project_get_title (cur_proj));
-	}
-
-	_n = config_show_tb_new;
-	_c = config_show_tb_ccp;
-	_j = config_show_tb_journal;
-	_p = config_show_tb_prop;
-	_t = config_show_tb_timer;
-	_o = config_show_tb_pref;
-	_h = config_show_tb_help;
-	_e = config_show_tb_exit;
-
-	/* get last running project */
-	cur_proj_id = GET_INT("/Misc/CurrProject=-1");
-
-	config_idle_timeout = GET_INT("/Misc/IdleTimeout=300");
-	config_autosave_period = GET_INT("/Misc/AutosavePeriod=60");
-
-	/* Reset the main window width and height to the values
-	 * last stored in the config file.  Note that if the user
-	 * specified command-line flags, then the command line
-	 * over-rides the config file. */
-	if (!geom_place_override)
-	{
-		int x, y;
-		x = GET_INT("/Geometry/X=10");
-		y = GET_INT("/Geometry/Y=10");
-		gtk_widget_set_uposition(GTK_WIDGET(app_window), x, y);
-	}
-	if (!geom_size_override)
-	{
-		int w, h;
-		w = GET_INT("/Geometry/Width=442");
-		h = GET_INT("/Geometry/Height=272");
-
-		gtk_window_set_default_size(GTK_WINDOW(app_window), w, h);
-	}
-
-	{
-		int vp, hp;
-		vp = GET_INT("/Geometry/VPaned=250");
-		hp = GET_INT("/Geometry/HPaned=220");
-		notes_area_set_pane_sizes (global_na, vp, hp);
-	}
-
-	config_show_secs = GET_BOOL("/Display/ShowSecs=false");
-	config_show_clist_titles = GET_BOOL("/Display/ShowTableHeader=false");
-	config_show_subprojects = GET_BOOL("/Display/ShowSubProjects=true");
-	config_show_statusbar = GET_BOOL("/Display/ShowStatusbar=true");
-
-	config_show_title_ever = GET_BOOL("/Display/ShowTimeEver=true");
-	config_show_title_day = GET_BOOL("/Display/ShowTimeDay=true");
-	config_show_title_yesterday = GET_BOOL("/Display/ShowTimeYesterday=false");
-	config_show_title_week = GET_BOOL("/Display/ShowTimeWeek=false");
-	config_show_title_lastweek = GET_BOOL("/Display/ShowTimeLastWeek=false");
-	config_show_title_month = GET_BOOL("/Display/ShowTimeMonth=false");
-	config_show_title_year = GET_BOOL("/Display/ShowTimeYear=false");
-	config_show_title_current = GET_BOOL("/Display/ShowTimeCurrent=false");
-	config_show_title_desc = GET_BOOL("/Display/ShowDesc=true");
-	config_show_title_task = GET_BOOL("/Display/ShowTask=true");
-	config_show_title_estimated_start = GET_BOOL("/Display/ShowEstimatedStart=false");
-	config_show_title_estimated_end = GET_BOOL("/Display/ShowEstimatedEnd=false");
-	config_show_title_due_date = GET_BOOL("/Display/ShowDueDate=false");
-	config_show_title_sizing = GET_BOOL("/Display/ShowSizing=false");
-	config_show_title_percent_complete = GET_BOOL("/Display/ShowPercentComplete=false");
-	config_show_title_urgency = GET_BOOL("/Display/ShowUrgency=true");
-	config_show_title_importance = GET_BOOL("/Display/ShowImportance=true");
-	config_show_title_status = GET_BOOL("/Display/ShowStatus=false");
-	prefs_update_projects_view ();
-
-
-	/* ------------ */
-	config_show_tb_tips = GET_BOOL("/Toolbar/ShowTips=true");
-	config_show_tb_new = GET_BOOL("/Toolbar/ShowNew=true");
-	config_show_tb_ccp = GET_BOOL("/Toolbar/ShowCCP=false");
-	config_show_tb_journal = GET_BOOL("/Toolbar/ShowJournal=true");
-	config_show_tb_prop = GET_BOOL("/Toolbar/ShowProp=true");
-	config_show_tb_timer = GET_BOOL("/Toolbar/ShowTimer=true");
-	config_show_tb_pref = GET_BOOL("/Toolbar/ShowPref=false");
-	config_show_tb_help = GET_BOOL("/Toolbar/ShowHelp=true");
-	config_show_tb_exit = GET_BOOL("/Toolbar/ShowExit=true");
-
-	/* ------------ */
-	config_shell_start = GET_STR("/Actions/StartCommand=echo start id=%D \\\"%t\\\"-\\\"%d\\\" %T  %H-%M-%S hours=%h min=%m secs=%s");
-	config_shell_stop = GET_STR("/Actions/StopCommand=echo stop id=%D \\\"%t\\\"-\\\"%d\\\" %T  %H-%M-%S hours=%h min=%m secs=%s");
-
-	/* ------------ */
-	config_logfile_use = GET_BOOL("/LogFile/Use=false");
-	config_logfile_name = GET_STR("/LogFile/Filename");
-	config_logfile_start = GET_STR("/LogFile/Entry");
-	if (!config_logfile_start)
-		config_logfile_start = g_strdup(_("project %t started"));
-	config_logfile_stop = GET_STR("/LogFile/EntryStop");
-	if (!config_logfile_stop)
-		config_logfile_stop = g_strdup(_("stopped project %t"));
-	config_logfile_min_secs = GET_INT("/LogFile/MinSecs");
-
-	/* ------------ */
-	save_count = GET_INT("/Data/SaveCount=0");
-	config_data_url = GET_STR("/Data/URL=" XML_DATA_FILENAME);
-	if (NULL == config_data_url)
-	{
-		config_data_url = XML_DATA_FILENAME;
-	}
-
-	/* ------------ */
-	num = 0;
-	for (i = 0; -1 < num; i++) {
-		g_snprintf(p, TOKLEN, "/CList/ColumnWidth%d=-1", i);
-		num = gnome_config_get_int(s);
-		if (-1 < num)
-		{
-//			ctree_set_col_width (global_ptw, i, num);
-		}
-	}
-
-	/* Read in the user-defined report locations */
-	num = GET_INT("/Misc/NumReports=0");
-	if (0 < num)
-	{
-		GnomeUIInfo * reports_menu;
-		reports_menu =  g_new0 (GnomeUIInfo, num+1);
-		for (i = num-1; i >= 0 ; i--)
-		{
-			GttPlugin *plg;
-			char * name, *path, *tip;
-			g_snprintf(p, TOKLEN, "/Report%d/Name", i);
-			name = gnome_config_get_string(s);
-			g_snprintf(p, TOKLEN, "/Report%d/Path", i);
-			path = gnome_config_get_string(s);
-			g_snprintf(p, TOKLEN, "/Report%d/Tooltip", i);
-			tip = gnome_config_get_string(s);
-			plg = gtt_plugin_new (name, path);
-			plg->tooltip = g_strdup (tip);
-
-			/* fixup */
-			reports_menu[i].type = GNOME_APP_UI_ITEM;
-			reports_menu[i].user_data = plg;
-			reports_menu[i].label = name;
-			reports_menu[i].hint = tip;
-			reports_menu[i].unused_data = NULL;
-			reports_menu[i].pixmap_type = GNOME_APP_PIXMAP_STOCK;
-			reports_menu[i].pixmap_info = GNOME_STOCK_BLANK;
-			reports_menu[i].accelerator_key = 0;
-			reports_menu[i].ac_mods = (GdkModifierType) 0;
-		}
-		reports_menu[num].type = GNOME_APP_UI_ENDOFINFO;
-		gtt_set_reports_menu (GNOME_APP(app_window), reports_menu);
-	}
-
-	/* The old-style config file also contained project data
-	 * in it. Read this data, if present.  The new config file
-	 * format has num-projects set to -1.
-	 */
-	run_timer = GET_INT("/Misc/TimerRunning=0");
-	last_timer = atol(GET_STR("/Misc/LastTimer=-1"));
-	num = GET_INT("/Misc/NumProjects=0");
-	if (0 < num)
-	{
-		for (i = 0; i < num; i++)
-		{
-			GttProject *proj;
-			time_t ever_secs, day_secs;
-
-			proj = gtt_project_new();
-			gtt_project_list_append(master_list, proj);
-			g_snprintf(p, TOKLEN, "/Project%d/Title", i);
-			gtt_project_set_title(proj, gnome_config_get_string(s));
-
-			/* Match the last running project */
-			if (i == cur_proj_id) {
-				cur_proj_set(proj);
-			}
-
-			g_snprintf(p, TOKLEN, "/Project%d/Desc", i);
-			gtt_project_set_desc(proj, gnome_config_get_string(s));
-			g_snprintf(p, TOKLEN, "/Project%d/SecsEver=0", i);
-			ever_secs = gnome_config_get_int(s);
-			g_snprintf(p, TOKLEN, "/Project%d/SecsDay=0", i);
-			day_secs = gnome_config_get_int(s);
-			gtt_project_compat_set_secs (proj, ever_secs, day_secs, last_timer);
-		}
-		gtt_project_list_compute_secs();
-	}
-
-	/* redraw the GUI */
-	if (config_show_statusbar)
-	{
-		gtk_widget_show(status_bar);
-	}
-	else
-	{
-		gtk_widget_hide(status_bar);
-	}
-
-	update_status_bar();
-	if ((_n != config_show_tb_new) ||
-	    (_c != config_show_tb_ccp) ||
-	    (_j != config_show_tb_journal) ||
-	    (_p != config_show_tb_prop) ||
-	    (_t != config_show_tb_timer) ||
-	    (_o != config_show_tb_pref) ||
-	    (_h != config_show_tb_help) ||
-	    (_e != config_show_tb_exit))
-	{
-		update_toolbar_sections();
-	}
-
-	g_free (s);
+    fclose(f);
+    gtt_err_set_code(GTT_FILE_CORRUPT);
+    g_warning("error reading %s\n", realname);
 }
 
 /* ======================================================= */
 
-void
-gtt_load_config (void)
+#define GET_INT(str)             \
+    ({                           \
+        strcpy(p, str);          \
+        gnome_config_get_int(s); \
+    })
+
+#define GET_BOOL(str)             \
+    ({                            \
+        strcpy(p, str);           \
+        gnome_config_get_bool(s); \
+    })
+
+#define GET_STR(str)                \
+    ({                              \
+        strcpy(p, str);             \
+        gnome_config_get_string(s); \
+    })
+
+static void gtt_load_gnome_config(const char *prefix)
 {
-	const char *h;
-	char * s;
+    char *s, *p;
+    int prefix_len;
+    int i, num;
+    int _n, _c, _j, _p, _t, _o, _h, _e;
 
-	/* Check for gconf2, and use that if it exists */
-	if (gtt_gconf_exists())
-	{
-		gtt_gconf_load ();
-		gtt_config_filepath = NULL;
-		return;
-	}
+#define TOKLEN 120
+    prefix_len = 0;
+    if (prefix)
+        prefix_len = strlen(prefix);
+    s = g_new(char, prefix_len + TOKLEN);
+    if (!s)
+        return;
+    s[0] = 0;
+    if (prefix)
+        strcpy(s, prefix);
+    p = &s[prefix_len];
 
-	/* gnotime breifly used the gnome2 gnome_config file */
-	if (gnome_config_has_section (GTT_CONF"/Misc"))
-	{
-		printf ("GTT: Info: Importing ~/.gnome2/" GTT_CONF " file\n");
-		gtt_load_gnome_config (GTT_CONF);
-		gtt_config_filepath = gnome_config_get_real_path (GTT_CONF);
+    /* If already running, and we are over-loading a new file,
+     * then save the currently running project, and try to set it
+     * running again ... */
+    if (gtt_project_get_title(cur_proj) && (!first_proj_title))
+    {
+        /* we need to strdup because title is freed when
+         * the project list is destroyed ... */
+        first_proj_title = g_strdup(gtt_project_get_title(cur_proj));
+    }
 
-		/* The data file will be in the same directory ...
-		 * so prune filename to get the directory */
-		char *p = strrchr (gtt_config_filepath, '/');
-		if (p) *p = 0x0;
-		return;
-	}
+    _n = config_show_tb_new;
+    _c = config_show_tb_ccp;
+    _j = config_show_tb_journal;
+    _p = config_show_tb_prop;
+    _t = config_show_tb_timer;
+    _o = config_show_tb_pref;
+    _h = config_show_tb_help;
+    _e = config_show_tb_exit;
 
-	/* Look for a gnome-1.4 era gnome_config file */
-	h = g_get_home_dir();
-	s = g_new (char, strlen (h) + 120);
-	strcpy (s, "=");
-	strcat (s, h);
-	strcat (s, "/.gnome/gtt=/Misc");
-	if (gnome_config_has_section (s))
-	{
-		strcpy (s, "=");
-		strcat (s, h);
-		strcat (s, "/.gnome/gtt=");
-		printf ("GTT: Info: Importing ~/.gnome/gtt file\n");
-		gtt_load_gnome_config (s);
-		strcpy (s, h);
-		strcat (s, "/.gnome");
-		gtt_config_filepath = s;
-		return;
-	}
-	g_free (s);
+    /* get last running project */
+    cur_proj_id = GET_INT("/Misc/CurrProject=-1");
 
-	/* OK, try to load the oldest file format */
-	project_list_load_old ();
-	config_data_url = XML_DATA_FILENAME;
-	return;
+    config_idle_timeout = GET_INT("/Misc/IdleTimeout=300");
+    config_autosave_period = GET_INT("/Misc/AutosavePeriod=60");
+
+    /* Reset the main window width and height to the values
+     * last stored in the config file.  Note that if the user
+     * specified command-line flags, then the command line
+     * over-rides the config file. */
+    if (!geom_place_override)
+    {
+        int x, y;
+        x = GET_INT("/Geometry/X=10");
+        y = GET_INT("/Geometry/Y=10");
+        gtk_widget_set_uposition(GTK_WIDGET(app_window), x, y);
+    }
+    if (!geom_size_override)
+    {
+        int w, h;
+        w = GET_INT("/Geometry/Width=442");
+        h = GET_INT("/Geometry/Height=272");
+
+        gtk_window_set_default_size(GTK_WINDOW(app_window), w, h);
+    }
+
+    {
+        int vp, hp;
+        vp = GET_INT("/Geometry/VPaned=250");
+        hp = GET_INT("/Geometry/HPaned=220");
+        notes_area_set_pane_sizes(global_na, vp, hp);
+    }
+
+    config_show_secs = GET_BOOL("/Display/ShowSecs=false");
+    config_show_clist_titles = GET_BOOL("/Display/ShowTableHeader=false");
+    config_show_subprojects = GET_BOOL("/Display/ShowSubProjects=true");
+    config_show_statusbar = GET_BOOL("/Display/ShowStatusbar=true");
+
+    config_show_title_ever = GET_BOOL("/Display/ShowTimeEver=true");
+    config_show_title_day = GET_BOOL("/Display/ShowTimeDay=true");
+    config_show_title_yesterday = GET_BOOL("/Display/ShowTimeYesterday=false");
+    config_show_title_week = GET_BOOL("/Display/ShowTimeWeek=false");
+    config_show_title_lastweek = GET_BOOL("/Display/ShowTimeLastWeek=false");
+    config_show_title_month = GET_BOOL("/Display/ShowTimeMonth=false");
+    config_show_title_year = GET_BOOL("/Display/ShowTimeYear=false");
+    config_show_title_current = GET_BOOL("/Display/ShowTimeCurrent=false");
+    config_show_title_desc = GET_BOOL("/Display/ShowDesc=true");
+    config_show_title_task = GET_BOOL("/Display/ShowTask=true");
+    config_show_title_estimated_start = GET_BOOL("/Display/ShowEstimatedStart=false");
+    config_show_title_estimated_end = GET_BOOL("/Display/ShowEstimatedEnd=false");
+    config_show_title_due_date = GET_BOOL("/Display/ShowDueDate=false");
+    config_show_title_sizing = GET_BOOL("/Display/ShowSizing=false");
+    config_show_title_percent_complete = GET_BOOL("/Display/ShowPercentComplete=false");
+    config_show_title_urgency = GET_BOOL("/Display/ShowUrgency=true");
+    config_show_title_importance = GET_BOOL("/Display/ShowImportance=true");
+    config_show_title_status = GET_BOOL("/Display/ShowStatus=false");
+    prefs_update_projects_view();
+
+    /* ------------ */
+    config_show_tb_tips = GET_BOOL("/Toolbar/ShowTips=true");
+    config_show_tb_new = GET_BOOL("/Toolbar/ShowNew=true");
+    config_show_tb_ccp = GET_BOOL("/Toolbar/ShowCCP=false");
+    config_show_tb_journal = GET_BOOL("/Toolbar/ShowJournal=true");
+    config_show_tb_prop = GET_BOOL("/Toolbar/ShowProp=true");
+    config_show_tb_timer = GET_BOOL("/Toolbar/ShowTimer=true");
+    config_show_tb_pref = GET_BOOL("/Toolbar/ShowPref=false");
+    config_show_tb_help = GET_BOOL("/Toolbar/ShowHelp=true");
+    config_show_tb_exit = GET_BOOL("/Toolbar/ShowExit=true");
+
+    /* ------------ */
+    config_shell_start = GET_STR("/Actions/StartCommand=echo start id=%D "
+                                 "\\\"%t\\\"-\\\"%d\\\" %T  %H-%M-%S hours=%h min=%m secs=%s");
+    config_shell_stop = GET_STR("/Actions/StopCommand=echo stop id=%D \\\"%t\\\"-\\\"%d\\\" "
+                                "%T  %H-%M-%S hours=%h min=%m secs=%s");
+
+    /* ------------ */
+    config_logfile_use = GET_BOOL("/LogFile/Use=false");
+    config_logfile_name = GET_STR("/LogFile/Filename");
+    config_logfile_start = GET_STR("/LogFile/Entry");
+    if (!config_logfile_start)
+        config_logfile_start = g_strdup(_("project %t started"));
+    config_logfile_stop = GET_STR("/LogFile/EntryStop");
+    if (!config_logfile_stop)
+        config_logfile_stop = g_strdup(_("stopped project %t"));
+    config_logfile_min_secs = GET_INT("/LogFile/MinSecs");
+
+    /* ------------ */
+    save_count = GET_INT("/Data/SaveCount=0");
+    config_data_url = GET_STR("/Data/URL=" XML_DATA_FILENAME);
+    if (NULL == config_data_url)
+    {
+        config_data_url = XML_DATA_FILENAME;
+    }
+
+    /* ------------ */
+    num = 0;
+    for (i = 0; -1 < num; i++)
+    {
+        g_snprintf(p, TOKLEN, "/CList/ColumnWidth%d=-1", i);
+        num = gnome_config_get_int(s);
+        if (-1 < num)
+        {
+            //			ctree_set_col_width (global_ptw, i, num);
+        }
+    }
+
+    /* Read in the user-defined report locations */
+    num = GET_INT("/Misc/NumReports=0");
+    if (0 < num)
+    {
+        GnomeUIInfo *reports_menu;
+        reports_menu = g_new0(GnomeUIInfo, num + 1);
+        for (i = num - 1; i >= 0; i--)
+        {
+            GttPlugin *plg;
+            char *name, *path, *tip;
+            g_snprintf(p, TOKLEN, "/Report%d/Name", i);
+            name = gnome_config_get_string(s);
+            g_snprintf(p, TOKLEN, "/Report%d/Path", i);
+            path = gnome_config_get_string(s);
+            g_snprintf(p, TOKLEN, "/Report%d/Tooltip", i);
+            tip = gnome_config_get_string(s);
+            plg = gtt_plugin_new(name, path);
+            plg->tooltip = g_strdup(tip);
+
+            /* fixup */
+            reports_menu[i].type = GNOME_APP_UI_ITEM;
+            reports_menu[i].user_data = plg;
+            reports_menu[i].label = name;
+            reports_menu[i].hint = tip;
+            reports_menu[i].unused_data = NULL;
+            reports_menu[i].pixmap_type = GNOME_APP_PIXMAP_STOCK;
+            reports_menu[i].pixmap_info = GNOME_STOCK_BLANK;
+            reports_menu[i].accelerator_key = 0;
+            reports_menu[i].ac_mods = (GdkModifierType) 0;
+        }
+        reports_menu[num].type = GNOME_APP_UI_ENDOFINFO;
+        gtt_set_reports_menu(GNOME_APP(app_window), reports_menu);
+    }
+
+    /* The old-style config file also contained project data
+     * in it. Read this data, if present.  The new config file
+     * format has num-projects set to -1.
+     */
+    run_timer = GET_INT("/Misc/TimerRunning=0");
+    last_timer = atol(GET_STR("/Misc/LastTimer=-1"));
+    num = GET_INT("/Misc/NumProjects=0");
+    if (0 < num)
+    {
+        for (i = 0; i < num; i++)
+        {
+            GttProject *proj;
+            time_t ever_secs, day_secs;
+
+            proj = gtt_project_new();
+            gtt_project_list_append(master_list, proj);
+            g_snprintf(p, TOKLEN, "/Project%d/Title", i);
+            gtt_project_set_title(proj, gnome_config_get_string(s));
+
+            /* Match the last running project */
+            if (i == cur_proj_id)
+            {
+                cur_proj_set(proj);
+            }
+
+            g_snprintf(p, TOKLEN, "/Project%d/Desc", i);
+            gtt_project_set_desc(proj, gnome_config_get_string(s));
+            g_snprintf(p, TOKLEN, "/Project%d/SecsEver=0", i);
+            ever_secs = gnome_config_get_int(s);
+            g_snprintf(p, TOKLEN, "/Project%d/SecsDay=0", i);
+            day_secs = gnome_config_get_int(s);
+            gtt_project_compat_set_secs(proj, ever_secs, day_secs, last_timer);
+        }
+        gtt_project_list_compute_secs();
+    }
+
+    /* redraw the GUI */
+    if (config_show_statusbar)
+    {
+        gtk_widget_show(status_bar);
+    }
+    else
+    {
+        gtk_widget_hide(status_bar);
+    }
+
+    update_status_bar();
+    if ((_n != config_show_tb_new) || (_c != config_show_tb_ccp)
+        || (_j != config_show_tb_journal) || (_p != config_show_tb_prop)
+        || (_t != config_show_tb_timer) || (_o != config_show_tb_pref)
+        || (_h != config_show_tb_help) || (_e != config_show_tb_exit))
+    {
+        update_toolbar_sections();
+    }
+
+    g_free(s);
 }
 
 /* ======================================================= */
 
-void
-gtt_post_data_config (void)
+void gtt_load_config(void)
 {
-	/* Assume we've already read the XML data, and just
-	 * set the current project */
-	cur_proj_set (gtt_project_locate_from_id (cur_proj_id));
+    const char *h;
+    char *s;
 
-	/* Over-ride the current project based on the
-	 * command-line setting */
-	if (first_proj_title)
-	{
-		GList *node;
-		node = gtt_project_list_get_list(master_list);
-		for (; node; node = node->next)
-		{
-			GttProject *prj = node->data;
-			if (!gtt_project_get_title(prj)) continue;
+    /* Check for gconf2, and use that if it exists */
+    if (gtt_gconf_exists())
+    {
+        gtt_gconf_load();
+        gtt_config_filepath = NULL;
+        return;
+    }
 
-			/* set project based on command line */
-			if (0 == strcmp(gtt_project_get_title(prj),
-					first_proj_title))
-			{
-				cur_proj_set(prj);
-				break;
-			}
-		}
-	}
+    /* gnotime breifly used the gnome2 gnome_config file */
+    if (gnome_config_has_section(GTT_CONF "/Misc"))
+    {
+        printf("GTT: Info: Importing ~/.gnome2/" GTT_CONF " file\n");
+        gtt_load_gnome_config(GTT_CONF);
+        gtt_config_filepath = gnome_config_get_real_path(GTT_CONF);
 
-	/* FIXME: this is a mem leak, depending on usage in main.c */
-	first_proj_title = NULL;
+        /* The data file will be in the same directory ...
+         * so prune filename to get the directory */
+        char *p = strrchr(gtt_config_filepath, '/');
+        if (p)
+            *p = 0x0;
+        return;
+    }
 
-	/* reset the clocks, if needed */
-	if (0 < last_timer)
-	{
-		set_last_reset (last_timer);
-		zero_daily_counters (NULL);
-	}
+    /* Look for a gnome-1.4 era gnome_config file */
+    h = g_get_home_dir();
+    s = g_new(char, strlen(h) + 120);
+    strcpy(s, "=");
+    strcat(s, h);
+    strcat(s, "/.gnome/gtt=/Misc");
+    if (gnome_config_has_section(s))
+    {
+        strcpy(s, "=");
+        strcat(s, h);
+        strcat(s, "/.gnome/gtt=");
+        printf("GTT: Info: Importing ~/.gnome/gtt file\n");
+        gtt_load_gnome_config(s);
+        strcpy(s, h);
+        strcat(s, "/.gnome");
+        gtt_config_filepath = s;
+        return;
+    }
+    g_free(s);
 
-	/* if a project is running, then set it running again,
-	 * otherwise be sure to stop the clock. */
-	if (FALSE == run_timer)
-	{
-		cur_proj_set (NULL);
-	}
+    /* OK, try to load the oldest file format */
+    project_list_load_old();
+    config_data_url = XML_DATA_FILENAME;
+    return;
 }
 
-void
-gtt_post_ctree_config (void)
+/* ======================================================= */
+
+void gtt_post_data_config(void)
 {
-	gchar * xpn = NULL;
+    /* Assume we've already read the XML data, and just
+     * set the current project */
+    cur_proj_set(gtt_project_locate_from_id(cur_proj_id));
 
-	/* Assume the ctree has been set up.  Now punch in the final
-	 * bit of ctree state.
-	 */
+    /* Over-ride the current project based on the
+     * command-line setting */
+    if (first_proj_title)
+    {
+        GList *node;
+        node = gtt_project_list_get_list(master_list);
+        for (; node; node = node->next)
+        {
+            GttProject *prj = node->data;
+            if (!gtt_project_get_title(prj))
+                continue;
 
-	/* Restore the expander state */
-	if (gtt_gconf_exists())
-	{
-		xpn = gtt_gconf_get_expander();
-	}
-	else
-	{
-		xpn = gnome_config_get_string(GTT_CONF"/Display/ExpanderState");
-	}
-	if (xpn)
-	{
-		gtt_projects_tree_set_expander_state (projects_tree, xpn);
-	}
+            /* set project based on command line */
+            if (0 == strcmp(gtt_project_get_title(prj), first_proj_title))
+            {
+                cur_proj_set(prj);
+                break;
+            }
+        }
+    }
+
+    /* FIXME: this is a mem leak, depending on usage in main.c */
+    first_proj_title = NULL;
+
+    /* reset the clocks, if needed */
+    if (0 < last_timer)
+    {
+        set_last_reset(last_timer);
+        zero_daily_counters(NULL);
+    }
+
+    /* if a project is running, then set it running again,
+     * otherwise be sure to stop the clock. */
+    if (FALSE == run_timer)
+    {
+        cur_proj_set(NULL);
+    }
+}
+
+void gtt_post_ctree_config(void)
+{
+    gchar *xpn = NULL;
+
+    /* Assume the ctree has been set up.  Now punch in the final
+     * bit of ctree state.
+     */
+
+    /* Restore the expander state */
+    if (gtt_gconf_exists())
+    {
+        xpn = gtt_gconf_get_expander();
+    }
+    else
+    {
+        xpn = gnome_config_get_string(GTT_CONF "/Display/ExpanderState");
+    }
+    if (xpn)
+    {
+        gtt_projects_tree_set_expander_state(projects_tree, xpn);
+    }
 }
 
 /* ======================================================= */
 /* Save only the GUI configuration info, not the actual data */
 
-void
-gtt_save_config(void)
+void gtt_save_config(void)
 {
-	gtt_gconf_save();
+    gtt_gconf_save();
 }
 
 /* ======================================================= */
 
-const char *
-gtt_get_config_filepath (void)
+const char *gtt_get_config_filepath(void)
 {
-	return gtt_config_filepath;
+    return gtt_config_filepath;
 }
 
 /* =========================== END OF FILE ========================= */

--- a/src/file-io.h
+++ b/src/file-io.h
@@ -25,8 +25,6 @@
  * user preference data to the default user config file (in .gnome2/gnotime)
  */
 
-
-
 /* The routine gtt_save_config() will save configuration/user-preference
  *    data using gconf2. If an error occurs, a GttErrCode is set.
  *
@@ -38,8 +36,8 @@
  *    it can't find the newer ones first.
  *    If an error occurs, a GttErrCode is set.
  */
-void gtt_save_config (void);
-void gtt_load_config (void);
+void gtt_save_config(void);
+void gtt_load_config(void);
 
 /* The gtt_post_data_config() routine should be called *after* the
  *    project data has been loaded. It performs some final configuration
@@ -51,10 +49,10 @@ void gtt_load_config (void);
  *    viz. restoring expander state.
  */
 
-void gtt_post_data_config (void);
-void gtt_post_ctree_config (void);
+void gtt_post_data_config(void);
+void gtt_post_ctree_config(void);
 
 /* Returns the 'real path' to the config file that was/would be used */
-const char * gtt_get_config_filepath (void);
+const char *gtt_get_config_filepath(void);
 
 #endif /* __GTT_FILEIO_H__ */

--- a/src/gconf-gnomeui.c
+++ b/src/gconf-gnomeui.c
@@ -27,141 +27,140 @@
 /* ======================================================= */
 /* Convert gnome enums to strings */
 
-#define CASE(x)  case x: return #x;
+#define CASE(x) \
+    case x:     \
+        return #x;
 
-static const char *
-gnome_ui_info_type_to_string (GnomeUIInfoType typ)
+static const char *gnome_ui_info_type_to_string(GnomeUIInfoType typ)
 {
-	switch (typ)
-	{
-		CASE (GNOME_APP_UI_ENDOFINFO);
-		CASE (GNOME_APP_UI_ITEM);
-		CASE (GNOME_APP_UI_TOGGLEITEM);
-		CASE (GNOME_APP_UI_RADIOITEMS);
-		CASE (GNOME_APP_UI_SUBTREE);
-		CASE (GNOME_APP_UI_SEPARATOR);
-		CASE (GNOME_APP_UI_HELP);
-		CASE (GNOME_APP_UI_BUILDER_DATA);
-		CASE (GNOME_APP_UI_ITEM_CONFIGURABLE);
-		CASE (GNOME_APP_UI_SUBTREE_STOCK);
-		CASE (GNOME_APP_UI_INCLUDE);
-	}
-	return "";
+    switch (typ)
+    {
+        CASE(GNOME_APP_UI_ENDOFINFO);
+        CASE(GNOME_APP_UI_ITEM);
+        CASE(GNOME_APP_UI_TOGGLEITEM);
+        CASE(GNOME_APP_UI_RADIOITEMS);
+        CASE(GNOME_APP_UI_SUBTREE);
+        CASE(GNOME_APP_UI_SEPARATOR);
+        CASE(GNOME_APP_UI_HELP);
+        CASE(GNOME_APP_UI_BUILDER_DATA);
+        CASE(GNOME_APP_UI_ITEM_CONFIGURABLE);
+        CASE(GNOME_APP_UI_SUBTREE_STOCK);
+        CASE(GNOME_APP_UI_INCLUDE);
+    }
+    return "";
 }
 
-static const char *
-gnome_ui_pixmap_type_to_string (GnomeUIPixmapType typ)
+static const char *gnome_ui_pixmap_type_to_string(GnomeUIPixmapType typ)
 {
-	switch (typ)
-	{
-		CASE (GNOME_APP_PIXMAP_NONE);
-		CASE (GNOME_APP_PIXMAP_STOCK);
-		CASE (GNOME_APP_PIXMAP_DATA);
-		CASE (GNOME_APP_PIXMAP_FILENAME);
-	}
-	return "";
+    switch (typ)
+    {
+        CASE(GNOME_APP_PIXMAP_NONE);
+        CASE(GNOME_APP_PIXMAP_STOCK);
+        CASE(GNOME_APP_PIXMAP_DATA);
+        CASE(GNOME_APP_PIXMAP_FILENAME);
+    }
+    return "";
 }
 
 /* ======================================================= */
 /* Convert strings to gnome enums */
 
-#define MATCH(str,x)  if (0==strcmp (str, #x)) return x;
+#define MATCH(str, x)         \
+    if (0 == strcmp(str, #x)) \
+        return x;
 
-static GnomeUIInfoType
-string_to_gnome_ui_info_type (const char *str)
+static GnomeUIInfoType string_to_gnome_ui_info_type(const char *str)
 {
-	MATCH (str, GNOME_APP_UI_ENDOFINFO);
-	MATCH (str, GNOME_APP_UI_ITEM);
-	MATCH (str, GNOME_APP_UI_TOGGLEITEM);
-	MATCH (str, GNOME_APP_UI_RADIOITEMS);
-	MATCH (str, GNOME_APP_UI_SUBTREE);
-	MATCH (str, GNOME_APP_UI_SEPARATOR);
-	MATCH (str, GNOME_APP_UI_HELP);
-	MATCH (str, GNOME_APP_UI_BUILDER_DATA);
-	MATCH (str, GNOME_APP_UI_ITEM_CONFIGURABLE);
-	MATCH (str, GNOME_APP_UI_SUBTREE_STOCK);
-	MATCH (str, GNOME_APP_UI_INCLUDE);
-	return 0;
+    MATCH(str, GNOME_APP_UI_ENDOFINFO);
+    MATCH(str, GNOME_APP_UI_ITEM);
+    MATCH(str, GNOME_APP_UI_TOGGLEITEM);
+    MATCH(str, GNOME_APP_UI_RADIOITEMS);
+    MATCH(str, GNOME_APP_UI_SUBTREE);
+    MATCH(str, GNOME_APP_UI_SEPARATOR);
+    MATCH(str, GNOME_APP_UI_HELP);
+    MATCH(str, GNOME_APP_UI_BUILDER_DATA);
+    MATCH(str, GNOME_APP_UI_ITEM_CONFIGURABLE);
+    MATCH(str, GNOME_APP_UI_SUBTREE_STOCK);
+    MATCH(str, GNOME_APP_UI_INCLUDE);
+    return 0;
 }
 
-static GnomeUIPixmapType
-string_to_gnome_ui_pixmap_type (const char * str)
+static GnomeUIPixmapType string_to_gnome_ui_pixmap_type(const char *str)
 {
-	MATCH (str, GNOME_APP_PIXMAP_NONE);
-	MATCH (str, GNOME_APP_PIXMAP_STOCK);
-	MATCH (str, GNOME_APP_PIXMAP_DATA);
-	MATCH (str, GNOME_APP_PIXMAP_FILENAME);
-	return 0;
+    MATCH(str, GNOME_APP_PIXMAP_NONE);
+    MATCH(str, GNOME_APP_PIXMAP_STOCK);
+    MATCH(str, GNOME_APP_PIXMAP_DATA);
+    MATCH(str, GNOME_APP_PIXMAP_FILENAME);
+    return 0;
 }
 
 /* ======================================================= */
 /* Save the contents of a GnomeUIInfo structure with GConf */
 
-void
-gtt_save_gnomeui_to_gconf (GConfClient *client,
-                const char * path, GnomeUIInfo *gui)
+void gtt_save_gnomeui_to_gconf(GConfClient *client, const char *path, GnomeUIInfo *gui)
 {
-	char *savepath, *tokptr;
+    char *savepath, *tokptr;
 
-	if (!client || !gui || !path) return;
+    if (!client || !gui || !path)
+        return;
 
-	if (GNOME_APP_UI_ENDOFINFO == gui->type) return;
+    if (GNOME_APP_UI_ENDOFINFO == gui->type)
+        return;
 
-	/* Reserve a big enough buffer for ourselves */
-	savepath = g_strdup_printf ("%sXXXXXXXXXXXXXXXXXXXX",path);
-	tokptr = savepath + strlen (path);
+    /* Reserve a big enough buffer for ourselves */
+    savepath = g_strdup_printf("%sXXXXXXXXXXXXXXXXXXXX", path);
+    tokptr = savepath + strlen(path);
 
-	/* Store the info */
-	strcpy (tokptr, "Type");
-	F_SETSTR (savepath, gnome_ui_info_type_to_string(gui->type));
-	strcpy (tokptr, "Label");
-	F_SETSTR (savepath, gui->label);
-	strcpy (tokptr, "Hint");
-	F_SETSTR (savepath, gui->hint);
-	strcpy (tokptr, "PixmapType");
-	F_SETSTR (savepath, gnome_ui_pixmap_type_to_string(gui->pixmap_type));
-	strcpy (tokptr, "PixmapInfo");
-	F_SETSTR (savepath, gui->pixmap_info);
-	strcpy (tokptr, "AcceleratorKey");
-	F_SETINT (savepath, gui->accelerator_key);
-	strcpy (tokptr, "AcMods");
-	F_SETINT (savepath, gui->ac_mods);
+    /* Store the info */
+    strcpy(tokptr, "Type");
+    F_SETSTR(savepath, gnome_ui_info_type_to_string(gui->type));
+    strcpy(tokptr, "Label");
+    F_SETSTR(savepath, gui->label);
+    strcpy(tokptr, "Hint");
+    F_SETSTR(savepath, gui->hint);
+    strcpy(tokptr, "PixmapType");
+    F_SETSTR(savepath, gnome_ui_pixmap_type_to_string(gui->pixmap_type));
+    strcpy(tokptr, "PixmapInfo");
+    F_SETSTR(savepath, gui->pixmap_info);
+    strcpy(tokptr, "AcceleratorKey");
+    F_SETINT(savepath, gui->accelerator_key);
+    strcpy(tokptr, "AcMods");
+    F_SETINT(savepath, gui->ac_mods);
 
-	g_free (savepath);
+    g_free(savepath);
 }
 
 /* ======================================================= */
 /* Restore the contents of a GnomeUIInfo structure from GConf */
 
-void
-gtt_restore_gnomeui_from_gconf (GConfClient *client,
-                const char * path, GnomeUIInfo *gui)
+void gtt_restore_gnomeui_from_gconf(GConfClient *client, const char *path, GnomeUIInfo *gui)
 {
-	char *savepath, *tokptr;
+    char *savepath, *tokptr;
 
-	if (!client || !gui || !path) return;
+    if (!client || !gui || !path)
+        return;
 
-	/* Reserve a big enough buffer for ourselves */
-	savepath = g_strdup_printf ("%sXXXXXXXXXXXXXXXXXXXX",path);
-	tokptr = savepath + strlen (path);
+    /* Reserve a big enough buffer for ourselves */
+    savepath = g_strdup_printf("%sXXXXXXXXXXXXXXXXXXXX", path);
+    tokptr = savepath + strlen(path);
 
-	/* Restore the info */
-	strcpy (tokptr, "Type");
-	gui->type = string_to_gnome_ui_info_type(F_GETSTR (savepath, ""));
-	strcpy (tokptr, "Label");
-	gui->label = F_GETSTR (savepath, "");
-	strcpy (tokptr, "Hint");
-	gui->hint = F_GETSTR (savepath, "");
-	strcpy (tokptr, "PixmapType");
-	gui->pixmap_type = string_to_gnome_ui_pixmap_type(F_GETSTR (savepath, ""));
-	strcpy (tokptr, "PixmapInfo");
-	gui->pixmap_info = F_GETSTR (savepath, "");
-	strcpy (tokptr, "AcceleratorKey");
-	gui->accelerator_key = F_GETINT (savepath, 0);
-	strcpy (tokptr, "AcMods");
-	gui->ac_mods = F_GETINT (savepath, 0);
+    /* Restore the info */
+    strcpy(tokptr, "Type");
+    gui->type = string_to_gnome_ui_info_type(F_GETSTR(savepath, ""));
+    strcpy(tokptr, "Label");
+    gui->label = F_GETSTR(savepath, "");
+    strcpy(tokptr, "Hint");
+    gui->hint = F_GETSTR(savepath, "");
+    strcpy(tokptr, "PixmapType");
+    gui->pixmap_type = string_to_gnome_ui_pixmap_type(F_GETSTR(savepath, ""));
+    strcpy(tokptr, "PixmapInfo");
+    gui->pixmap_info = F_GETSTR(savepath, "");
+    strcpy(tokptr, "AcceleratorKey");
+    gui->accelerator_key = F_GETINT(savepath, 0);
+    strcpy(tokptr, "AcMods");
+    gui->ac_mods = F_GETINT(savepath, 0);
 
-	g_free (savepath);
+    g_free(savepath);
 }
 
 /* ======================= END OF FILE ======================== */

--- a/src/gconf-gnomeui.h
+++ b/src/gconf-gnomeui.h
@@ -32,11 +32,9 @@
 
 /* Save the contents of a GnomeUIInfo structure with GConf
  * to the indicated path. */
-void gtt_save_gnomeui_to_gconf (GConfClient *client,
-                const char * path, GnomeUIInfo *gui);
+void gtt_save_gnomeui_to_gconf(GConfClient *client, const char *path, GnomeUIInfo *gui);
 
 /* Restore from GConf path into the designated GnomeUIInfo struct */
-void gtt_restore_gnomeui_from_gconf (GConfClient *client,
-                const char * path, GnomeUIInfo *gui);
+void gtt_restore_gnomeui_from_gconf(GConfClient *client, const char *path, GnomeUIInfo *gui);
 
 #endif

--- a/src/gconf-io-p.h
+++ b/src/gconf-io-p.h
@@ -27,125 +27,142 @@
 /* ======================================================= */
 /* XXX Should use GConfChangesets */
 /* XXX warnings should be graphical */
-#define CHKERR(rc,err_ret,dir) {                                       \
-   if (FALSE == rc) {                                                  \
-      printf ("GTT: GConf: Warning: set %s failed: ", dir);            \
-      if (err_ret) printf ("%s", err_ret->message);                    \
-      printf ("\n");                                                   \
-   }                                                                   \
-}
+#define CHKERR(rc, err_ret, dir)                                 \
+    {                                                            \
+        if (FALSE == rc)                                         \
+        {                                                        \
+            printf("GTT: GConf: Warning: set %s failed: ", dir); \
+            if (err_ret)                                         \
+                printf("%s", err_ret->message);                  \
+            printf("\n");                                        \
+        }                                                        \
+    }
 
-#define SETBOOL(dir,val) {                                             \
-   gboolean rc;                                                        \
-   GError *err_ret= NULL;                                              \
-                                                                       \
-   rc = gconf_client_set_bool (client, GTT_GCONF dir, val, &err_ret);  \
-   CHKERR (rc,err_ret,dir);                                            \
-}
+#define SETBOOL(dir, val)                                                 \
+    {                                                                     \
+        gboolean rc;                                                      \
+        GError *err_ret = NULL;                                           \
+                                                                          \
+        rc = gconf_client_set_bool(client, GTT_GCONF dir, val, &err_ret); \
+        CHKERR(rc, err_ret, dir);                                         \
+    }
 
-#define F_SETINT(dir,val) {                                            \
-   gboolean rc;                                                        \
-   GError *err_ret= NULL;                                              \
-                                                                       \
-   rc = gconf_client_set_int (client, dir, val, &err_ret);             \
-   CHKERR (rc,err_ret,dir);                                            \
-}
+#define F_SETINT(dir, val)                                     \
+    {                                                          \
+        gboolean rc;                                           \
+        GError *err_ret = NULL;                                \
+                                                               \
+        rc = gconf_client_set_int(client, dir, val, &err_ret); \
+        CHKERR(rc, err_ret, dir);                              \
+    }
 
-#define SETINT(dir,val) F_SETINT (GTT_GCONF dir, val)
+#define SETINT(dir, val) F_SETINT(GTT_GCONF dir, val)
 
-#define F_SETSTR(dir,val) {                                            \
-   gboolean rc;                                                        \
-   GError *err_ret= NULL;                                              \
-                                                                       \
-   const gchar *sval = val;                                            \
-   if (!sval) sval = "";                                               \
-   rc = gconf_client_set_string (client, dir, sval, &err_ret);         \
-   CHKERR (rc,err_ret,dir);                                            \
-}
+#define F_SETSTR(dir, val)                                         \
+    {                                                              \
+        gboolean rc;                                               \
+        GError *err_ret = NULL;                                    \
+                                                                   \
+        const gchar *sval = val;                                   \
+        if (!sval)                                                 \
+            sval = "";                                             \
+        rc = gconf_client_set_string(client, dir, sval, &err_ret); \
+        CHKERR(rc, err_ret, dir);                                  \
+    }
 
-#define SETSTR(dir,val) F_SETSTR (GTT_GCONF dir, val)
+#define SETSTR(dir, val) F_SETSTR(GTT_GCONF dir, val)
 
-#define SETLIST(dir,tipe,val) {                                        \
-   gboolean rc;                                                        \
-   GError *err_ret= NULL;                                              \
-                                                                       \
-   rc = gconf_client_set_list (client, GTT_GCONF dir, tipe, val, &err_ret);  \
-   CHKERR (rc,err_ret,dir);                                            \
-}
+#define SETLIST(dir, tipe, val)                                                 \
+    {                                                                           \
+        gboolean rc;                                                            \
+        GError *err_ret = NULL;                                                 \
+                                                                                \
+        rc = gconf_client_set_list(client, GTT_GCONF dir, tipe, val, &err_ret); \
+        CHKERR(rc, err_ret, dir);                                               \
+    }
 
-#define UNSET(dir) {                                                   \
-   gboolean rc;                                                        \
-   GError *err_ret= NULL;                                              \
-                                                                       \
-   rc = gconf_client_unset (client, GTT_GCONF dir, &err_ret);          \
-   CHKERR (rc,err_ret,dir);                                            \
-}
+#define UNSET(dir)                                                \
+    {                                                             \
+        gboolean rc;                                              \
+        GError *err_ret = NULL;                                   \
+                                                                  \
+        rc = gconf_client_unset(client, GTT_GCONF dir, &err_ret); \
+        CHKERR(rc, err_ret, dir);                                 \
+    }
 
 /* ======================================================= */
 
-#define CHKGET(gcv,err_ret,dir,default_val)                            \
-   if ((NULL == gcv) || (FALSE == GCONF_VALUE_TYPE_VALID(gcv->type))) {\
-      retval = default_val;                                            \
-      printf ("GTT: GConf: Warning: get %s failed: ", dir);            \
-      if (err_ret) printf ("%s\n\t", err_ret->message);                \
-      printf ("Using default value\n");                                \
-   }
+#define CHKGET(gcv, err_ret, dir, default_val)                         \
+    if ((NULL == gcv) || (FALSE == GCONF_VALUE_TYPE_VALID(gcv->type))) \
+    {                                                                  \
+        retval = default_val;                                          \
+        printf("GTT: GConf: Warning: get %s failed: ", dir);           \
+        if (err_ret)                                                   \
+            printf("%s\n\t", err_ret->message);                        \
+        printf("Using default value\n");                               \
+    }
 
-#define GETBOOL(dir,default_val) ({                                    \
-   gboolean retval;                                                    \
-   GError *err_ret= NULL;                                              \
-   GConfValue *gcv;                                                    \
-   gcv = gconf_client_get (client, GTT_GCONF dir, &err_ret);           \
-   CHKGET (gcv,err_ret, dir, default_val)                              \
-   else retval = gconf_value_get_bool (gcv);                           \
-   retval;                                                             \
-})
+#define GETBOOL(dir, default_val)                                \
+    ({                                                           \
+        gboolean retval;                                         \
+        GError *err_ret = NULL;                                  \
+        GConfValue *gcv;                                         \
+        gcv = gconf_client_get(client, GTT_GCONF dir, &err_ret); \
+        CHKGET(gcv, err_ret, dir, default_val)                   \
+        else retval = gconf_value_get_bool(gcv);                 \
+        retval;                                                  \
+    })
 
-#define F_GETINT(dir,default_val) ({                                   \
-   int retval;                                                         \
-   GError *err_ret= NULL;                                              \
-   GConfValue *gcv;                                                    \
-   gcv = gconf_client_get (client, dir, &err_ret);                     \
-   CHKGET (gcv,err_ret, dir, default_val)                              \
-   else retval = gconf_value_get_int (gcv);                            \
-   retval;                                                             \
-})
+#define F_GETINT(dir, default_val)                     \
+    ({                                                 \
+        int retval;                                    \
+        GError *err_ret = NULL;                        \
+        GConfValue *gcv;                               \
+        gcv = gconf_client_get(client, dir, &err_ret); \
+        CHKGET(gcv, err_ret, dir, default_val)         \
+        else retval = gconf_value_get_int(gcv);        \
+        retval;                                        \
+    })
 
-#define GETINT(dir,default_val) F_GETINT (GTT_GCONF dir, default_val)
+#define GETINT(dir, default_val) F_GETINT(GTT_GCONF dir, default_val)
 
-#define F_GETLIST(dir,default_val) ({                                  \
-   GSList *retval;                                                     \
-   GError *err_ret= NULL;                                              \
-   GConfValue *gcv;                                                    \
-   gcv = gconf_client_get (client, dir, &err_ret);                     \
-   CHKGET (gcv,err_ret, dir, default_val)                              \
-   else retval = gconf_value_get_list (gcv);                           \
-   retval;                                                             \
-})
+#define F_GETLIST(dir, default_val)                    \
+    ({                                                 \
+        GSList *retval;                                \
+        GError *err_ret = NULL;                        \
+        GConfValue *gcv;                               \
+        gcv = gconf_client_get(client, dir, &err_ret); \
+        CHKGET(gcv, err_ret, dir, default_val)         \
+        else retval = gconf_value_get_list(gcv);       \
+        retval;                                        \
+    })
 
-#define GETLIST(dir,default_val) F_GETLIST (GTT_GCONF dir,  default_val)
+#define GETLIST(dir, default_val) F_GETLIST(GTT_GCONF dir, default_val)
 
-#define F_GETSTR(dir,default_val) ({                                   \
-   const char *retval;                                                 \
-   GError *err_ret= NULL;                                              \
-   GConfValue *gcv;                                                    \
-   gcv = gconf_client_get (client, dir, &err_ret);                     \
-   CHKGET (gcv,err_ret, dir, default_val)                              \
-   else retval = gconf_value_get_string (gcv);                         \
-   g_strdup (retval);                                                  \
-})
+#define F_GETSTR(dir, default_val)                     \
+    ({                                                 \
+        const char *retval;                            \
+        GError *err_ret = NULL;                        \
+        GConfValue *gcv;                               \
+        gcv = gconf_client_get(client, dir, &err_ret); \
+        CHKGET(gcv, err_ret, dir, default_val)         \
+        else retval = gconf_value_get_string(gcv);     \
+        g_strdup(retval);                              \
+    })
 
-#define GETSTR(dir,default_val) F_GETSTR (GTT_GCONF dir, default_val)
+#define GETSTR(dir, default_val) F_GETSTR(GTT_GCONF dir, default_val)
 
 /* Convert list of GConfValue to list of the actual values */
-#define GETINTLIST(dir) ({                                             \
-   GSList *l,*n;                                                       \
-   l = GETLIST(dir, NULL);                                             \
-   for (n=l; n; n=n->next) {                                           \
-      /* XXX mem leak?? do we need to free gconf value  ?? */          \
-      n->data = (gpointer) (long) gconf_value_get_int (n->data);       \
-   }                                                                   \
-   l;                                                                  \
-})
+#define GETINTLIST(dir)                                               \
+    ({                                                                \
+        GSList *l, *n;                                                \
+        l = GETLIST(dir, NULL);                                       \
+        for (n = l; n; n = n->next)                                   \
+        {                                                             \
+            /* XXX mem leak?? do we need to free gconf value  ?? */   \
+            n->data = (gpointer) (long) gconf_value_get_int(n->data); \
+        }                                                             \
+        l;                                                            \
+    })
 
 #endif /* GTT_GCONF_IO_P_H_ */

--- a/src/gconf-io.c
+++ b/src/gconf-io.c
@@ -26,8 +26,8 @@
 #include "app.h"
 #include "cur-proj.h"
 #include "gconf-gnomeui.h"
-#include "gconf-io.h"
 #include "gconf-io-p.h"
+#include "gconf-io.h"
 #include "gtt.h"
 #include "menus.h"
 #include "plug-in.h"
@@ -38,476 +38,484 @@
 /* XXX these should not be externs, they should be part of
  * some app-global structure.
  */
-extern int save_count; /* XXX */
-extern char *first_proj_title;   /* command line flag */
-extern time_t last_timer;  /* XXX */
+extern int save_count;         /* XXX */
+extern char *first_proj_title; /* command line flag */
+extern time_t last_timer;      /* XXX */
 extern int cur_proj_id;
 extern int run_timer;
 
 #define GTT_GCONF "/apps/gnotime"
 
-
 /* ======================================================= */
 
-void
-gtt_save_reports_menu (void)
+void gtt_save_reports_menu(void)
 {
-	int i;
-	char s[120], *p;
-	GnomeUIInfo * reports_menu;
-	GConfClient *client;
+    int i;
+    char s[120], *p;
+    GnomeUIInfo *reports_menu;
+    GConfClient *client;
 
-	client = gconf_client_get_default ();
-	reports_menu = gtt_get_reports_menu();
-	
-	/* Write out the customer report info */
-	for (i=0; GNOME_APP_UI_ENDOFINFO != reports_menu[i].type; i++)
-	{
-		GttPlugin *plg = reports_menu[i].user_data;
-		g_snprintf(s, sizeof (s), GTT_GCONF"/Reports/%d/", i);
-		p = s + strlen(s);
-		strcpy (p, "Name");
-		F_SETSTR (s, plg->name);
-		
-		strcpy (p, "Path");
-		F_SETSTR (s, plg->path);
+    client = gconf_client_get_default();
+    reports_menu = gtt_get_reports_menu();
 
-		strcpy (p, "Tooltip");
-		F_SETSTR (s, plg->tooltip);
+    /* Write out the customer report info */
+    for (i = 0; GNOME_APP_UI_ENDOFINFO != reports_menu[i].type; i++)
+    {
+        GttPlugin *plg = reports_menu[i].user_data;
+        g_snprintf(s, sizeof(s), GTT_GCONF "/Reports/%d/", i);
+        p = s + strlen(s);
+        strcpy(p, "Name");
+        F_SETSTR(s, plg->name);
 
-		strcpy (p, "LastSaveURL");
-		F_SETSTR (s, plg->last_url);
+        strcpy(p, "Path");
+        F_SETSTR(s, plg->path);
 
-		*p = 0;
-		gtt_save_gnomeui_to_gconf (client, s, &reports_menu[i]);
-	}
-	SETINT ("/Misc/NumReports", i);
+        strcpy(p, "Tooltip");
+        F_SETSTR(s, plg->tooltip);
+
+        strcpy(p, "LastSaveURL");
+        F_SETSTR(s, plg->last_url);
+
+        *p = 0;
+        gtt_save_gnomeui_to_gconf(client, s, &reports_menu[i]);
+    }
+    SETINT("/Misc/NumReports", i);
 }
 
 /* ======================================================= */
 /* Save only the GUI configuration info, not the actual data */
 /* XXX fixme -- this should really use GConfChangeSet */
 
-void
-gtt_gconf_save (void)
+void gtt_gconf_save(void)
 {
-	char s[120];
-	int x, y, w, h;
-	const char *xpn;
-	
-	GConfEngine* gengine;
-	GConfClient *client;
+    char s[120];
+    int x, y, w, h;
+    const char *xpn;
 
-	gengine = gconf_engine_get_default ();
-	client = gconf_client_get_for_engine (gengine);
-	SETINT ("/dir_exists", 1);
+    GConfEngine *gengine;
+    GConfClient *client;
 
-	/* ------------- */
-	/* save the window location and size */
-	gdk_window_get_origin(app_window->window, &x, &y);
-	gdk_window_get_size(app_window->window, &w, &h);
-	SETINT ("/Geometry/Width", w);
-	SETINT ("/Geometry/Height", h);
-	SETINT ("/Geometry/X", x);
-	SETINT ("/Geometry/Y", y);
+    gengine = gconf_engine_get_default();
+    client = gconf_client_get_for_engine(gengine);
+    SETINT("/dir_exists", 1);
 
-	{
-		int vp, hp;
-		notes_area_get_pane_sizes (global_na, &vp, &hp);
-		SETINT ("/Geometry/VPaned", vp);
-		SETINT ("/Geometry/HPaned", hp);
-	}
-	/* ------------- */
-	/* save the configure dialog values */
-	SETBOOL ("/Display/ShowSecs", config_show_secs);
-	SETBOOL ("/Display/ShowStatusbar", config_show_statusbar);
-	SETBOOL ("/Display/ShowSubProjects", config_show_subprojects);
-	SETBOOL ("/Display/ShowTableHeader", config_show_clist_titles);
-	SETBOOL ("/Display/ShowTimeCurrent", config_show_title_current);
-	SETBOOL ("/Display/ShowTimeDay", config_show_title_day);
-	SETBOOL ("/Display/ShowTimeYesterday", config_show_title_yesterday);
-	SETBOOL ("/Display/ShowTimeWeek", config_show_title_week);
-	SETBOOL ("/Display/ShowTimeLastWeek", config_show_title_lastweek);
-	SETBOOL ("/Display/ShowTimeMonth", config_show_title_month);
-	SETBOOL ("/Display/ShowTimeYear", config_show_title_year);
-	SETBOOL ("/Display/ShowTimeEver", config_show_title_ever);
-	SETBOOL ("/Display/ShowDesc", config_show_title_desc);
-	SETBOOL ("/Display/ShowTask", config_show_title_task);
-	SETBOOL ("/Display/ShowEstimatedStart", config_show_title_estimated_start);
-	SETBOOL ("/Display/ShowEstimatedEnd", config_show_title_estimated_end);
-	SETBOOL ("/Display/ShowDueDate", config_show_title_due_date);
-	SETBOOL ("/Display/ShowSizing", config_show_title_sizing);
-	SETBOOL ("/Display/ShowPercentComplete", config_show_title_percent_complete);
-	SETBOOL ("/Display/ShowUrgency", config_show_title_urgency);
-	SETBOOL ("/Display/ShowImportance", config_show_title_importance);
-	SETBOOL ("/Display/ShowStatus", config_show_title_status);
+    /* ------------- */
+    /* save the window location and size */
+    gdk_window_get_origin(app_window->window, &x, &y);
+    gdk_window_get_size(app_window->window, &w, &h);
+    SETINT("/Geometry/Width", w);
+    SETINT("/Geometry/Height", h);
+    SETINT("/Geometry/X", x);
+    SETINT("/Geometry/Y", y);
 
-	xpn = gtt_projects_tree_get_expander_state (projects_tree);
-	SETSTR ("/Display/ExpanderState", xpn);
+    {
+        int vp, hp;
+        notes_area_get_pane_sizes(global_na, &vp, &hp);
+        SETINT("/Geometry/VPaned", vp);
+        SETINT("/Geometry/HPaned", hp);
+    }
+    /* ------------- */
+    /* save the configure dialog values */
+    SETBOOL("/Display/ShowSecs", config_show_secs);
+    SETBOOL("/Display/ShowStatusbar", config_show_statusbar);
+    SETBOOL("/Display/ShowSubProjects", config_show_subprojects);
+    SETBOOL("/Display/ShowTableHeader", config_show_clist_titles);
+    SETBOOL("/Display/ShowTimeCurrent", config_show_title_current);
+    SETBOOL("/Display/ShowTimeDay", config_show_title_day);
+    SETBOOL("/Display/ShowTimeYesterday", config_show_title_yesterday);
+    SETBOOL("/Display/ShowTimeWeek", config_show_title_week);
+    SETBOOL("/Display/ShowTimeLastWeek", config_show_title_lastweek);
+    SETBOOL("/Display/ShowTimeMonth", config_show_title_month);
+    SETBOOL("/Display/ShowTimeYear", config_show_title_year);
+    SETBOOL("/Display/ShowTimeEver", config_show_title_ever);
+    SETBOOL("/Display/ShowDesc", config_show_title_desc);
+    SETBOOL("/Display/ShowTask", config_show_title_task);
+    SETBOOL("/Display/ShowEstimatedStart", config_show_title_estimated_start);
+    SETBOOL("/Display/ShowEstimatedEnd", config_show_title_estimated_end);
+    SETBOOL("/Display/ShowDueDate", config_show_title_due_date);
+    SETBOOL("/Display/ShowSizing", config_show_title_sizing);
+    SETBOOL("/Display/ShowPercentComplete", config_show_title_percent_complete);
+    SETBOOL("/Display/ShowUrgency", config_show_title_urgency);
+    SETBOOL("/Display/ShowImportance", config_show_title_importance);
+    SETBOOL("/Display/ShowStatus", config_show_title_status);
 
-	/* ------------- */
-	SETBOOL ("/Toolbar/ShowToolbar", config_show_toolbar);
-	SETBOOL ("/Toolbar/ShowTips", config_show_tb_tips);
-	SETBOOL ("/Toolbar/ShowNew", config_show_tb_new);
-	SETBOOL ("/Toolbar/ShowCCP", config_show_tb_ccp);
-	SETBOOL ("/Toolbar/ShowJournal", config_show_tb_journal);
-	SETBOOL ("/Toolbar/ShowProp", config_show_tb_prop);
-	SETBOOL ("/Toolbar/ShowTimer", config_show_tb_timer);
-	SETBOOL ("/Toolbar/ShowPref", config_show_tb_pref);
-	SETBOOL ("/Toolbar/ShowHelp", config_show_tb_help);
-	SETBOOL ("/Toolbar/ShowExit", config_show_tb_exit);
+    xpn = gtt_projects_tree_get_expander_state(projects_tree);
+    SETSTR("/Display/ExpanderState", xpn);
 
-	/* ------------- */
-	if (config_shell_start) {
-		SETSTR ("/Actions/StartCommand", config_shell_start);
-	} else {
-		UNSET ("/Actions/StartCommand");
-	}
+    /* ------------- */
+    SETBOOL("/Toolbar/ShowToolbar", config_show_toolbar);
+    SETBOOL("/Toolbar/ShowTips", config_show_tb_tips);
+    SETBOOL("/Toolbar/ShowNew", config_show_tb_new);
+    SETBOOL("/Toolbar/ShowCCP", config_show_tb_ccp);
+    SETBOOL("/Toolbar/ShowJournal", config_show_tb_journal);
+    SETBOOL("/Toolbar/ShowProp", config_show_tb_prop);
+    SETBOOL("/Toolbar/ShowTimer", config_show_tb_timer);
+    SETBOOL("/Toolbar/ShowPref", config_show_tb_pref);
+    SETBOOL("/Toolbar/ShowHelp", config_show_tb_help);
+    SETBOOL("/Toolbar/ShowExit", config_show_tb_exit);
 
-	if (config_shell_stop) {
-		SETSTR ("/Actions/StopCommand", config_shell_stop);
-	} else {
-		UNSET ("/Actions/StopCommand");
-	}
+    /* ------------- */
+    if (config_shell_start)
+    {
+        SETSTR("/Actions/StartCommand", config_shell_start);
+    }
+    else
+    {
+        UNSET("/Actions/StartCommand");
+    }
 
-	/* ------------- */
-	SETBOOL ("/LogFile/Use", config_logfile_use);
-	if (config_logfile_name) {
-		SETSTR ("/LogFile/Filename", config_logfile_name);
-	} else {
-		UNSET ("/LogFile/Filename");
-	}
-		
-	if (config_logfile_start) {
-		SETSTR ("/LogFile/EntryStart", config_logfile_start);
-	} else {
-		SETSTR ("/LogFile/EntryStart", "");
-	}
-		
-	if (config_logfile_stop) {
-		SETSTR ("/LogFile/EntryStop", config_logfile_stop);
-	} else {
-		SETSTR ("/LogFile/EntryStop", "");
-	}
+    if (config_shell_stop)
+    {
+        SETSTR("/Actions/StopCommand", config_shell_stop);
+    }
+    else
+    {
+        UNSET("/Actions/StopCommand");
+    }
 
-	SETINT ("/LogFile/MinSecs", config_logfile_min_secs);
+    /* ------------- */
+    SETBOOL("/LogFile/Use", config_logfile_use);
+    if (config_logfile_name)
+    {
+        SETSTR("/LogFile/Filename", config_logfile_name);
+    }
+    else
+    {
+        UNSET("/LogFile/Filename");
+    }
 
-	/* ------------- */
-	SETSTR ("/Data/URL", config_data_url);
-	SETINT ("/Data/SaveCount", save_count);
+    if (config_logfile_start)
+    {
+        SETSTR("/LogFile/EntryStart", config_logfile_start);
+    }
+    else
+    {
+        SETSTR("/LogFile/EntryStart", "");
+    }
 
-	/* ------------- */
-	{
-		long i, w;
-		GSList *list= NULL;
-		for (i=0, w=0; -1< w; i++)
-		{
-			w = gtt_projects_tree_get_col_width (projects_tree, i);
-			if (0 > w) break;
-			list = g_slist_prepend (list, (gpointer) w);
-		}
-		list = g_slist_reverse (list);
-		SETLIST ("/CList/ColumnWidths", GCONF_VALUE_INT, list);
-		g_slist_free (list);
-	}
+    if (config_logfile_stop)
+    {
+        SETSTR("/LogFile/EntryStop", config_logfile_stop);
+    }
+    else
+    {
+        SETSTR("/LogFile/EntryStop", "");
+    }
 
-	/* ------------- */
-	/* Use string for time, to avoid integer conversion problems */
-	g_snprintf(s, sizeof (s), "%ld", time(0));
-	SETSTR ("/Misc/LastTimer", s);
-	SETINT ("/Misc/IdleTimeout", config_idle_timeout);
-	SETINT ("/Misc/NoProjectTimeout", config_no_project_timeout);
-	SETINT ("/Misc/AutosavePeriod", config_autosave_period);
-	SETINT ("/Misc/TimerRunning", timer_is_running());
-	SETINT ("/Misc/CurrProject", gtt_project_get_id (cur_proj));
-	SETINT ("/Misc/NumProjects", -1);
+    SETINT("/LogFile/MinSecs", config_logfile_min_secs);
 
-	SETINT ("/Misc/DayStartOffset", config_daystart_offset);
-	SETINT ("/Misc/WeekStartOffset", config_weekstart_offset);
+    /* ------------- */
+    SETSTR("/Data/URL", config_data_url);
+    SETINT("/Data/SaveCount", save_count);
 
-	SETINT ("/time_format", config_time_format);
+    /* ------------- */
+    {
+        long i, w;
+        GSList *list = NULL;
+        for (i = 0, w = 0; -1 < w; i++)
+        {
+            w = gtt_projects_tree_get_col_width(projects_tree, i);
+            if (0 > w)
+                break;
+            list = g_slist_prepend(list, (gpointer) w);
+        }
+        list = g_slist_reverse(list);
+        SETLIST("/CList/ColumnWidths", GCONF_VALUE_INT, list);
+        g_slist_free(list);
+    }
 
-	SETSTR ("/Report/CurrencySymbol", config_currency_symbol);
-	SETBOOL ("/Report/CurrencyUseLocale", config_currency_use_locale);
+    /* ------------- */
+    /* Use string for time, to avoid integer conversion problems */
+    g_snprintf(s, sizeof(s), "%ld", time(0));
+    SETSTR("/Misc/LastTimer", s);
+    SETINT("/Misc/IdleTimeout", config_idle_timeout);
+    SETINT("/Misc/NoProjectTimeout", config_no_project_timeout);
+    SETINT("/Misc/AutosavePeriod", config_autosave_period);
+    SETINT("/Misc/TimerRunning", timer_is_running());
+    SETINT("/Misc/CurrProject", gtt_project_get_id(cur_proj));
+    SETINT("/Misc/NumProjects", -1);
 
-	/* Write out the user's report menu structure */
-	gtt_save_reports_menu ();
+    SETINT("/Misc/DayStartOffset", config_daystart_offset);
+    SETINT("/Misc/WeekStartOffset", config_weekstart_offset);
 
-	/* Sync to file.
-	 * XXX if this fails, the error is serious, and there should be a
-	 * graphical popup.
-	 */
-	{
-		GError *err_ret= NULL;
-		gconf_client_suggest_sync (client, &err_ret);
-		if (NULL != err_ret)
-		{
-			printf ("GTT: GConf: Sync Failed\n");
-		}
-	}
+    SETINT("/time_format", config_time_format);
+
+    SETSTR("/Report/CurrencySymbol", config_currency_symbol);
+    SETBOOL("/Report/CurrencyUseLocale", config_currency_use_locale);
+
+    /* Write out the user's report menu structure */
+    gtt_save_reports_menu();
+
+    /* Sync to file.
+     * XXX if this fails, the error is serious, and there should be a
+     * graphical popup.
+     */
+    {
+        GError *err_ret = NULL;
+        gconf_client_suggest_sync(client, &err_ret);
+        if (NULL != err_ret)
+        {
+            printf("GTT: GConf: Sync Failed\n");
+        }
+    }
 }
 
 /* ======================================================= */
 
-gboolean
-gtt_gconf_exists (void)
+gboolean gtt_gconf_exists(void)
 {
-	GError *err_ret= NULL;
-	GConfClient *client;
-	GConfValue *gcv;
+    GError *err_ret = NULL;
+    GConfClient *client;
+    GConfValue *gcv;
 
+    /* Calling gconf_engine_dir_exists() on a non-existant directory
+     * completely hoses that directory for future use. Its Badddd.
+     * rc = gconf_engine_dir_exists (gengine, GTT_GCONF, &err_ret);
+     * gconf_client_dir_exists() is no better.
+     * Actually, the bug is that the dirs are unusable only while
+     * gconf is still running. Upon reboot, its starts working OK.
+     * Hack around it by trying to fetch a key.
+     */
 
-	/* Calling gconf_engine_dir_exists() on a non-existant directory
-	 * completely hoses that directory for future use. Its Badddd.
-	 * rc = gconf_engine_dir_exists (gengine, GTT_GCONF, &err_ret);
-	 * gconf_client_dir_exists() is no better.
-	 * Actually, the bug is that the dirs are unusable only while
-	 * gconf is still running. Upon reboot, its starts working OK.
-	 * Hack around it by trying to fetch a key.
-	 */
+    client = gconf_client_get_default();
+    gcv = gconf_client_get(client, GTT_GCONF "/dir_exists", &err_ret);
+    if ((NULL == gcv) || (FALSE == GCONF_VALUE_TYPE_VALID(gcv->type)))
+    {
+        if (err_ret)
+            printf("GTT: Error: gconf_exists XXX err %s\n", err_ret->message);
+        return FALSE;
+    }
 
-	client = gconf_client_get_default ();
-	gcv = gconf_client_get (client, GTT_GCONF "/dir_exists", &err_ret);
-	if ((NULL == gcv) || (FALSE == GCONF_VALUE_TYPE_VALID(gcv->type)))
-	{
-		if (err_ret) printf ("GTT: Error: gconf_exists XXX err %s\n", err_ret->message);
-		return FALSE;
-	}
-
-	return TRUE;
+    return TRUE;
 }
 
 /* ======================================================= */
 
-void
-gtt_restore_reports_menu (GnomeApp *app)
+void gtt_restore_reports_menu(GnomeApp *app)
 {
-	int i, num;
-	char s[120], *p;
-	GnomeUIInfo * reports_menu;
-	GConfClient *client;
+    int i, num;
+    char s[120], *p;
+    GnomeUIInfo *reports_menu;
+    GConfClient *client;
 
-	client = gconf_client_get_default ();
-	
-	/* Read in the user-defined report locations */
-	num = GETINT ("/Misc/NumReports", 0);
-	reports_menu =  g_new0 (GnomeUIInfo, num+1);
-	
-	for (i = 0; i < num; i++)
-	{
-		GttPlugin *plg;
-		const char * name, *path, *tip, *url;
+    client = gconf_client_get_default();
 
-		g_snprintf(s, sizeof (s), GTT_GCONF"/Reports/%d/", i);
-		p = s + strlen(s);
-		
-		strcpy (p, "Name");
-		name = F_GETSTR (s, "");
-		
-		strcpy (p, "Path");
-		path = F_GETSTR(s, "");
-		
-		strcpy (p, "Tooltip");
-		tip = F_GETSTR(s, "");
+    /* Read in the user-defined report locations */
+    num = GETINT("/Misc/NumReports", 0);
+    reports_menu = g_new0(GnomeUIInfo, num + 1);
 
-		strcpy (p, "LastSaveURL");
-		url = F_GETSTR(s, "");
+    for (i = 0; i < num; i++)
+    {
+        GttPlugin *plg;
+        const char *name, *path, *tip, *url;
 
-		plg = gtt_plugin_new (name, path);
-		plg->tooltip = g_strdup (tip);
-		plg->last_url = g_strdup (url);
+        g_snprintf(s, sizeof(s), GTT_GCONF "/Reports/%d/", i);
+        p = s + strlen(s);
 
-		*p = 0;
-		gtt_restore_gnomeui_from_gconf (client, s, &reports_menu[i]);
+        strcpy(p, "Name");
+        name = F_GETSTR(s, "");
 
-		/* fixup */
-		reports_menu[i].user_data = plg;
-	}
-	reports_menu[i].type = GNOME_APP_UI_ENDOFINFO;
+        strcpy(p, "Path");
+        path = F_GETSTR(s, "");
 
-	gtt_set_reports_menu (app, reports_menu);
+        strcpy(p, "Tooltip");
+        tip = F_GETSTR(s, "");
+
+        strcpy(p, "LastSaveURL");
+        url = F_GETSTR(s, "");
+
+        plg = gtt_plugin_new(name, path);
+        plg->tooltip = g_strdup(tip);
+        plg->last_url = g_strdup(url);
+
+        *p = 0;
+        gtt_restore_gnomeui_from_gconf(client, s, &reports_menu[i]);
+
+        /* fixup */
+        reports_menu[i].user_data = plg;
+    }
+    reports_menu[i].type = GNOME_APP_UI_ENDOFINFO;
+
+    gtt_set_reports_menu(app, reports_menu);
 }
 
 /* ======================================================= */
 
-void
-gtt_gconf_load (void)
+void gtt_gconf_load(void)
 {
-	int i, num;
-	int _n, _c, _j, _p, _t, _o, _h, _e;
-	GConfClient *client;
+    int i, num;
+    int _n, _c, _j, _p, _t, _o, _h, _e;
+    GConfClient *client;
 
-	client = gconf_client_get_default ();
-	gconf_client_add_dir (client, GTT_GCONF,
-	                GCONF_CLIENT_PRELOAD_RECURSIVE, NULL);
+    client = gconf_client_get_default();
+    gconf_client_add_dir(client, GTT_GCONF, GCONF_CLIENT_PRELOAD_RECURSIVE, NULL);
 
-	/* If already running, and we are over-loading a new file,
-	 * then save the currently running project, and try to set it
-	 * running again ... */
-	if (gtt_project_get_title(cur_proj) && (!first_proj_title))
-	{
-		/* We need to strdup because title is freed when
-		 * the project list is destroyed ... */
-		first_proj_title = g_strdup (gtt_project_get_title (cur_proj));
-	}
+    /* If already running, and we are over-loading a new file,
+     * then save the currently running project, and try to set it
+     * running again ... */
+    if (gtt_project_get_title(cur_proj) && (!first_proj_title))
+    {
+        /* We need to strdup because title is freed when
+         * the project list is destroyed ... */
+        first_proj_title = g_strdup(gtt_project_get_title(cur_proj));
+    }
 
-	_n = config_show_tb_new;
-	_c = config_show_tb_ccp;
-	_j = config_show_tb_journal;
-	_p = config_show_tb_prop;
-	_t = config_show_tb_timer;
-	_o = config_show_tb_pref;
-	_h = config_show_tb_help;
-	_e = config_show_tb_exit;
+    _n = config_show_tb_new;
+    _c = config_show_tb_ccp;
+    _j = config_show_tb_journal;
+    _p = config_show_tb_prop;
+    _t = config_show_tb_timer;
+    _o = config_show_tb_pref;
+    _h = config_show_tb_help;
+    _e = config_show_tb_exit;
 
-	/* Get last running project */
-	cur_proj_id = GETINT("/Misc/CurrProject", -1);
+    /* Get last running project */
+    cur_proj_id = GETINT("/Misc/CurrProject", -1);
 
-	config_idle_timeout = GETINT ("/Misc/IdleTimeout", 300);
-	config_no_project_timeout = GETINT ("/Misc/NoProjectTimeout", 300);
-	config_autosave_period = GETINT ("/Misc/AutosavePeriod", 60);
-	config_daystart_offset = GETINT ("/Misc/DayStartOffset", 0);
-	config_weekstart_offset = GETINT ("/Misc/WeekStartOffset", 0);
+    config_idle_timeout = GETINT("/Misc/IdleTimeout", 300);
+    config_no_project_timeout = GETINT("/Misc/NoProjectTimeout", 300);
+    config_autosave_period = GETINT("/Misc/AutosavePeriod", 60);
+    config_daystart_offset = GETINT("/Misc/DayStartOffset", 0);
+    config_weekstart_offset = GETINT("/Misc/WeekStartOffset", 0);
 
-	/* Reset the main window width and height to the values
-	 * last stored in the config file.  Note that if the user
-	 * specified command-line flags, then the command line
-	 * over-rides the config file. */
-	if (!geom_place_override)
-	{
-		int x, y;
-		x = GETINT ("/Geometry/X", 10);
-		y = GETINT ("/Geometry/Y", 10);
-		gtk_widget_set_uposition(GTK_WIDGET(app_window), x, y);
-	}
-	if (!geom_size_override)
-	{
-		int w, h;
-		w = GETINT ("/Geometry/Width", 442);
-		h = GETINT ("/Geometry/Height", 272);
+    /* Reset the main window width and height to the values
+     * last stored in the config file.  Note that if the user
+     * specified command-line flags, then the command line
+     * over-rides the config file. */
+    if (!geom_place_override)
+    {
+        int x, y;
+        x = GETINT("/Geometry/X", 10);
+        y = GETINT("/Geometry/Y", 10);
+        gtk_widget_set_uposition(GTK_WIDGET(app_window), x, y);
+    }
+    if (!geom_size_override)
+    {
+        int w, h;
+        w = GETINT("/Geometry/Width", 442);
+        h = GETINT("/Geometry/Height", 272);
 
-		gtk_window_set_default_size(GTK_WINDOW(app_window), w, h);
-	}
+        gtk_window_set_default_size(GTK_WINDOW(app_window), w, h);
+    }
 
-	{
-		int vp, hp;
-		vp = GETINT ("/Geometry/VPaned", 250);
-		hp = GETINT ("/Geometry/HPaned", 220);
-		notes_area_set_pane_sizes (global_na, vp, hp);
-	}
+    {
+        int vp, hp;
+        vp = GETINT("/Geometry/VPaned", 250);
+        hp = GETINT("/Geometry/HPaned", 220);
+        notes_area_set_pane_sizes(global_na, vp, hp);
+    }
 
-	config_show_secs            = GETBOOL ("/Display/ShowSecs", FALSE);
+    config_show_secs = GETBOOL("/Display/ShowSecs", FALSE);
 
-	prefs_set_show_secs ();
+    prefs_set_show_secs();
 
-	config_show_clist_titles    = GETBOOL ("/Display/ShowTableHeader", FALSE);
-	config_show_subprojects     = GETBOOL ("/Display/ShowSubProjects", TRUE);
-	config_show_statusbar       = GETBOOL ("/Display/ShowStatusbar", TRUE);
+    config_show_clist_titles = GETBOOL("/Display/ShowTableHeader", FALSE);
+    config_show_subprojects = GETBOOL("/Display/ShowSubProjects", TRUE);
+    config_show_statusbar = GETBOOL("/Display/ShowStatusbar", TRUE);
 
-	config_show_title_ever      = GETBOOL ("/Display/ShowTimeEver", TRUE);
-	config_show_title_day       = GETBOOL ("/Display/ShowTimeDay", TRUE);
-	config_show_title_yesterday = GETBOOL ("/Display/ShowTimeYesterday", FALSE);
-	config_show_title_week      = GETBOOL ("/Display/ShowTimeWeek", FALSE);
-	config_show_title_lastweek  = GETBOOL ("/Display/ShowTimeLastWeek", FALSE);
-	config_show_title_month     = GETBOOL ("/Display/ShowTimeMonth", FALSE);
-	config_show_title_year      = GETBOOL ("/Display/ShowTimeYear", FALSE);
-	config_show_title_current   = GETBOOL ("/Display/ShowTimeCurrent", FALSE);
-	config_show_title_desc      = GETBOOL ("/Display/ShowDesc", TRUE);
-	config_show_title_task      = GETBOOL ("/Display/ShowTask", TRUE);
-	config_show_title_estimated_start = GETBOOL ("/Display/ShowEstimatedStart", FALSE);
-	config_show_title_estimated_end = GETBOOL ("/Display/ShowEstimatedEnd", FALSE);
-	config_show_title_due_date = GETBOOL ("/Display/ShowDueDate", FALSE);
-	config_show_title_sizing   = GETBOOL ("/Display/ShowSizing", FALSE);
-	config_show_title_percent_complete = GETBOOL ("/Display/ShowPercentComplete", FALSE);
-	config_show_title_urgency    = GETBOOL ("/Display/ShowUrgency", TRUE);
-	config_show_title_importance = GETBOOL ("/Display/ShowImportance", TRUE);
-	config_show_title_status     = GETBOOL ("/Display/ShowStatus", FALSE);
+    config_show_title_ever = GETBOOL("/Display/ShowTimeEver", TRUE);
+    config_show_title_day = GETBOOL("/Display/ShowTimeDay", TRUE);
+    config_show_title_yesterday = GETBOOL("/Display/ShowTimeYesterday", FALSE);
+    config_show_title_week = GETBOOL("/Display/ShowTimeWeek", FALSE);
+    config_show_title_lastweek = GETBOOL("/Display/ShowTimeLastWeek", FALSE);
+    config_show_title_month = GETBOOL("/Display/ShowTimeMonth", FALSE);
+    config_show_title_year = GETBOOL("/Display/ShowTimeYear", FALSE);
+    config_show_title_current = GETBOOL("/Display/ShowTimeCurrent", FALSE);
+    config_show_title_desc = GETBOOL("/Display/ShowDesc", TRUE);
+    config_show_title_task = GETBOOL("/Display/ShowTask", TRUE);
+    config_show_title_estimated_start = GETBOOL("/Display/ShowEstimatedStart", FALSE);
+    config_show_title_estimated_end = GETBOOL("/Display/ShowEstimatedEnd", FALSE);
+    config_show_title_due_date = GETBOOL("/Display/ShowDueDate", FALSE);
+    config_show_title_sizing = GETBOOL("/Display/ShowSizing", FALSE);
+    config_show_title_percent_complete = GETBOOL("/Display/ShowPercentComplete", FALSE);
+    config_show_title_urgency = GETBOOL("/Display/ShowUrgency", TRUE);
+    config_show_title_importance = GETBOOL("/Display/ShowImportance", TRUE);
+    config_show_title_status = GETBOOL("/Display/ShowStatus", FALSE);
 
-	prefs_update_projects_view ();
+    prefs_update_projects_view();
 
-	/* ------------ */
-	config_show_toolbar    = GETBOOL ("/Toolbar/ShowToolbar", TRUE);
-	config_show_tb_tips    = GETBOOL ("/Toolbar/ShowTips", TRUE);
-	config_show_tb_new     = GETBOOL ("/Toolbar/ShowNew", TRUE);
-	config_show_tb_ccp     = GETBOOL ("/Toolbar/ShowCCP", FALSE);
-	config_show_tb_journal = GETBOOL ("/Toolbar/ShowJournal", TRUE);
-	config_show_tb_prop    = GETBOOL ("/Toolbar/ShowProp", TRUE);
-	config_show_tb_timer   = GETBOOL ("/Toolbar/ShowTimer", TRUE);
-	config_show_tb_pref    = GETBOOL ("/Toolbar/ShowPref", FALSE);
-	config_show_tb_help    = GETBOOL ("/Toolbar/ShowHelp", TRUE);
-	config_show_tb_exit    = GETBOOL ("/Toolbar/ShowExit", TRUE);
+    /* ------------ */
+    config_show_toolbar = GETBOOL("/Toolbar/ShowToolbar", TRUE);
+    config_show_tb_tips = GETBOOL("/Toolbar/ShowTips", TRUE);
+    config_show_tb_new = GETBOOL("/Toolbar/ShowNew", TRUE);
+    config_show_tb_ccp = GETBOOL("/Toolbar/ShowCCP", FALSE);
+    config_show_tb_journal = GETBOOL("/Toolbar/ShowJournal", TRUE);
+    config_show_tb_prop = GETBOOL("/Toolbar/ShowProp", TRUE);
+    config_show_tb_timer = GETBOOL("/Toolbar/ShowTimer", TRUE);
+    config_show_tb_pref = GETBOOL("/Toolbar/ShowPref", FALSE);
+    config_show_tb_help = GETBOOL("/Toolbar/ShowHelp", TRUE);
+    config_show_tb_exit = GETBOOL("/Toolbar/ShowExit", TRUE);
 
-	/* ------------ */
-	config_shell_start = GETSTR ("/Actions/StartCommand",
-	      "echo start id=%D \\\"%t\\\"-\\\"%d\\\" %T  %H-%M-%S hours=%h min=%m secs=%s");
-	config_shell_stop = GETSTR ("/Actions/StopCommand",
-	      "echo stop id=%D \\\"%t\\\"-\\\"%d\\\" %T  %H-%M-%S hours=%h min=%m secs=%s");
+    /* ------------ */
+    config_shell_start = GETSTR(
+        "/Actions/StartCommand",
+        "echo start id=%D \\\"%t\\\"-\\\"%d\\\" %T  %H-%M-%S hours=%h min=%m secs=%s"
+    );
+    config_shell_stop = GETSTR(
+        "/Actions/StopCommand",
+        "echo stop id=%D \\\"%t\\\"-\\\"%d\\\" %T  %H-%M-%S hours=%h min=%m secs=%s"
+    );
 
-	/* ------------ */
-	config_logfile_use   = GETBOOL ("/LogFile/Use", FALSE);
-	config_logfile_name  = GETSTR ("/LogFile/Filename", NULL);
-	config_logfile_start = GETSTR ("/LogFile/EntryStart", _("project %t started"));
-	config_logfile_stop  = GETSTR ("/LogFile/EntryStop", _("stopped project %t"));
-	config_logfile_min_secs = GETINT ("/LogFile/MinSecs", 3);
+    /* ------------ */
+    config_logfile_use = GETBOOL("/LogFile/Use", FALSE);
+    config_logfile_name = GETSTR("/LogFile/Filename", NULL);
+    config_logfile_start = GETSTR("/LogFile/EntryStart", _("project %t started"));
+    config_logfile_stop = GETSTR("/LogFile/EntryStop", _("stopped project %t"));
+    config_logfile_min_secs = GETINT("/LogFile/MinSecs", 3);
 
-	/* ------------ */
-	config_time_format = GETINT("/time_format", 3);
+    /* ------------ */
+    config_time_format = GETINT("/time_format", 3);
 
-	config_currency_symbol = GETSTR ("/Report/CurrencySymbol","$");
-	config_currency_use_locale = GETBOOL ("/Report/CurrencyUseLocale",TRUE);
-	/* ------------ */
-	save_count = GETINT ("/Data/SaveCount", 0);
-	config_data_url = GETSTR ("/Data/URL", XML_DATA_FILENAME);
+    config_currency_symbol = GETSTR("/Report/CurrencySymbol", "$");
+    config_currency_use_locale = GETBOOL("/Report/CurrencyUseLocale", TRUE);
+    /* ------------ */
+    save_count = GETINT("/Data/SaveCount", 0);
+    config_data_url = GETSTR("/Data/URL", XML_DATA_FILENAME);
 
-	/* ------------ */
-	{
-		GSList *node, *list = GETINTLIST ("/CList/ColumnWidths");
-		for (i=0,node=list; node != NULL; node=node->next, i++)
-		{
-			num = (long)(node->data);
-			if (-1 < num)
-			{
-				gtt_projects_tree_set_col_width (projects_tree, i, num);
-			}
-		}
-	}
-	
-	/* Read in the user-defined report locations */
-	gtt_restore_reports_menu(GNOME_APP(app_window));
+    /* ------------ */
+    {
+        GSList *node, *list = GETINTLIST("/CList/ColumnWidths");
+        for (i = 0, node = list; node != NULL; node = node->next, i++)
+        {
+            num = (long) (node->data);
+            if (-1 < num)
+            {
+                gtt_projects_tree_set_col_width(projects_tree, i, num);
+            }
+        }
+    }
 
-	run_timer = GETINT ("/Misc/TimerRunning", 0);
-	/* Use string for time, to avoid unsigned-long problems */
-	last_timer = (time_t) atol (GETSTR ("/Misc/LastTimer", "-1"));
+    /* Read in the user-defined report locations */
+    gtt_restore_reports_menu(GNOME_APP(app_window));
 
-	/* redraw the GUI */
-	if (config_show_statusbar)
-	{
-		gtk_widget_show(status_bar);
-	}
-	else
-	{
-		gtk_widget_hide(status_bar);
-	}
+    run_timer = GETINT("/Misc/TimerRunning", 0);
+    /* Use string for time, to avoid unsigned-long problems */
+    last_timer = (time_t) atol(GETSTR("/Misc/LastTimer", "-1"));
 
-	update_status_bar();
-	if ((_n != config_show_tb_new) ||
-	    (_c != config_show_tb_ccp) ||
-	    (_j != config_show_tb_journal) ||
-	    (_p != config_show_tb_prop) ||
-	    (_t != config_show_tb_timer) ||
-	    (_o != config_show_tb_pref) ||
-	    (_h != config_show_tb_help) ||
-	    (_e != config_show_tb_exit))
-	{
-		update_toolbar_sections();
-	}
+    /* redraw the GUI */
+    if (config_show_statusbar)
+    {
+        gtk_widget_show(status_bar);
+    }
+    else
+    {
+        gtk_widget_hide(status_bar);
+    }
+
+    update_status_bar();
+    if ((_n != config_show_tb_new) || (_c != config_show_tb_ccp)
+        || (_j != config_show_tb_journal) || (_p != config_show_tb_prop)
+        || (_t != config_show_tb_timer) || (_o != config_show_tb_pref)
+        || (_h != config_show_tb_help) || (_e != config_show_tb_exit))
+    {
+        update_toolbar_sections();
+    }
 }
 
-gchar *
-gtt_gconf_get_expander (void)
+gchar *gtt_gconf_get_expander(void)
 {
-	GConfClient * client = gconf_client_get_default ();
-	return GETSTR ("/Display/ExpanderState", NULL);
+    GConfClient *client = gconf_client_get_default();
+    return GETSTR("/Display/ExpanderState", NULL);
 }
 
 /* =========================== END OF FILE ========================= */

--- a/src/gconf-io.h
+++ b/src/gconf-io.h
@@ -16,7 +16,6 @@
  *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-
 #ifndef GTT_GCONF_IO_H_
 #define GTT_GCONF_IO_H_
 
@@ -26,13 +25,13 @@
  * The gtt_gconf_save() routine will save all of the GTT attributes
  * into the Gnome2 Gconf attribute system.
  */
-void gtt_gconf_save (void);
+void gtt_gconf_save(void);
 
 /**
  * The gtt_gconf_load() routine will fetch all of the GTT attributes
  * from the Gnome2 Gconf attribute system.
  */
-void gtt_gconf_load (void);
+void gtt_gconf_load(void);
 
 /**
  * The gtt_gconf_exists() routine returns TRUE if the Gnome2 GConf system
@@ -40,17 +39,15 @@ void gtt_gconf_load (void);
  * the very first time this version of GTT is run.  This gives the code
  * a chance to pull attributes out of the older gnome_config system.
  */
-gboolean gtt_gconf_exists (void);
+gboolean gtt_gconf_exists(void);
 
 /**
  * The gtt_save_reports_menu() routine saves only the reports menu
  * attributes to the gconf system.
  */
-void gtt_save_reports_menu (void);
-
+void gtt_save_reports_menu(void);
 
 /* quick hack */
-char *gtt_gconf_get_expander (void);
+char *gtt_gconf_get_expander(void);
 
 #endif /* GTT_GCONF_IO_H_ */
-

--- a/src/ghtml-deprecated.c
+++ b/src/ghtml-deprecated.c
@@ -27,9 +27,9 @@
 #include <qof.h>
 
 #include "app.h"
-#include "gtt.h"
-#include "ghtml.h"
 #include "ghtml-deprecated.h"
+#include "ghtml.h"
+#include "gtt.h"
 #include "proj.h"
 #include "util.h"
 
@@ -37,29 +37,29 @@
  * sometime in 2004 or 2005, around gnotime version 3.0 or so
  */
 
-typedef enum {
-	NUL=0,
+typedef enum
+{
+    NUL = 0,
 
-	/* task things */
-	MEMO = 1,
-	NOTES,
-	TASK_TIME,
-	BILLSTATUS,
-	BILLABLE,
-	BILLRATE,
-	VALUE,
-	BILLABLE_VALUE,
+    /* task things */
+    MEMO = 1,
+    NOTES,
+    TASK_TIME,
+    BILLSTATUS,
+    BILLABLE,
+    BILLRATE,
+    VALUE,
+    BILLABLE_VALUE,
 
-	/* interval things */
-	START_DATIME =100,
-	STOP_DATIME,
-	ELAPSED,
-	FUZZ,
+    /* interval things */
+    START_DATIME = 100,
+    STOP_DATIME,
+    ELAPSED,
+    FUZZ,
 
 } TableCol;
 
 #define NCOL 30
-
 
 /* ============================================================== */
 /* This routine outputs a simple, hard-coded table showing the
@@ -67,546 +67,619 @@ typedef enum {
  * reports, but its a great place to understand how the other
  * code in this file works. */
 
-static SCM
-do_show_journal (GttGhtml *ghtml, GttProject *prj)
+static SCM do_show_journal(GttGhtml *ghtml, GttProject *prj)
 {
-	char buff[100];
-	GList *node;
-	GString *p;
-	char * ps;
-	gboolean show_links = ghtml->show_links;
+    char buff[100];
+    GList *node;
+    GString *p;
+    char *ps;
+    gboolean show_links = ghtml->show_links;
 
-	if (NULL == ghtml->write_stream) return SCM_UNSPECIFIED;
+    if (NULL == ghtml->write_stream)
+        return SCM_UNSPECIFIED;
 
-	p = g_string_new(NULL);
-	g_string_append_printf (p,
-		"<b>The use of this function is deprecated. "
-		" Please see the examples for the recommended style.</b>"
-		"<table border=1>\n"
-		"<tr><th colspan=4>%s</th></tr>\n"
-		"<tr><th> &nbsp; </th><th>%s</th><th>%s</th><th>%s</th></tr>\n",
-		_("Diary Entry"), _("Start"), _("Stop"), _("Elapsed"));
+    p = g_string_new(NULL);
+    g_string_append_printf(
+        p,
+        "<b>The use of this function is deprecated. "
+        " Please see the examples for the recommended style.</b>"
+        "<table border=1>\n"
+        "<tr><th colspan=4>%s</th></tr>\n"
+        "<tr><th> &nbsp; </th><th>%s</th><th>%s</th><th>%s</th></tr>\n",
+        _("Diary Entry"), _("Start"), _("Stop"), _("Elapsed")
+    );
 
-	(ghtml->write_stream) (ghtml, p->str, p->len, ghtml->user_data);
+    (ghtml->write_stream)(ghtml, p->str, p->len, ghtml->user_data);
 
-	for (node = gtt_project_get_tasks(prj); node; node=node->next)
-	{
-		const char *pp;
-		int prt_date = 1;
-		time_t prev_stop = 0;
-		GList *in;
-		GttTask *tsk = node->data;
-		
-		p = g_string_truncate (p, 0);
-		p = g_string_append (p, "<tr><td colspan=4>");
-		if (show_links)
-		{
-			g_string_append_printf (p, "<a href=\"gtt:task:0x%lx\">", (long)tsk);
-		}
+    for (node = gtt_project_get_tasks(prj); node; node = node->next)
+    {
+        const char *pp;
+        int prt_date = 1;
+        time_t prev_stop = 0;
+        GList *in;
+        GttTask *tsk = node->data;
 
-		pp = gtt_task_get_memo(tsk);
-		if (!pp || !pp[0]) pp = _("(empty)");
-		p = g_string_append (p, pp);
-		if (show_links) p = g_string_append (p, "</a>");
-		p = g_string_append (p, "</td>\n</tr>\n");
+        p = g_string_truncate(p, 0);
+        p = g_string_append(p, "<tr><td colspan=4>");
+        if (show_links)
+        {
+            g_string_append_printf(p, "<a href=\"gtt:task:0x%lx\">", (long) tsk);
+        }
 
-		(ghtml->write_stream) (ghtml, p->str, p->len, ghtml->user_data);
+        pp = gtt_task_get_memo(tsk);
+        if (!pp || !pp[0])
+            pp = _("(empty)");
+        p = g_string_append(p, pp);
+        if (show_links)
+            p = g_string_append(p, "</a>");
+        p = g_string_append(p, "</td>\n</tr>\n");
 
-		
-		for (in=gtt_task_get_intervals(tsk); in; in=in->next)
-		{
-			GttInterval *ivl = in->data;
-			time_t start, stop, elapsed;
-			start = gtt_interval_get_start (ivl);
-			stop = gtt_interval_get_stop (ivl);
-			elapsed = stop - start;
-			
-			p = g_string_truncate (p, 0);
-			p = g_string_append (p,
-				"<tr><td> &nbsp; &nbsp; &nbsp; </td>\n"
-				"<td align=right> &nbsp; &nbsp; ");
-			if (show_links)
-			{
-				g_string_append_printf (p, "<a href=\"gtt:interval:0x%lx\">", (long)ivl);
-			}
+        (ghtml->write_stream)(ghtml, p->str, p->len, ghtml->user_data);
 
-			/* print hour only or date too? */
-			if (0 != prev_stop) {
-				prt_date = xxxqof_is_same_day(start, prev_stop);
-			}
-			if (prt_date) {
-				xxxqof_print_date_time_buff (buff, 100, start);
-				p = g_string_append (p, buff);
-			} else {
-				xxxqof_print_time_buff (buff, 100, start);
-				p = g_string_append (p, buff);
-			}
+        for (in = gtt_task_get_intervals(tsk); in; in = in->next)
+        {
+            GttInterval *ivl = in->data;
+            time_t start, stop, elapsed;
+            start = gtt_interval_get_start(ivl);
+            stop = gtt_interval_get_stop(ivl);
+            elapsed = stop - start;
 
-			/* print hour only or date too? */
-			prt_date = xxxqof_is_same_day(start, stop);
-			if (show_links) p = g_string_append (p, "</a>");
-			p = g_string_append (p,
-				" &nbsp; &nbsp; </td>\n"
-				"<td> &nbsp; &nbsp; ");
-			if (show_links)
-			{
-				g_string_append_printf (p, "<a href=\"gtt:interval:0x%lx\">", (long)ivl);
-			}
-			if (prt_date) {
-				xxxqof_print_date_time_buff (buff, 100, stop);
-				p = g_string_append (p, buff);
-			} else {
-				xxxqof_print_time_buff (buff, 100, stop);
-				p = g_string_append (p, buff);
-			}
+            p = g_string_truncate(p, 0);
+            p = g_string_append(
+                p, "<tr><td> &nbsp; &nbsp; &nbsp; </td>\n"
+                   "<td align=right> &nbsp; &nbsp; "
+            );
+            if (show_links)
+            {
+                g_string_append_printf(p, "<a href=\"gtt:interval:0x%lx\">", (long) ivl);
+            }
 
-			prev_stop = stop;
+            /* print hour only or date too? */
+            if (0 != prev_stop)
+            {
+                prt_date = xxxqof_is_same_day(start, prev_stop);
+            }
+            if (prt_date)
+            {
+                xxxqof_print_date_time_buff(buff, 100, start);
+                p = g_string_append(p, buff);
+            }
+            else
+            {
+                xxxqof_print_time_buff(buff, 100, start);
+                p = g_string_append(p, buff);
+            }
 
-			if (show_links) p = g_string_append (p, "</a>");
-			p = g_string_append (p, " &nbsp; &nbsp; </td>\n<td> &nbsp; &nbsp; ");
-			xxxqof_print_hours_elapsed_buff (buff, 100, elapsed, TRUE);
-			p = g_string_append (p, buff);
-			p = g_string_append (p, " &nbsp; &nbsp; </td></tr>\n");
-			(ghtml->write_stream) (ghtml, p->str, p->len, ghtml->user_data);
-		}
+            /* print hour only or date too? */
+            prt_date = xxxqof_is_same_day(start, stop);
+            if (show_links)
+                p = g_string_append(p, "</a>");
+            p = g_string_append(
+                p, " &nbsp; &nbsp; </td>\n"
+                   "<td> &nbsp; &nbsp; "
+            );
+            if (show_links)
+            {
+                g_string_append_printf(p, "<a href=\"gtt:interval:0x%lx\">", (long) ivl);
+            }
+            if (prt_date)
+            {
+                xxxqof_print_date_time_buff(buff, 100, stop);
+                p = g_string_append(p, buff);
+            }
+            else
+            {
+                xxxqof_print_time_buff(buff, 100, stop);
+                p = g_string_append(p, buff);
+            }
 
-	}
-	
-	ps = "</table>\n";
-	(ghtml->write_stream) (ghtml, ps, strlen(ps), ghtml->user_data);
+            prev_stop = stop;
 
-	/* should the free-segment be false or true ??? */
-	g_string_free (p, FALSE);
+            if (show_links)
+                p = g_string_append(p, "</a>");
+            p = g_string_append(p, " &nbsp; &nbsp; </td>\n<td> &nbsp; &nbsp; ");
+            xxxqof_print_hours_elapsed_buff(buff, 100, elapsed, TRUE);
+            p = g_string_append(p, buff);
+            p = g_string_append(p, " &nbsp; &nbsp; </td></tr>\n");
+            (ghtml->write_stream)(ghtml, p->str, p->len, ghtml->user_data);
+        }
+    }
 
-	return SCM_UNSPECIFIED;
+    ps = "</table>\n";
+    (ghtml->write_stream)(ghtml, ps, strlen(ps), ghtml->user_data);
+
+    /* should the free-segment be false or true ??? */
+    g_string_free(p, FALSE);
+
+    return SCM_UNSPECIFIED;
 }
 
 /* ============================================================== */
-
 
 #define TASK_COL_TITLE(DEFAULT_STR)                        \
-{                                                          \
-   if (ghtml->task_titles[i]) {                            \
-      p = g_string_append (p, ghtml->task_titles[i]);      \
-   } else {                                                \
-      p = g_string_append (p, DEFAULT_STR);                \
-   }                                                       \
-}
+    {                                                      \
+        if (ghtml->task_titles[i])                         \
+        {                                                  \
+            p = g_string_append(p, ghtml->task_titles[i]); \
+        }                                                  \
+        else                                               \
+        {                                                  \
+            p = g_string_append(p, DEFAULT_STR);           \
+        }                                                  \
+    }
 
 #define INVL_COL_TITLE(DEFAULT_STR)                        \
-{                                                          \
-   if (ghtml->invl_titles[i]) {                            \
-      p = g_string_append (p, ghtml->invl_titles[i]);      \
-   } else {                                                \
-      p = g_string_append (p, DEFAULT_STR);                \
-   }                                                       \
-}
+    {                                                      \
+        if (ghtml->invl_titles[i])                         \
+        {                                                  \
+            p = g_string_append(p, ghtml->invl_titles[i]); \
+        }                                                  \
+        else                                               \
+        {                                                  \
+            p = g_string_append(p, DEFAULT_STR);           \
+        }                                                  \
+    }
 
-static void
-do_show_table (GttGhtml *ghtml, GttProject *prj, int invoice)
+static void do_show_table(GttGhtml *ghtml, GttProject *prj, int invoice)
 {
-	int i;
-	GList *node;
-	char buff [100];
-	GString *p;
-	gboolean output_html = ghtml->show_html;
-	gboolean show_links = ghtml->show_links;
+    int i;
+    GList *node;
+    char buff[100];
+    GString *p;
+    gboolean output_html = ghtml->show_html;
+    gboolean show_links = ghtml->show_links;
 
-	if (NULL == ghtml->write_stream) return;
+    if (NULL == ghtml->write_stream)
+        return;
 
-	p = g_string_new (NULL);
-	if (output_html) p = g_string_append (p, "<table border=1>");
-	p = g_string_append (p,
-		"<b>The use of this function is deprecated. "
-		" Please see the examples for the recommended style.</b>");
+    p = g_string_new(NULL);
+    if (output_html)
+        p = g_string_append(p, "<table border=1>");
+    p = g_string_append(
+        p, "<b>The use of this function is deprecated. "
+           " Please see the examples for the recommended style.</b>"
+    );
 
-	/* write out the table header */
-	if (output_html && (0 < ghtml->ntask_cols))
-	{
-		p = g_string_append (p, "<tr>");
-	}
-	for (i=0; i<ghtml->ntask_cols; i++)
-	{
-		switch (ghtml->task_cols[i])
-		{
-			case MEMO:
-			{
-				int mcols;
-				mcols = ghtml->ninvl_cols - ghtml->ntask_cols;
-				if (0 >= mcols) mcols = 1;
-				if (output_html) g_string_append_printf (p, "<th colspan=%d>", mcols);
-				TASK_COL_TITLE (_("Diary Entry"));
-				break;
-			}
-			case NOTES:
-				if (output_html) p = g_string_append (p, "<th>");
-				TASK_COL_TITLE (_("Notes"));
-				break;
-			case TASK_TIME:
-				if (output_html) p = g_string_append (p, "<th>");
-				TASK_COL_TITLE (_("Task Time"));
-				break;
-			case BILLSTATUS:
-				if (output_html) p = g_string_append (p, "<th>");
-				TASK_COL_TITLE (_("Bill Status"));
-				break;
-			case BILLABLE:
-				if (output_html) p = g_string_append (p, "<th>");
-				TASK_COL_TITLE (_("Billable"));
-				break;
-			case BILLRATE:
-				if (output_html) p = g_string_append (p, "<th>");
-				TASK_COL_TITLE (_("Bill Rate"));
-				break;
-			case VALUE:
-				if (output_html) p = g_string_append (p, "<th>");
-				TASK_COL_TITLE (_("Value"));
-				break;
-			case BILLABLE_VALUE:
-				if (output_html) p = g_string_append (p, "<th>");
-				TASK_COL_TITLE (_("Billable Value"));
-				break;
-			default:
-				if (output_html) p = g_string_append (p, "<th>");
-				TASK_COL_TITLE (_("No Default Value"));
-		}
-		p = g_string_append (p, ghtml->delim);	
-		if (output_html) p = g_string_append (p, "</th>\n");
-	}
+    /* write out the table header */
+    if (output_html && (0 < ghtml->ntask_cols))
+    {
+        p = g_string_append(p, "<tr>");
+    }
+    for (i = 0; i < ghtml->ntask_cols; i++)
+    {
+        switch (ghtml->task_cols[i])
+        {
+        case MEMO:
+        {
+            int mcols;
+            mcols = ghtml->ninvl_cols - ghtml->ntask_cols;
+            if (0 >= mcols)
+                mcols = 1;
+            if (output_html)
+                g_string_append_printf(p, "<th colspan=%d>", mcols);
+            TASK_COL_TITLE(_("Diary Entry"));
+            break;
+        }
+        case NOTES:
+            if (output_html)
+                p = g_string_append(p, "<th>");
+            TASK_COL_TITLE(_("Notes"));
+            break;
+        case TASK_TIME:
+            if (output_html)
+                p = g_string_append(p, "<th>");
+            TASK_COL_TITLE(_("Task Time"));
+            break;
+        case BILLSTATUS:
+            if (output_html)
+                p = g_string_append(p, "<th>");
+            TASK_COL_TITLE(_("Bill Status"));
+            break;
+        case BILLABLE:
+            if (output_html)
+                p = g_string_append(p, "<th>");
+            TASK_COL_TITLE(_("Billable"));
+            break;
+        case BILLRATE:
+            if (output_html)
+                p = g_string_append(p, "<th>");
+            TASK_COL_TITLE(_("Bill Rate"));
+            break;
+        case VALUE:
+            if (output_html)
+                p = g_string_append(p, "<th>");
+            TASK_COL_TITLE(_("Value"));
+            break;
+        case BILLABLE_VALUE:
+            if (output_html)
+                p = g_string_append(p, "<th>");
+            TASK_COL_TITLE(_("Billable Value"));
+            break;
+        default:
+            if (output_html)
+                p = g_string_append(p, "<th>");
+            TASK_COL_TITLE(_("No Default Value"));
+        }
+        p = g_string_append(p, ghtml->delim);
+        if (output_html)
+            p = g_string_append(p, "</th>\n");
+    }
 
-	if (output_html && (0 < ghtml->ninvl_cols))
-	{
-		p = g_string_append (p, "</tr><tr>");
-	}
-	for (i=0; i<ghtml->ninvl_cols; i++)
-	{
-		if (output_html) p = g_string_append (p, "<th>");
-		switch (ghtml->invl_cols[i])
-		{
-			case START_DATIME:
-				INVL_COL_TITLE (_("Start"));
-				break;
-			case STOP_DATIME:
-				INVL_COL_TITLE (_("Stop"));
-				break;
-			case ELAPSED:
-				INVL_COL_TITLE (_("Elapsed"));
-				break;
-			case FUZZ:
-				INVL_COL_TITLE (_("Start Time Fuzziness"));
-				break;
-			default:
-				TASK_COL_TITLE (_("No Default Value"));
-		}
-		if (output_html) p = g_string_append (p, "</th>\n");
-	}
-	if (output_html && (0 < ghtml->ninvl_cols))
-	{
-		p = g_string_append (p, "</tr>");
-	}
-	p = g_string_append (p, "\n");
+    if (output_html && (0 < ghtml->ninvl_cols))
+    {
+        p = g_string_append(p, "</tr><tr>");
+    }
+    for (i = 0; i < ghtml->ninvl_cols; i++)
+    {
+        if (output_html)
+            p = g_string_append(p, "<th>");
+        switch (ghtml->invl_cols[i])
+        {
+        case START_DATIME:
+            INVL_COL_TITLE(_("Start"));
+            break;
+        case STOP_DATIME:
+            INVL_COL_TITLE(_("Stop"));
+            break;
+        case ELAPSED:
+            INVL_COL_TITLE(_("Elapsed"));
+            break;
+        case FUZZ:
+            INVL_COL_TITLE(_("Start Time Fuzziness"));
+            break;
+        default:
+            TASK_COL_TITLE(_("No Default Value"));
+        }
+        if (output_html)
+            p = g_string_append(p, "</th>\n");
+    }
+    if (output_html && (0 < ghtml->ninvl_cols))
+    {
+        p = g_string_append(p, "</tr>");
+    }
+    p = g_string_append(p, "\n");
 
-	(ghtml->write_stream) (ghtml, p->str, p->len, ghtml->user_data);
+    (ghtml->write_stream)(ghtml, p->str, p->len, ghtml->user_data);
 
-	for (node = gtt_project_get_tasks(prj); node; node=node->next)
-	{
-		GttBillStatus billstatus;
-		GttBillable billable;
-		GttBillRate billrate;
-		const char *pp;
-		time_t prev_stop = 0;
-		GList *in;
-		GttTask *tsk = node->data;
-		int task_secs;
-		double hours, value=0.0, billable_value=0.0;
-		
-		/* set up data */
-		billstatus = gtt_task_get_billstatus (tsk);
-		billable = gtt_task_get_billable (tsk);
-		billrate = gtt_task_get_billrate (tsk);
+    for (node = gtt_project_get_tasks(prj); node; node = node->next)
+    {
+        GttBillStatus billstatus;
+        GttBillable billable;
+        GttBillRate billrate;
+        const char *pp;
+        time_t prev_stop = 0;
+        GList *in;
+        GttTask *tsk = node->data;
+        int task_secs;
+        double hours, value = 0.0, billable_value = 0.0;
 
-		/* if we are in invoice mode, then skip anything not billable */
-		if (invoice)
-		{
-			if ((GTT_BILL != billstatus) ||
-			    (GTT_NOT_BILLABLE == billable)) continue;
-		}
+        /* set up data */
+        billstatus = gtt_task_get_billstatus(tsk);
+        billable = gtt_task_get_billable(tsk);
+        billrate = gtt_task_get_billrate(tsk);
 
-		task_secs = gtt_task_get_secs_ever(tsk);
-		hours = task_secs;
-		hours /= 3600;
-		switch (billrate)
-		{
-			case GTT_REGULAR:
-				value = hours * gtt_project_get_billrate (prj);
-				break;
-			case GTT_OVERTIME:
-				value = hours * gtt_project_get_overtime_rate (prj);
-				break;
-			case GTT_OVEROVER:
-				value = hours * gtt_project_get_overover_rate (prj);
-				break;
-			case GTT_FLAT_FEE:
-				value = gtt_project_get_flat_fee (prj);
-				break;
-		}
+        /* if we are in invoice mode, then skip anything not billable */
+        if (invoice)
+        {
+            if ((GTT_BILL != billstatus) || (GTT_NOT_BILLABLE == billable))
+                continue;
+        }
 
-		switch (billable)
-		{
-			case GTT_BILLABLE:
-				billable_value = value;
-				break;
-			case GTT_NOT_BILLABLE:
-				billable_value = 0.0;
-				break;
-			case GTT_NO_CHARGE:
-				billable_value = 0.0;
-				break;
-		}
+        task_secs = gtt_task_get_secs_ever(tsk);
+        hours = task_secs;
+        hours /= 3600;
+        switch (billrate)
+        {
+        case GTT_REGULAR:
+            value = hours * gtt_project_get_billrate(prj);
+            break;
+        case GTT_OVERTIME:
+            value = hours * gtt_project_get_overtime_rate(prj);
+            break;
+        case GTT_OVEROVER:
+            value = hours * gtt_project_get_overover_rate(prj);
+            break;
+        case GTT_FLAT_FEE:
+            value = gtt_project_get_flat_fee(prj);
+            break;
+        }
 
-		/* start with an empty string */
-		p = g_string_truncate (p,0);
+        switch (billable)
+        {
+        case GTT_BILLABLE:
+            billable_value = value;
+            break;
+        case GTT_NOT_BILLABLE:
+            billable_value = 0.0;
+            break;
+        case GTT_NO_CHARGE:
+            billable_value = 0.0;
+            break;
+        }
 
-		/* write the task data */
-		if (output_html && (0 < ghtml->ntask_cols))
-		{
-			p = g_string_append (p, "<tr>");
-		}
-		for (i=0; i<ghtml->ntask_cols; i++)
-		{
-			switch (ghtml->task_cols[i])
-			{
-				case MEMO:
-				{
-					int mcols;
-					mcols = ghtml->ninvl_cols - ghtml->ntask_cols;
-					if (0 >= mcols) mcols = 1;
-					if (output_html) g_string_append_printf (p, "<td colspan=%d>", mcols);
-					if (show_links)
-					{
-						g_string_append_printf (p, "<a href=\"gtt:task:0x%lx\">", (long)tsk);
-					}
-					pp = gtt_task_get_memo(tsk);
-					if (!pp || !pp[0]) pp = _("(empty)");
-					p = g_string_append (p, pp);
-					if (show_links) p = g_string_append (p, "</a>");
-					break;
-				}
+        /* start with an empty string */
+        p = g_string_truncate(p, 0);
 
-				case NOTES:
-					if (output_html) p = g_string_append (p, "<td align=left>");
-					pp = gtt_task_get_notes(tsk);
-					if (!pp || !pp[0]) pp = _("(empty)");
-					p = g_string_append (p, pp);
-					break;
+        /* write the task data */
+        if (output_html && (0 < ghtml->ntask_cols))
+        {
+            p = g_string_append(p, "<tr>");
+        }
+        for (i = 0; i < ghtml->ntask_cols; i++)
+        {
+            switch (ghtml->task_cols[i])
+            {
+            case MEMO:
+            {
+                int mcols;
+                mcols = ghtml->ninvl_cols - ghtml->ntask_cols;
+                if (0 >= mcols)
+                    mcols = 1;
+                if (output_html)
+                    g_string_append_printf(p, "<td colspan=%d>", mcols);
+                if (show_links)
+                {
+                    g_string_append_printf(p, "<a href=\"gtt:task:0x%lx\">", (long) tsk);
+                }
+                pp = gtt_task_get_memo(tsk);
+                if (!pp || !pp[0])
+                    pp = _("(empty)");
+                p = g_string_append(p, pp);
+                if (show_links)
+                    p = g_string_append(p, "</a>");
+                break;
+            }
 
-				case TASK_TIME:
-					if (output_html) p = g_string_append (p, "<td align=right>");
-					xxxqof_print_hours_elapsed_buff (buff, 100, task_secs, TRUE);
-					p = g_string_append (p, buff);
-					break;
+            case NOTES:
+                if (output_html)
+                    p = g_string_append(p, "<td align=left>");
+                pp = gtt_task_get_notes(tsk);
+                if (!pp || !pp[0])
+                    pp = _("(empty)");
+                p = g_string_append(p, pp);
+                break;
 
-				case BILLSTATUS:
-					if (output_html) p = g_string_append (p, "<td>");
-					switch (billstatus)
-					{
-						case GTT_HOLD:
-							p = g_string_append (p, _("Hold"));
-							break;
-						case GTT_BILL:
-							p = g_string_append (p, _("Bill"));
-							break;
-						case GTT_PAID:
-							p = g_string_append (p, _("Paid"));
-							break;
-					}
-					break;
+            case TASK_TIME:
+                if (output_html)
+                    p = g_string_append(p, "<td align=right>");
+                xxxqof_print_hours_elapsed_buff(buff, 100, task_secs, TRUE);
+                p = g_string_append(p, buff);
+                break;
 
-				case BILLABLE:
-					if (output_html) p = g_string_append (p, "<td>");
-					switch (billable)
-					{
-						case GTT_BILLABLE:
-							p = g_string_append (p, _("Billable"));
-							break;
-						case GTT_NOT_BILLABLE:
-							p = g_string_append (p, _("Not Billable"));
-							break;
-						case GTT_NO_CHARGE:
-							p = g_string_append (p, _("No Charge"));
-							break;
-					}
-					break;
+            case BILLSTATUS:
+                if (output_html)
+                    p = g_string_append(p, "<td>");
+                switch (billstatus)
+                {
+                case GTT_HOLD:
+                    p = g_string_append(p, _("Hold"));
+                    break;
+                case GTT_BILL:
+                    p = g_string_append(p, _("Bill"));
+                    break;
+                case GTT_PAID:
+                    p = g_string_append(p, _("Paid"));
+                    break;
+                }
+                break;
 
-				case BILLRATE:
-					if (output_html) p = g_string_append (p, "<td>");
-					switch (billrate)
-					{
-						case GTT_REGULAR:
-							p = g_string_append (p, _("Regular"));
-							break;
-						case GTT_OVERTIME:
-							p = g_string_append (p, _("Overtime"));
-							break;
-						case GTT_OVEROVER:
-							p = g_string_append (p, _("Double Overtime"));
-							break;
-						case GTT_FLAT_FEE:
-							p = g_string_append (p, _("Flat Fee"));
-							break;
-					}
-					break;
+            case BILLABLE:
+                if (output_html)
+                    p = g_string_append(p, "<td>");
+                switch (billable)
+                {
+                case GTT_BILLABLE:
+                    p = g_string_append(p, _("Billable"));
+                    break;
+                case GTT_NOT_BILLABLE:
+                    p = g_string_append(p, _("Not Billable"));
+                    break;
+                case GTT_NO_CHARGE:
+                    p = g_string_append(p, _("No Charge"));
+                    break;
+                }
+                break;
 
-				case VALUE:
-					if (output_html) p = g_string_append (p, "<td align=right>");
-					
-					/* hack alert should use i18n currency/monetary printing */
-					g_string_append_printf (p, "$%.2f", value+0.0049);
-					break;
+            case BILLRATE:
+                if (output_html)
+                    p = g_string_append(p, "<td>");
+                switch (billrate)
+                {
+                case GTT_REGULAR:
+                    p = g_string_append(p, _("Regular"));
+                    break;
+                case GTT_OVERTIME:
+                    p = g_string_append(p, _("Overtime"));
+                    break;
+                case GTT_OVEROVER:
+                    p = g_string_append(p, _("Double Overtime"));
+                    break;
+                case GTT_FLAT_FEE:
+                    p = g_string_append(p, _("Flat Fee"));
+                    break;
+                }
+                break;
 
-				case BILLABLE_VALUE:
-					if (output_html) p = g_string_append (p, "<td align=right>");
-					/* hack alert should use i18n currency/monetary printing */
-					g_string_append_printf (p, "$%.2f", billable_value+0.0049);
-					break;
+            case VALUE:
+                if (output_html)
+                    p = g_string_append(p, "<td align=right>");
 
-				default:
-					if (output_html) p = g_string_append (p, "<td>");
-					p = g_string_append (p, _("Error - Unknown"));
-			}
-			p = g_string_append (p, ghtml->delim);
-			if (output_html) p = g_string_append (p, "</td>\n");
-		}
+                /* hack alert should use i18n currency/monetary printing */
+                g_string_append_printf(p, "$%.2f", value + 0.0049);
+                break;
 
-		if (0 < ghtml->ntask_cols)
-		{
-			if (output_html) p = g_string_append (p, "</tr>");
-			p = g_string_append (p, "\n");
-			(ghtml->write_stream) (ghtml, p->str, p->len, ghtml->user_data);
-		}
-		
-		/* write out intervals */
-		for (in=gtt_task_get_intervals(tsk); in; in=in->next)
-		{
-			GttInterval *ivl = in->data;
-			time_t start, stop, elapsed;
-			int prt_start_date = 1;
-			int prt_stop_date = 1;
+            case BILLABLE_VALUE:
+                if (output_html)
+                    p = g_string_append(p, "<td align=right>");
+                /* hack alert should use i18n currency/monetary printing */
+                g_string_append_printf(p, "$%.2f", billable_value + 0.0049);
+                break;
 
-			/* data setup */
-			start = gtt_interval_get_start (ivl);
-			stop = gtt_interval_get_stop (ivl);
-			elapsed = stop - start;
+            default:
+                if (output_html)
+                    p = g_string_append(p, "<td>");
+                p = g_string_append(p, _("Error - Unknown"));
+            }
+            p = g_string_append(p, ghtml->delim);
+            if (output_html)
+                p = g_string_append(p, "</td>\n");
+        }
 
-			/* print hour only or date too? */
-			prt_stop_date = xxxqof_is_same_day(start, stop);
-			if (0 != prev_stop) {
-				prt_start_date = xxxqof_is_same_day(start, prev_stop);
-			}
-			prev_stop = stop;
+        if (0 < ghtml->ntask_cols)
+        {
+            if (output_html)
+                p = g_string_append(p, "</tr>");
+            p = g_string_append(p, "\n");
+            (ghtml->write_stream)(ghtml, p->str, p->len, ghtml->user_data);
+        }
 
+        /* write out intervals */
+        for (in = gtt_task_get_intervals(tsk); in; in = in->next)
+        {
+            GttInterval *ivl = in->data;
+            time_t start, stop, elapsed;
+            int prt_start_date = 1;
+            int prt_stop_date = 1;
 
-			/* -------------------------- */
-			p = g_string_truncate (p,0);
-			if (output_html && (0<ghtml->ninvl_cols)) p = g_string_append (p, "<tr>");
-			for (i=0; i<ghtml->ninvl_cols; i++)
-			{
+            /* data setup */
+            start = gtt_interval_get_start(ivl);
+            stop = gtt_interval_get_stop(ivl);
+            elapsed = stop - start;
 
-				switch (ghtml->invl_cols[i])
-				{
-	case START_DATIME:
-	{
-		if (output_html) p = g_string_append (p, "<td align=right>&nbsp;&nbsp;");
-		if (show_links)
-		{
-			g_string_append_printf (p, "<a href=\"gtt:interval:0x%lx\">", (long)ivl);
-		}
-		if (prt_start_date) {
-			xxxqof_print_date_time_buff (buff, 100, start);
-			p = g_string_append (p, buff);
-		} else {
-			xxxqof_print_time_buff (buff, 100, start);
-			p = g_string_append (p, buff);
-		}
-		if (show_links) p = g_string_append (p, "</a>");
-		p = g_string_append (p, "&nbsp;&nbsp;");
-		break;
-	}
-	case STOP_DATIME:
-	{
-		if (output_html) p = g_string_append (p, "<td align=right>&nbsp;&nbsp;");
-		if (show_links)
-		{
-			g_string_append_printf (p, "<a href=\"gtt:interval:0x%lx\">", (long)ivl);
-		}
-		if (prt_stop_date) {
-			xxxqof_print_date_time_buff (buff, 100, stop);
-			p = g_string_append (p, buff);
-		} else {
-			xxxqof_print_time_buff (buff, 100, stop);
-			p = g_string_append (p, buff);
-		}
-		if (show_links) p = g_string_append (p, "</a>");
-		if (output_html) p = g_string_append (p, "&nbsp;&nbsp;");
-		break;
-	}
-	case ELAPSED:
-	{
-		if (output_html) p = g_string_append (p, "<td>&nbsp;&nbsp;");
-		xxxqof_print_hours_elapsed_buff (buff, 100, elapsed, TRUE);
-		p = g_string_append (p, buff);
-		if (output_html) p = g_string_append (p, "&nbsp;&nbsp;");
-		break;
-	}
-	case FUZZ:
-	{
-		if (output_html) p = g_string_append (p, "<td>&nbsp;&nbsp;");
-		xxxqof_print_hours_elapsed_buff (buff, 100, gtt_interval_get_fuzz(ivl), TRUE);
-		p = g_string_append (p, buff);
-		if (output_html) p = g_string_append (p, "&nbsp;&nbsp;");
-		break;
-	}
-	default:
-		if (output_html) p = g_string_append (p, "<td>");
-				}
-				if (output_html) p = g_string_append (p, "</td>\n");
-			}
+            /* print hour only or date too? */
+            prt_stop_date = xxxqof_is_same_day(start, stop);
+            if (0 != prev_stop)
+            {
+                prt_start_date = xxxqof_is_same_day(start, prev_stop);
+            }
+            prev_stop = stop;
 
-			if (output_html && (0<ghtml->ninvl_cols)) p = g_string_append (p, "</tr>\n");
-			p = g_string_append (p, ghtml->delim);
-			if (0 < p->len)
-			{
-				(ghtml->write_stream) (ghtml, p->str, p->len, ghtml->user_data);
-			}
-		}
+            /* -------------------------- */
+            p = g_string_truncate(p, 0);
+            if (output_html && (0 < ghtml->ninvl_cols))
+                p = g_string_append(p, "<tr>");
+            for (i = 0; i < ghtml->ninvl_cols; i++)
+            {
 
-		p = g_string_append (p, "\n");
-	}
+                switch (ghtml->invl_cols[i])
+                {
+                case START_DATIME:
+                {
+                    if (output_html)
+                        p = g_string_append(p, "<td align=right>&nbsp;&nbsp;");
+                    if (show_links)
+                    {
+                        g_string_append_printf(
+                            p, "<a href=\"gtt:interval:0x%lx\">", (long) ivl
+                        );
+                    }
+                    if (prt_start_date)
+                    {
+                        xxxqof_print_date_time_buff(buff, 100, start);
+                        p = g_string_append(p, buff);
+                    }
+                    else
+                    {
+                        xxxqof_print_time_buff(buff, 100, start);
+                        p = g_string_append(p, buff);
+                    }
+                    if (show_links)
+                        p = g_string_append(p, "</a>");
+                    p = g_string_append(p, "&nbsp;&nbsp;");
+                    break;
+                }
+                case STOP_DATIME:
+                {
+                    if (output_html)
+                        p = g_string_append(p, "<td align=right>&nbsp;&nbsp;");
+                    if (show_links)
+                    {
+                        g_string_append_printf(
+                            p, "<a href=\"gtt:interval:0x%lx\">", (long) ivl
+                        );
+                    }
+                    if (prt_stop_date)
+                    {
+                        xxxqof_print_date_time_buff(buff, 100, stop);
+                        p = g_string_append(p, buff);
+                    }
+                    else
+                    {
+                        xxxqof_print_time_buff(buff, 100, stop);
+                        p = g_string_append(p, buff);
+                    }
+                    if (show_links)
+                        p = g_string_append(p, "</a>");
+                    if (output_html)
+                        p = g_string_append(p, "&nbsp;&nbsp;");
+                    break;
+                }
+                case ELAPSED:
+                {
+                    if (output_html)
+                        p = g_string_append(p, "<td>&nbsp;&nbsp;");
+                    xxxqof_print_hours_elapsed_buff(buff, 100, elapsed, TRUE);
+                    p = g_string_append(p, buff);
+                    if (output_html)
+                        p = g_string_append(p, "&nbsp;&nbsp;");
+                    break;
+                }
+                case FUZZ:
+                {
+                    if (output_html)
+                        p = g_string_append(p, "<td>&nbsp;&nbsp;");
+                    xxxqof_print_hours_elapsed_buff(
+                        buff, 100, gtt_interval_get_fuzz(ivl), TRUE
+                    );
+                    p = g_string_append(p, buff);
+                    if (output_html)
+                        p = g_string_append(p, "&nbsp;&nbsp;");
+                    break;
+                }
+                default:
+                    if (output_html)
+                        p = g_string_append(p, "<td>");
+                }
+                if (output_html)
+                    p = g_string_append(p, "</td>\n");
+            }
 
-	g_string_free (p, FALSE);
-	
-	if (output_html)
-	{
-		char * ps = "</table>\n";
-		(ghtml->write_stream) (ghtml, ps, strlen(ps), ghtml->user_data);
-	}
+            if (output_html && (0 < ghtml->ninvl_cols))
+                p = g_string_append(p, "</tr>\n");
+            p = g_string_append(p, ghtml->delim);
+            if (0 < p->len)
+            {
+                (ghtml->write_stream)(ghtml, p->str, p->len, ghtml->user_data);
+            }
+        }
+
+        p = g_string_append(p, "\n");
+    }
+
+    g_string_free(p, FALSE);
+
+    if (output_html)
+    {
+        char *ps = "</table>\n";
+        (ghtml->write_stream)(ghtml, ps, strlen(ps), ghtml->user_data);
+    }
 }
 
 /* ============================================================== */
 
-static SCM
-gtt_hello (void)
+static SCM gtt_hello(void)
 {
-	GttGhtml *ghtml = ghtml_guile_global_hack;
-	char *p;
-	if (NULL == ghtml->write_stream) return SCM_UNSPECIFIED;
+    GttGhtml *ghtml = ghtml_guile_global_hack;
+    char *p;
+    if (NULL == ghtml->write_stream)
+        return SCM_UNSPECIFIED;
 
-	p = "Hello World!";
+    p = "Hello World!";
 
-	(ghtml->write_stream) (ghtml, p, strlen(p), ghtml->user_data);
+    (ghtml->write_stream)(ghtml, p, strlen(p), ghtml->user_data);
 
-	/* maybe we should return something meaningful, like the string? */
-	return SCM_UNSPECIFIED;
+    /* maybe we should return something meaningful, like the string? */
+    return SCM_UNSPECIFIED;
 }
 
 /* ============================================================== */
@@ -615,182 +688,168 @@ gtt_hello (void)
  * for later use.
  */
 
-#define TASK_COL(TYPE) {                                        \
-        ghtml->task_cols[ghtml->ntask_cols] = TYPE;             \
-        ghtml->tp = &(ghtml->task_titles[ghtml->ntask_cols]);   \
-        *(ghtml->tp) = NULL;                                    \
-        if (NCOL-1 > ghtml->ntask_cols) ghtml->ntask_cols ++;   \
-}
+#define TASK_COL(TYPE)                                        \
+    {                                                         \
+        ghtml->task_cols[ghtml->ntask_cols] = TYPE;           \
+        ghtml->tp = &(ghtml->task_titles[ghtml->ntask_cols]); \
+        *(ghtml->tp) = NULL;                                  \
+        if (NCOL - 1 > ghtml->ntask_cols)                     \
+            ghtml->ntask_cols++;                              \
+    }
 
-#define INVL_COL(TYPE) {                                        \
-        ghtml->invl_cols[ghtml->ninvl_cols] = TYPE;             \
-        ghtml->tp = &(ghtml->invl_titles[ghtml->ninvl_cols]);   \
-        *(ghtml->tp) = NULL;                                    \
-        if (NCOL-1 > ghtml->ninvl_cols) ghtml->ninvl_cols ++;   \
-}
+#define INVL_COL(TYPE)                                        \
+    {                                                         \
+        ghtml->invl_cols[ghtml->ninvl_cols] = TYPE;           \
+        ghtml->tp = &(ghtml->invl_titles[ghtml->ninvl_cols]); \
+        *(ghtml->tp) = NULL;                                  \
+        if (NCOL - 1 > ghtml->ninvl_cols)                     \
+            ghtml->ninvl_cols++;                              \
+    }
 
-static void
-decode_column (GttGhtml *ghtml, const char * tok)
+static void decode_column(GttGhtml *ghtml, const char *tok)
 {
-	if ('$' != tok[0])
-	{
-		if (ghtml->tp)
-		{
-			if (*ghtml->tp) g_free (*ghtml->tp);
-			*ghtml->tp = g_strdup (tok);
-		}
-	}
-	else
-	if (0 == strncmp (tok, "$start_datime", 13))
-	{
-		INVL_COL (START_DATIME);
-	}
-	else
-	if (0 == strncmp (tok, "$stop_datime", 12))
-	{
-		INVL_COL (STOP_DATIME);
-	}
-	else
-	if (0 == strncmp (tok, "$fuzz", 5))
-	{
-		INVL_COL (FUZZ);
-	}
-	else
-	if (0 == strncmp (tok, "$elapsed", 8))
-	{
-		INVL_COL (ELAPSED);
-	}
-	else
-	if (0 == strncmp (tok, "$memo", 5))
-	{
-		TASK_COL(MEMO);
-	}
-	else
-	if (0 == strncmp (tok, "$notes", 6))
-	{
-		TASK_COL(NOTES);
-	}
-	else
-	if (0 == strncmp (tok, "$task_time", 10))
-	{
-		TASK_COL(TASK_TIME);
-	}
-	else
-	if (0 == strncmp (tok, "$billstatus", 11))
-	{
-		TASK_COL(BILLSTATUS);
-	}
-	else
-	if (0 == strncmp (tok, "$billable", 9))
-	{
-		TASK_COL(BILLABLE);
-	}
-	else
-	if (0 == strncmp (tok, "$billrate", 9))
-	{
-		TASK_COL(BILLRATE);
-	}
-	else
-	if (0 == strncmp (tok, "$value", 6))
-	{
-		TASK_COL(VALUE);
-	}
-	else
-	if (0 == strncmp (tok, "$bill_value", 11))
-	{
-		TASK_COL(BILLABLE_VALUE);
-	}
-	else if (ghtml->write_stream)
-	{
-		const char * str;
-		str = _("unknown token: >>>>");
-		(ghtml->write_stream) (ghtml, str, strlen(str), ghtml->user_data);
-		str = tok;
-		(ghtml->write_stream) (ghtml, str, strlen(str), ghtml->user_data);
-		str = "<<<<";
-		(ghtml->write_stream) (ghtml, str, strlen(str), ghtml->user_data);
-	}
+    if ('$' != tok[0])
+    {
+        if (ghtml->tp)
+        {
+            if (*ghtml->tp)
+                g_free(*ghtml->tp);
+            *ghtml->tp = g_strdup(tok);
+        }
+    }
+    else if (0 == strncmp(tok, "$start_datime", 13))
+    {
+        INVL_COL(START_DATIME);
+    }
+    else if (0 == strncmp(tok, "$stop_datime", 12))
+    {
+        INVL_COL(STOP_DATIME);
+    }
+    else if (0 == strncmp(tok, "$fuzz", 5))
+    {
+        INVL_COL(FUZZ);
+    }
+    else if (0 == strncmp(tok, "$elapsed", 8))
+    {
+        INVL_COL(ELAPSED);
+    }
+    else if (0 == strncmp(tok, "$memo", 5))
+    {
+        TASK_COL(MEMO);
+    }
+    else if (0 == strncmp(tok, "$notes", 6))
+    {
+        TASK_COL(NOTES);
+    }
+    else if (0 == strncmp(tok, "$task_time", 10))
+    {
+        TASK_COL(TASK_TIME);
+    }
+    else if (0 == strncmp(tok, "$billstatus", 11))
+    {
+        TASK_COL(BILLSTATUS);
+    }
+    else if (0 == strncmp(tok, "$billable", 9))
+    {
+        TASK_COL(BILLABLE);
+    }
+    else if (0 == strncmp(tok, "$billrate", 9))
+    {
+        TASK_COL(BILLRATE);
+    }
+    else if (0 == strncmp(tok, "$value", 6))
+    {
+        TASK_COL(VALUE);
+    }
+    else if (0 == strncmp(tok, "$bill_value", 11))
+    {
+        TASK_COL(BILLABLE_VALUE);
+    }
+    else if (ghtml->write_stream)
+    {
+        const char *str;
+        str = _("unknown token: >>>>");
+        (ghtml->write_stream)(ghtml, str, strlen(str), ghtml->user_data);
+        str = tok;
+        (ghtml->write_stream)(ghtml, str, strlen(str), ghtml->user_data);
+        str = "<<<<";
+        (ghtml->write_stream)(ghtml, str, strlen(str), ghtml->user_data);
+    }
 }
 
 /* ============================================================== */
 
-static SCM
-decode_scm_col_list (GttGhtml *ghtml, SCM col_list)
+static SCM decode_scm_col_list(GttGhtml *ghtml, SCM col_list)
 {
-	SCM col_name;
-	char * tok = NULL;
+    SCM col_name;
+    char *tok = NULL;
 
-	/* reset the parser */
-	ghtml->ninvl_cols = 0;
-	ghtml->ntask_cols = 0;
-		
-	while (!scm_is_null (col_list))
-	{
-		col_name = SCM_CAR (col_list);
+    /* reset the parser */
+    ghtml->ninvl_cols = 0;
+    ghtml->ntask_cols = 0;
 
-		/* either a 'symbol or a "quoted string" */
-		if (!scm_is_symbol(col_name) && !scm_is_string (col_name))
-		{
-			col_list = SCM_CDR (col_list);
-			continue;
-		}
-		tok = scm_to_locale_string (col_name);
-		decode_column (ghtml, tok);
+    while (!scm_is_null(col_list))
+    {
+        col_name = SCM_CAR(col_list);
 
-		free (tok);
-		col_list = SCM_CDR (col_list);
-	}
+        /* either a 'symbol or a "quoted string" */
+        if (!scm_is_symbol(col_name) && !scm_is_string(col_name))
+        {
+            col_list = SCM_CDR(col_list);
+            continue;
+        }
+        tok = scm_to_locale_string(col_name);
+        decode_column(ghtml, tok);
 
-	return SCM_UNSPECIFIED;
+        free(tok);
+        col_list = SCM_CDR(col_list);
+    }
+
+    return SCM_UNSPECIFIED;
 }
 
-static SCM
-show_journal (SCM junk)
+static SCM show_journal(SCM junk)
 {
-	GttGhtml *ghtml = ghtml_guile_global_hack;
-	do_show_journal (ghtml, ghtml->prj);
-	return SCM_UNSPECIFIED;
+    GttGhtml *ghtml = ghtml_guile_global_hack;
+    do_show_journal(ghtml, ghtml->prj);
+    return SCM_UNSPECIFIED;
 }
 
-static SCM
-show_table (SCM col_list)
+static SCM show_table(SCM col_list)
 {
-	GttGhtml *ghtml = ghtml_guile_global_hack;
-	SCM rc;
-	SCM_ASSERT ( scm_is_pair (col_list), col_list, SCM_ARG1, "gtt-show-table");
-	rc = decode_scm_col_list (ghtml, col_list);
-	do_show_table (ghtml, ghtml->prj, FALSE);
-	return rc;
+    GttGhtml *ghtml = ghtml_guile_global_hack;
+    SCM rc;
+    SCM_ASSERT(scm_is_pair(col_list), col_list, SCM_ARG1, "gtt-show-table");
+    rc = decode_scm_col_list(ghtml, col_list);
+    do_show_table(ghtml, ghtml->prj, FALSE);
+    return rc;
 }
 
-static SCM
-show_invoice (SCM col_list)
+static SCM show_invoice(SCM col_list)
 {
-	GttGhtml *ghtml = ghtml_guile_global_hack;
-	SCM rc;
-	SCM_ASSERT ( scm_is_pair (col_list), col_list, SCM_ARG1, "gtt-show-invoice");
-	rc = decode_scm_col_list (ghtml, col_list);
-	do_show_table (ghtml, ghtml->prj, TRUE);
-	return rc;
+    GttGhtml *ghtml = ghtml_guile_global_hack;
+    SCM rc;
+    SCM_ASSERT(scm_is_pair(col_list), col_list, SCM_ARG1, "gtt-show-invoice");
+    rc = decode_scm_col_list(ghtml, col_list);
+    do_show_table(ghtml, ghtml->prj, TRUE);
+    return rc;
 }
 
-static SCM
-show_export (SCM col_list)
+static SCM show_export(SCM col_list)
 {
-	GttGhtml *ghtml = ghtml_guile_global_hack;
-	
-	SCM rc;
-	SCM_ASSERT ( scm_is_pair (col_list), col_list, SCM_ARG1, "gtt-show-export");
-	rc = decode_scm_col_list (ghtml, col_list);
-	
-	ghtml->show_html = FALSE;
-	ghtml->show_links = FALSE;
-	ghtml->delim = "\t";
-	
-	do_show_table (ghtml, ghtml->prj, FALSE);
-	
-	
-	return rc;
+    GttGhtml *ghtml = ghtml_guile_global_hack;
+
+    SCM rc;
+    SCM_ASSERT(scm_is_pair(col_list), col_list, SCM_ARG1, "gtt-show-export");
+    rc = decode_scm_col_list(ghtml, col_list);
+
+    ghtml->show_html = FALSE;
+    ghtml->show_links = FALSE;
+    ghtml->delim = "\t";
+
+    do_show_table(ghtml, ghtml->prj, FALSE);
+
+    return rc;
 }
 
 /* ============================================================== */
@@ -800,43 +859,39 @@ show_export (SCM col_list)
 
 static int depr_is_inited = 0;
 
-static void
-depr_register_procs (void)
+static void depr_register_procs(void)
 {
-	scm_c_define_gsubr("gtt-hello",        0, 0, 0, gtt_hello);
-	scm_c_define_gsubr("gtt-show-journal", 1, 0, 0, show_journal);
-	scm_c_define_gsubr("gtt-show-table",   1, 0, 0, show_table);
-	scm_c_define_gsubr("gtt-show-invoice", 1, 0, 0, show_invoice);
-	scm_c_define_gsubr("gtt-show-export",  1, 0, 0, show_export);
-	
+    scm_c_define_gsubr("gtt-hello", 0, 0, 0, gtt_hello);
+    scm_c_define_gsubr("gtt-show-journal", 1, 0, 0, show_journal);
+    scm_c_define_gsubr("gtt-show-table", 1, 0, 0, show_table);
+    scm_c_define_gsubr("gtt-show-invoice", 1, 0, 0, show_invoice);
+    scm_c_define_gsubr("gtt-show-export", 1, 0, 0, show_export);
 }
-
 
 /* ============================================================== */
 
-void
-gtt_ghtml_deprecated_init (GttGhtml *p)
+void gtt_ghtml_deprecated_init(GttGhtml *p)
 {
-	int i;
+    int i;
 
-	if (!depr_is_inited)
-	{
-		depr_is_inited = 1;
-		depr_register_procs();
-	}
+    if (!depr_is_inited)
+    {
+        depr_is_inited = 1;
+        depr_register_procs();
+    }
 
-	p->show_html = TRUE;
-	p->delim = "";
+    p->show_html = TRUE;
+    p->delim = "";
 
-	p->ninvl_cols = 0;
-	p->ntask_cols = 0;
-	p->tp = NULL;
+    p->ninvl_cols = 0;
+    p->ntask_cols = 0;
+    p->tp = NULL;
 
-	for (i=0; i<NCOL; i++)
-	{
-		p->task_titles[i] = NULL;
-		p->invl_titles[i] = NULL;
-	}
+    for (i = 0; i < NCOL; i++)
+    {
+        p->task_titles[i] = NULL;
+        p->invl_titles[i] = NULL;
+    }
 }
 
 /* ===================== END OF FILE ==============================  */

--- a/src/ghtml-deprecated.h
+++ b/src/ghtml-deprecated.h
@@ -19,10 +19,9 @@
 #ifndef __GTT_GHTML_DEPRECATED_H__
 #define __GTT_GHTML_DEPRECATED_H__
 
-#include "proj.h"
 #include "ghtml.h"
+#include "proj.h"
 
-void gtt_ghtml_deprecated_init (GttGhtml *);
+void gtt_ghtml_deprecated_init(GttGhtml *);
 
 #endif /* __GTT_GHTML_DEPRECATED_H__ */
-

--- a/src/ghtml.c
+++ b/src/ghtml.c
@@ -20,13 +20,13 @@
 
 #define _GNU_SOURCE
 #include <glib.h>
+#include <libgnomevfs/gnome-vfs.h>
 #include <libguile.h>
 #include <libguile/backtrace.h>
 #include <limits.h>
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
-#include <libgnomevfs/gnome-vfs.h>
 
 #include <qof.h>
 
@@ -35,14 +35,13 @@
 
 #include "app.h"
 #include "cur-proj.h"
-#include "gtt.h"
-#include "ghtml.h"
 #include "ghtml-deprecated.h"
+#include "ghtml.h"
+#include "gtt.h"
 #include "prefs.h"
 #include "proj.h"
 #include "query.h"
 #include "util.h"
-
 
 /* Design problems:
  * The way this is currently defined, there is no type safety, and
@@ -66,35 +65,32 @@
 
 GttGhtml *ghtml_guile_global_hack = NULL;
 
-static SCM
-do_ret_did_query (GttGhtml *ghtml)
+static SCM do_ret_did_query(GttGhtml *ghtml)
 {
-	return scm_from_bool (ghtml->did_query);
+    return scm_from_bool(ghtml->did_query);
 }
 
-static SCM
-ret_did_query (void)
+static SCM ret_did_query(void)
 {
-	GttGhtml *ghtml = ghtml_guile_global_hack;
-	return do_ret_did_query (ghtml);
+    GttGhtml *ghtml = ghtml_guile_global_hack;
+    return do_ret_did_query(ghtml);
 }
 
 /* ============================================================== */
 /* This routine will reverse the order of a scheme list */
 
-static SCM
-reverse_list (SCM node_list)
+static SCM reverse_list(SCM node_list)
 {
-	SCM rc, node;
-	rc = SCM_EOL;
+    SCM rc, node;
+    rc = SCM_EOL;
 
-	while (!scm_is_null (node_list))
-	{
-		node = SCM_CAR (node_list);
-		rc = scm_cons (node, rc);
-		node_list = SCM_CDR (node_list);
-	}
-	return rc;
+    while (!scm_is_null(node_list))
+    {
+        node = SCM_CAR(node_list);
+        rc = scm_cons(node, rc);
+        node_list = SCM_CDR(node_list);
+    }
+    return rc;
 }
 
 /* ============================================================== */
@@ -103,192 +99,189 @@ reverse_list (SCM node_list)
 
 typedef enum
 {
-	GTT_NONE=0,
-	GTT_PRJ,
-	GTT_TASK,
-	GTT_IVL
+    GTT_NONE = 0,
+    GTT_PRJ,
+    GTT_TASK,
+    GTT_IVL
 } PtrType;
 
-static SCM
-do_apply_based_on_type (GttGhtml *ghtml, SCM node,
-             PtrType cur_type,
-             SCM (*str_func)(GttGhtml *, const char *),
-             SCM (*prj_func)(GttGhtml *, GttProject *),
-             SCM (*tsk_func)(GttGhtml *, GttTask *),
-             SCM (*ivl_func)(GttGhtml *, GttInterval *))
+static SCM do_apply_based_on_type(
+    GttGhtml *ghtml, SCM node, PtrType cur_type, SCM (*str_func)(GttGhtml *, const char *),
+    SCM (*prj_func)(GttGhtml *, GttProject *), SCM (*tsk_func)(GttGhtml *, GttTask *),
+    SCM (*ivl_func)(GttGhtml *, GttInterval *)
+)
 {
-	/* Either a 'symbol or a "quoted string" */
-	if (scm_is_symbol(node) || scm_is_string (node))
-	{
-		SCM rc = SCM_EOL;
-		char *str = scm_to_locale_string (node);
-		int len = strlen (str);
-		if ((0<len) && str_func) rc = str_func (ghtml, str);
-		return rc;
-	}
+    /* Either a 'symbol or a "quoted string" */
+    if (scm_is_symbol(node) || scm_is_string(node))
+    {
+        SCM rc = SCM_EOL;
+        char *str = scm_to_locale_string(node);
+        int len = strlen(str);
+        if ((0 < len) && str_func)
+            rc = str_func(ghtml, str);
+        return rc;
+    }
 
-	/* If its a number, its in fact a pointer to the C struct. */
-	if (scm_is_number(node))
-	{
-		SCM rc = SCM_EOL;
-		switch (cur_type)
-		{
-			case GTT_PRJ: {
-				GttProject *prj = (GttProject *) scm_to_ulong (node);
-				if (prj_func) rc = prj_func (ghtml, prj);
-				break;
-			}
-			case GTT_TASK: {
-				GttTask *tsk = (GttTask *) scm_to_ulong (node);
-				if (tsk_func) rc = tsk_func (ghtml, tsk);
-				break;
-			}
-			case GTT_IVL: {
-				GttInterval *ivl = (GttInterval *) scm_to_ulong (node);
-				if (ivl_func) rc = ivl_func (ghtml, ivl);
-				break;
-			}
-			case GTT_NONE:
-				rc = SCM_EOL;
-				break;
-		}
-		return rc;
-	}
+    /* If its a number, its in fact a pointer to the C struct. */
+    if (scm_is_number(node))
+    {
+        SCM rc = SCM_EOL;
+        switch (cur_type)
+        {
+        case GTT_PRJ:
+        {
+            GttProject *prj = (GttProject *) scm_to_ulong(node);
+            if (prj_func)
+                rc = prj_func(ghtml, prj);
+            break;
+        }
+        case GTT_TASK:
+        {
+            GttTask *tsk = (GttTask *) scm_to_ulong(node);
+            if (tsk_func)
+                rc = tsk_func(ghtml, tsk);
+            break;
+        }
+        case GTT_IVL:
+        {
+            GttInterval *ivl = (GttInterval *) scm_to_ulong(node);
+            if (ivl_func)
+                rc = ivl_func(ghtml, ivl);
+            break;
+        }
+        case GTT_NONE:
+            rc = SCM_EOL;
+            break;
+        }
+        return rc;
+    }
 
-	/* If its a list, then process the list */
-	if (scm_is_pair(node))
-	{
-		SCM rc = SCM_EOL;
-		SCM node_list = node;
+    /* If its a list, then process the list */
+    if (scm_is_pair(node))
+    {
+        SCM rc = SCM_EOL;
+        SCM node_list = node;
 
-		/* Check to see if there's a type-label of the appropriate
-		 * type.  If so, then strip off the label, and pass back
-		 * car to ourselves, and passing the corrected type.
-		 */
-		if (!scm_is_null (node))
-		{
-			SCM type;
-			type = SCM_CDR (node);
-			if (scm_is_symbol(type) || scm_is_string (type))
-			{
-				cur_type = GTT_NONE;
-				char *buff = scm_to_locale_string (type);
+        /* Check to see if there's a type-label of the appropriate
+         * type.  If so, then strip off the label, and pass back
+         * car to ourselves, and passing the corrected type.
+         */
+        if (!scm_is_null(node))
+        {
+            SCM type;
+            type = SCM_CDR(node);
+            if (scm_is_symbol(type) || scm_is_string(type))
+            {
+                cur_type = GTT_NONE;
+                char *buff = scm_to_locale_string(type);
 
-				if ((!strncmp (buff, "gtt-project-ptr",15)) ||
-				    (!strncmp (buff, "gtt-project-list",16)))
-				{
-					cur_type = GTT_PRJ;
-				}
-				else if (!strncmp (buff, "gtt-task-list", 13))
-				{
-					cur_type = GTT_TASK;
-				}
-				else if (!strncmp (buff, "gtt-interval-list", 17))
-				{
-					cur_type = GTT_IVL;
-				}
-				else
-				{
-					g_warning ("Unknown GTT list type\n");
-					return SCM_EOL;
-				}
-				node_list = SCM_CAR (node);
-				return do_apply_based_on_type (ghtml, node_list, cur_type,
-				               str_func, prj_func, tsk_func, ivl_func);
-			}
-		}
-		/* Otherwise, we have just a list. Walk that list,
-		 * apply recursively to it.
-		 */
-		while (!scm_is_null (node_list))
-		{
-			SCM evl;
-			node = SCM_CAR (node_list);
+                if ((!strncmp(buff, "gtt-project-ptr", 15))
+                    || (!strncmp(buff, "gtt-project-list", 16)))
+                {
+                    cur_type = GTT_PRJ;
+                }
+                else if (!strncmp(buff, "gtt-task-list", 13))
+                {
+                    cur_type = GTT_TASK;
+                }
+                else if (!strncmp(buff, "gtt-interval-list", 17))
+                {
+                    cur_type = GTT_IVL;
+                }
+                else
+                {
+                    g_warning("Unknown GTT list type\n");
+                    return SCM_EOL;
+                }
+                node_list = SCM_CAR(node);
+                return do_apply_based_on_type(
+                    ghtml, node_list, cur_type, str_func, prj_func, tsk_func, ivl_func
+                );
+            }
+        }
+        /* Otherwise, we have just a list. Walk that list,
+         * apply recursively to it.
+         */
+        while (!scm_is_null(node_list))
+        {
+            SCM evl;
+            node = SCM_CAR(node_list);
 
-			evl = do_apply_based_on_type (ghtml, node, cur_type,
-				               str_func, prj_func, tsk_func, ivl_func);
+            evl = do_apply_based_on_type(
+                ghtml, node, cur_type, str_func, prj_func, tsk_func, ivl_func
+            );
 
-			if (!scm_is_null (evl))
-			{
-				rc = scm_cons (evl, rc);
-			}
-			node_list = SCM_CDR (node_list);
-		}
+            if (!scm_is_null(evl))
+            {
+                rc = scm_cons(evl, rc);
+            }
+            node_list = SCM_CDR(node_list);
+        }
 
-		/* reverse the list. Ughh */
-		/* gh_reverse (rc);  this doesn't work, to it manually */
-		rc = reverse_list (rc);
+        /* reverse the list. Ughh */
+        /* gh_reverse (rc);  this doesn't work, to it manually */
+        rc = reverse_list(rc);
 
-		return rc;
-	}
+        return rc;
+    }
 
-	/* If its a null list, do nothing */
-	if (scm_is_null (node))
-	{
-		return node;
-	}
+    /* If its a null list, do nothing */
+    if (scm_is_null(node))
+    {
+        return node;
+    }
 
-	g_warning ("expecting a gtt data object,  got something else\n");
-	return SCM_EOL;
+    g_warning("expecting a gtt data object,  got something else\n");
+    return SCM_EOL;
 }
 
 /* ============================================================== */
 /* A routine to recursively apply a scheme form to a hierarchical
  * list of gtt projects.  It returns the result of the apply. */
 
-static SCM
-do_apply_on_string (GttGhtml *ghtml, SCM strs,
-             SCM (*func)(GttGhtml *, const char *))
+static SCM do_apply_on_string(GttGhtml *ghtml, SCM strs, SCM (*func)(GttGhtml *, const char *))
 {
-	return do_apply_based_on_type (ghtml, strs,
-	             GTT_NONE, func, NULL, NULL, NULL);
+    return do_apply_based_on_type(ghtml, strs, GTT_NONE, func, NULL, NULL, NULL);
 }
 
 static SCM
-do_apply_on_project (GttGhtml *ghtml, SCM project,
-             SCM (*func)(GttGhtml *, GttProject *))
+do_apply_on_project(GttGhtml *ghtml, SCM project, SCM (*func)(GttGhtml *, GttProject *))
 {
-	return do_apply_based_on_type (ghtml, project,
-	             GTT_PRJ, NULL, func, NULL, NULL);
+    return do_apply_based_on_type(ghtml, project, GTT_PRJ, NULL, func, NULL, NULL);
+}
+
+static SCM do_apply_on_task(GttGhtml *ghtml, SCM task, SCM (*func)(GttGhtml *, GttTask *))
+{
+    return do_apply_based_on_type(ghtml, task, GTT_TASK, NULL, NULL, func, NULL);
 }
 
 static SCM
-do_apply_on_task (GttGhtml *ghtml, SCM task,
-             SCM (*func)(GttGhtml *, GttTask *))
+do_apply_on_interval(GttGhtml *ghtml, SCM invl, SCM (*func)(GttGhtml *, GttInterval *))
 {
-	return do_apply_based_on_type (ghtml, task,
-	             GTT_TASK, NULL, NULL, func, NULL);
-}
-
-
-static SCM
-do_apply_on_interval (GttGhtml *ghtml, SCM invl,
-             SCM (*func)(GttGhtml *, GttInterval *))
-{
-	return do_apply_based_on_type (ghtml, invl,
-	             GTT_IVL, NULL, NULL, NULL, func);
+    return do_apply_based_on_type(ghtml, invl, GTT_IVL, NULL, NULL, NULL, func);
 }
 
 /* ============================================================== */
 
-static SCM
-kvp_cb (GttGhtml *ghtml, const char *key)
+static SCM kvp_cb(GttGhtml *ghtml, const char *key)
 {
-	KvpValue *val;
-	const char * str;
-	if (!ghtml->kvp) return SCM_EOL;
-	val = kvp_frame_get_slot (ghtml->kvp, key);
-	if (!val) return SCM_EOL;
-	str = kvp_value_get_string (val);
-	if (!str) return SCM_EOL;
-	return scm_from_locale_string (str);
+    KvpValue *val;
+    const char *str;
+    if (!ghtml->kvp)
+        return SCM_EOL;
+    val = kvp_frame_get_slot(ghtml->kvp, key);
+    if (!val)
+        return SCM_EOL;
+    str = kvp_value_get_string(val);
+    if (!str)
+        return SCM_EOL;
+    return scm_from_locale_string(str);
 }
 
-static SCM
-ret_kvp_str (SCM key)
+static SCM ret_kvp_str(SCM key)
 {
-	GttGhtml *ghtml = ghtml_guile_global_hack;
-	return do_apply_on_string (ghtml, key, kvp_cb);
+    GttGhtml *ghtml = ghtml_guile_global_hack;
+    return do_apply_on_string(ghtml, key, kvp_cb);
 }
 
 /* ============================================================== */
@@ -296,87 +289,85 @@ ret_kvp_str (SCM key)
  * (or tries to). It knows how to print numbers strings and lists.
  */
 
-static SCM
-do_show_scm (GttGhtml *ghtml, SCM node)
+static SCM do_show_scm(GttGhtml *ghtml, SCM node)
 {
-	size_t len;
-	char * str = NULL;
-	if (NULL == ghtml->write_stream) return SCM_EOL;
+    size_t len;
+    char *str = NULL;
+    if (NULL == ghtml->write_stream)
+        return SCM_EOL;
 
-	/* Need to test for numbers first, since later tests
-	 * may core-dump guile-1.3.4 if the node was in fact a number. */
-	if (scm_is_number(node))
-	{
-		char buf[132];
-		double x;
-		long  ix;
+    /* Need to test for numbers first, since later tests
+     * may core-dump guile-1.3.4 if the node was in fact a number. */
+    if (scm_is_number(node))
+    {
+        char buf[132];
+        double x;
+        long ix;
 
-		x = scm_to_double (node);
-		ix = (long) x;
+        x = scm_to_double(node);
+        ix = (long) x;
 
-		/* If the number is representable in 32 bits,
-		 * and if the fractional part is so small its
-		 * not representable as a double, then print it
-		 * as an integer. */
-		if ((INT_MAX > x) && (-INT_MAX < x) &&
-			 ((x-(double)ix) < 4.0*x*DBL_EPSILON) )
-		{
-			sprintf (buf, "%ld", ix);
-		}
-		else
-		{
-			sprintf (buf, "%26.18g", x);
-		}
-		(ghtml->write_stream) (ghtml, buf, strlen(buf), ghtml->user_data);
-	}
-	else
-	/* either a 'symbol or a "quoted string" */
-	if (scm_is_symbol(node) || scm_is_string (node))
-	{
-		str = scm_to_locale_string (node);
-		len = strlen (str);
-		if (0<len) (ghtml->write_stream) (ghtml, str, len, ghtml->user_data);
-	}
-	else
-	if (scm_is_pair(node))
-	{
-		SCM node_list = node;
-		do
-		{
-			node = SCM_CAR (node_list);
-			do_show_scm (ghtml, node);
-			node_list = SCM_CDR (node_list);
-		}
-		while (scm_is_pair(node_list));
-		do_show_scm (ghtml, node_list);
-	}
-	else
-	if (scm_is_bool(node))
-	{
-		const char *str;
-		if (scm_is_false (node)) str = _("False");
-		else str = _("True");
-		(ghtml->write_stream) (ghtml, str, strlen(str), ghtml->user_data);
-	}
-	else
-	if (scm_is_null (node))
-	{
-		/* No op; maybe this should be a warning? */
-	}
-	else
-	{
-		g_warning ("Don't know how to gtt-show this type\n");
-	}
+        /* If the number is representable in 32 bits,
+         * and if the fractional part is so small its
+         * not representable as a double, then print it
+         * as an integer. */
+        if ((INT_MAX > x) && (-INT_MAX < x) && ((x - (double) ix) < 4.0 * x * DBL_EPSILON))
+        {
+            sprintf(buf, "%ld", ix);
+        }
+        else
+        {
+            sprintf(buf, "%26.18g", x);
+        }
+        (ghtml->write_stream)(ghtml, buf, strlen(buf), ghtml->user_data);
+    }
+    else
+        /* either a 'symbol or a "quoted string" */
+        if (scm_is_symbol(node) || scm_is_string(node))
+        {
+            str = scm_to_locale_string(node);
+            len = strlen(str);
+            if (0 < len)
+                (ghtml->write_stream)(ghtml, str, len, ghtml->user_data);
+        }
+        else if (scm_is_pair(node))
+        {
+            SCM node_list = node;
+            do
+            {
+                node = SCM_CAR(node_list);
+                do_show_scm(ghtml, node);
+                node_list = SCM_CDR(node_list);
+            }
+            while (scm_is_pair(node_list));
+            do_show_scm(ghtml, node_list);
+        }
+        else if (scm_is_bool(node))
+        {
+            const char *str;
+            if (scm_is_false(node))
+                str = _("False");
+            else
+                str = _("True");
+            (ghtml->write_stream)(ghtml, str, strlen(str), ghtml->user_data);
+        }
+        else if (scm_is_null(node))
+        {
+            /* No op; maybe this should be a warning? */
+        }
+        else
+        {
+            g_warning("Don't know how to gtt-show this type\n");
+        }
 
-	/* We could return the printed string, but I'm not sure why.. */
-	return SCM_EOL;
+    /* We could return the printed string, but I'm not sure why.. */
+    return SCM_EOL;
 }
 
-static SCM
-show_scm (SCM node_list)
+static SCM show_scm(SCM node_list)
 {
-	GttGhtml *ghtml = ghtml_guile_global_hack;
-	return do_show_scm (ghtml, node_list);
+    GttGhtml *ghtml = ghtml_guile_global_hack;
+    return do_show_scm(ghtml, node_list);
 }
 
 /* ============================================================== */
@@ -391,128 +382,115 @@ show_scm (SCM node_list)
  * --linas
  */
 
-static SCM
-do_ret_project (GttGhtml *ghtml, GttProject *prj)
+static SCM do_ret_project(GttGhtml *ghtml, GttProject *prj)
 {
-	SCM node,rc;
-	rc = scm_from_ulong ((unsigned long) prj);
+    SCM node, rc;
+    rc = scm_from_ulong((unsigned long) prj);
 
-	/* Label the pointer with a type identifier */
-	node = scm_from_locale_string ("gtt-project-ptr");
-	rc = scm_cons (rc, node);
+    /* Label the pointer with a type identifier */
+    node = scm_from_locale_string("gtt-project-ptr");
+    rc = scm_cons(rc, node);
 
-	return rc;
+    return rc;
 }
 
 /* The 'selected project' is the project highlighted by the
  * focus row in the main window.
  */
 
-static SCM
-do_ret_selected_project (GttGhtml *ghtml)
+static SCM do_ret_selected_project(GttGhtml *ghtml)
 {
-	GttProject *prj = gtt_projects_tree_get_selected_project (projects_tree);
-	return do_ret_project (ghtml, prj);
+    GttProject *prj = gtt_projects_tree_get_selected_project(projects_tree);
+    return do_ret_project(ghtml, prj);
 }
 
-static SCM
-ret_selected_project (void)
+static SCM ret_selected_project(void)
 {
-	GttGhtml *ghtml = ghtml_guile_global_hack;
-	return do_ret_selected_project (ghtml);
+    GttGhtml *ghtml = ghtml_guile_global_hack;
+    return do_ret_selected_project(ghtml);
 }
 
-static SCM
-do_ret_linked_project (GttGhtml *ghtml)
+static SCM do_ret_linked_project(GttGhtml *ghtml)
 {
-	return do_ret_project (ghtml, ghtml->prj);
+    return do_ret_project(ghtml, ghtml->prj);
 }
 
-static SCM
-ret_linked_project (void)
+static SCM ret_linked_project(void)
 {
-	GttGhtml *ghtml = ghtml_guile_global_hack;
-	return do_ret_linked_project (ghtml);
+    GttGhtml *ghtml = ghtml_guile_global_hack;
+    return do_ret_linked_project(ghtml);
 }
 
 /* ============================================================== */
 /* Control printing of internal links */
 
-static SCM
-do_set_links_on (GttGhtml *ghtml)
+static SCM do_set_links_on(GttGhtml *ghtml)
 {
-	if (FALSE == ghtml->really_hide_links)
-	{
-		ghtml->show_links = TRUE;
-	}
-	return SCM_EOL;
+    if (FALSE == ghtml->really_hide_links)
+    {
+        ghtml->show_links = TRUE;
+    }
+    return SCM_EOL;
 }
 
-static SCM
-set_links_on (void)
+static SCM set_links_on(void)
 {
-	GttGhtml *ghtml = ghtml_guile_global_hack;
-	return do_set_links_on (ghtml);
+    GttGhtml *ghtml = ghtml_guile_global_hack;
+    return do_set_links_on(ghtml);
 }
 
-static SCM
-do_set_links_off (GttGhtml *ghtml)
+static SCM do_set_links_off(GttGhtml *ghtml)
 {
-	ghtml->show_links = FALSE;
-	return SCM_EOL;
+    ghtml->show_links = FALSE;
+    return SCM_EOL;
 }
 
-static SCM
-set_links_off (void)
+static SCM set_links_off(void)
 {
-	GttGhtml *ghtml = ghtml_guile_global_hack;
-	return do_set_links_off (ghtml);
+    GttGhtml *ghtml = ghtml_guile_global_hack;
+    return do_set_links_off(ghtml);
 }
 
 /* ============================================================== */
 
-static SCM
-do_include_file_scm (GttGhtml *ghtml, SCM node)
+static SCM do_include_file_scm(GttGhtml *ghtml, SCM node)
 {
-	/* either a 'symbol or a "quoted string" */
-	if (scm_is_symbol(node) || scm_is_string (node))
-	{
-		const char * filepath = scm_to_locale_string (node);
-		filepath = gtt_ghtml_resolve_path(filepath, ghtml->ref_path);
-		gtt_ghtml_display (ghtml, filepath, NULL);
-	}
-	else
-	if (scm_is_pair(node))
-	{
-		SCM node_list = node;
-		do
-		{
-			node = SCM_CAR (node_list);
-			do_include_file_scm (ghtml, node);
-			node_list = SCM_CDR (node_list);
-		}
-		while (scm_is_pair(node_list));
-		do_include_file_scm (ghtml, node_list);
-	}
-	else
-	if (scm_is_null (node))
-	{
-		/* No op; maybe this should be a warning? */
-	}
-	else
-	{
-		g_warning ("Don't know how to gtt-include this type\n");
-	}
+    /* either a 'symbol or a "quoted string" */
+    if (scm_is_symbol(node) || scm_is_string(node))
+    {
+        const char *filepath = scm_to_locale_string(node);
+        filepath = gtt_ghtml_resolve_path(filepath, ghtml->ref_path);
+        gtt_ghtml_display(ghtml, filepath, NULL);
+    }
+    else if (scm_is_pair(node))
+    {
+        SCM node_list = node;
+        do
+        {
+            node = SCM_CAR(node_list);
+            do_include_file_scm(ghtml, node);
+            node_list = SCM_CDR(node_list);
+        }
+        while (scm_is_pair(node_list));
+        do_include_file_scm(ghtml, node_list);
+    }
+    else if (scm_is_null(node))
+    {
+        /* No op; maybe this should be a warning? */
+    }
+    else
+    {
+        g_warning("Don't know how to gtt-include this type\n");
+    }
 
-	/* We could return the printed string, but I'm not sure why.. */
-	return SCM_EOL;
+    /* We could return the printed string, but I'm not sure why.. */
+    return SCM_EOL;
 }
 
-static SCM
-include_file_scm (SCM node_list)
+static SCM include_file_scm(SCM node_list)
 {
-	GttGhtml *ghtml = ghtml_guile_global_hack;
-	return do_include_file_scm (ghtml, node_list);
+    GttGhtml *ghtml = ghtml_guile_global_hack;
+    return do_include_file_scm(ghtml, node_list);
 }
 
 /* ============================================================== */
@@ -521,59 +499,62 @@ include_file_scm (SCM node_list)
  *  pointers, and (cdr rc) is the type-string that identifies the
  *  type of the pointers. */
 
-static SCM
-g_list_to_scm (GList * gplist, const char * type)
+static SCM g_list_to_scm(GList *gplist, const char *type)
 {
-	SCM rc, node;
-	GList *n;
+    SCM rc, node;
+    GList *n;
 
-	/* Get a pointer to null */
-	rc = SCM_EOL;
-	if (gplist)
-	{
-		/* Get tail of g_list */
-		for (n= gplist; n->next; n=n->next) {}
-		gplist = n;
+    /* Get a pointer to null */
+    rc = SCM_EOL;
+    if (gplist)
+    {
+        /* Get tail of g_list */
+        for (n = gplist; n->next; n = n->next)
+        {
+        }
+        gplist = n;
 
-		/* Walk backwards, creating a scheme list */
-		for (n= gplist; n; n=n->prev)
-		{
-			node = scm_from_ulong ((unsigned long) n->data);
-			rc = scm_cons (node, rc);
-		}
-	}
+        /* Walk backwards, creating a scheme list */
+        for (n = gplist; n; n = n->prev)
+        {
+            node = scm_from_ulong((unsigned long) n->data);
+            rc = scm_cons(node, rc);
+        }
+    }
 
-	/* Prepend type label */
-	node = scm_from_locale_string (type);
-	rc = scm_cons (rc, node);
+    /* Prepend type label */
+    node = scm_from_locale_string(type);
+    rc = scm_cons(rc, node);
 
-	return rc;
+    return rc;
 }
 
 /* ============================================================== */
 /* Return a list of all of the projects */
 
-static SCM
-do_ret_project_list (GttGhtml *ghtml, GList *proj_list)
+static SCM do_ret_project_list(GttGhtml *ghtml, GList *proj_list)
 {
-	SCM rc;
-	GList *n;
+    SCM rc;
+    GList *n;
 
-	/* Get a pointer to null */
-	rc = SCM_EOL;
-	if (!proj_list) return rc;
+    /* Get a pointer to null */
+    rc = SCM_EOL;
+    if (!proj_list)
+        return rc;
 
-	/* XXX should use g_list_to_scm() here */
-	/* XXX should use type identifier gtt-project-list */
-	/* Find the tail */
-	for (n= proj_list; n->next; n=n->next) {}
-	proj_list = n;
+    /* XXX should use g_list_to_scm() here */
+    /* XXX should use type identifier gtt-project-list */
+    /* Find the tail */
+    for (n = proj_list; n->next; n = n->next)
+    {
+    }
+    proj_list = n;
 
-	/* Walk backwards, creating a scheme list */
-	for (n= proj_list; n; n=n->prev)
-	{
-		GttProject *prj = n->data;
-		SCM node;
+    /* Walk backwards, creating a scheme list */
+    for (n = proj_list; n; n = n->prev)
+    {
+        GttProject *prj = n->data;
+        SCM node;
 #if 0
 		GList *subprjs;
 
@@ -585,228 +566,226 @@ do_ret_project_list (GttGhtml *ghtml, GList *proj_list)
 			rc = scm_cons (node, rc);
 		}
 #endif
-		node = scm_from_ulong ((unsigned long) prj);
-		rc = scm_cons (node, rc);
-	}
-	return rc;
+        node = scm_from_ulong((unsigned long) prj);
+        rc = scm_cons(node, rc);
+    }
+    return rc;
 }
 
-static SCM
-ret_projects (void)
+static SCM ret_projects(void)
 {
-	GttGhtml *ghtml = ghtml_guile_global_hack;
+    GttGhtml *ghtml = ghtml_guile_global_hack;
 
-	/* Get list of all top-level projects */
-	GList *proj_list = gtt_project_list_get_list(master_list);
-	return do_ret_project_list (ghtml, proj_list);
+    /* Get list of all top-level projects */
+    GList *proj_list = gtt_project_list_get_list(master_list);
+    return do_ret_project_list(ghtml, proj_list);
 }
 
-static SCM
-ret_query_projects (void)
+static SCM ret_query_projects(void)
 {
-	GttGhtml *ghtml = ghtml_guile_global_hack;
+    GttGhtml *ghtml = ghtml_guile_global_hack;
 
-	return do_ret_project_list (ghtml, ghtml->query_result);
+    return do_ret_project_list(ghtml, ghtml->query_result);
 }
 
 /* ============================================================== */
 /* Return a list of all subprojects of a project */
 
-static SCM
-do_ret_subprjs (GttGhtml *ghtml, GttProject *prj)
+static SCM do_ret_subprjs(GttGhtml *ghtml, GttProject *prj)
 {
-	GList *proj_list;
+    GList *proj_list;
 
-	/* Get list of subprojects. */
-	proj_list = gtt_project_get_children (prj);
-	if (!proj_list) return SCM_EOL;
-	return do_ret_project_list (ghtml, proj_list);
+    /* Get list of subprojects. */
+    proj_list = gtt_project_get_children(prj);
+    if (!proj_list)
+        return SCM_EOL;
+    return do_ret_project_list(ghtml, proj_list);
 }
 
-static SCM
-ret_project_subprjs(SCM proj_list)
+static SCM ret_project_subprjs(SCM proj_list)
 {
-	GttGhtml *ghtml = ghtml_guile_global_hack;
-	return do_apply_on_project (ghtml, proj_list, do_ret_subprjs);
+    GttGhtml *ghtml = ghtml_guile_global_hack;
+    return do_apply_on_project(ghtml, proj_list, do_ret_subprjs);
 }
 
 /* ============================================================== */
 /* Return the parent of a project */
-static SCM
-get_proj_parent_scm (GttGhtml *ghtml, GttProject *prj)
+static SCM get_proj_parent_scm(GttGhtml *ghtml, GttProject *prj)
 {
-	GttProject *parent = gtt_project_get_parent (prj);
-	return do_ret_project (ghtml, parent);
+    GttProject *parent = gtt_project_get_parent(prj);
+    return do_ret_project(ghtml, parent);
 }
 
-static SCM
-ret_project_parent (SCM proj_list)
+static SCM ret_project_parent(SCM proj_list)
 {
-	GttGhtml *ghtml = ghtml_guile_global_hack;
-	return do_apply_on_project (ghtml, proj_list, get_proj_parent_scm);
+    GttGhtml *ghtml = ghtml_guile_global_hack;
+    return do_apply_on_project(ghtml, proj_list, get_proj_parent_scm);
 }
 
 /* ============================================================== */
 /* Return a list of all of the tasks of a project */
 
-static SCM
-do_ret_tasks (GttGhtml *ghtml, GttProject *prj)
+static SCM do_ret_tasks(GttGhtml *ghtml, GttProject *prj)
 {
-	SCM rc;
-	GList *n, *task_list;
+    SCM rc;
+    GList *n, *task_list;
 
-	/* Get a pointer to null */
-	rc = SCM_EOL;
-	if (!prj) return rc;
+    /* Get a pointer to null */
+    rc = SCM_EOL;
+    if (!prj)
+        return rc;
 
-	/* Get list of tasks, then get tail */
-	task_list = gtt_project_get_tasks (prj);
-	if (!task_list) return rc;
+    /* Get list of tasks, then get tail */
+    task_list = gtt_project_get_tasks(prj);
+    if (!task_list)
+        return rc;
 
-	/* XXX should use g_list_to_scm() here */
-	for (n= task_list; n->next; n=n->next) {}
-	task_list = n;
+    /* XXX should use g_list_to_scm() here */
+    for (n = task_list; n->next; n = n->next)
+    {
+    }
+    task_list = n;
 
-	/* Walk backwards, creating a scheme list */
-	for (n= task_list; n; n=n->prev)
-	{
-		GttTask *tsk = n->data;
-		SCM node;
+    /* Walk backwards, creating a scheme list */
+    for (n = task_list; n; n = n->prev)
+    {
+        GttTask *tsk = n->data;
+        SCM node;
 
-		node = scm_from_ulong ((unsigned long) tsk);
-		rc = scm_cons (node, rc);
-	}
-	return rc;
+        node = scm_from_ulong((unsigned long) tsk);
+        rc = scm_cons(node, rc);
+    }
+    return rc;
 }
 
-static SCM
-ret_tasks (SCM proj_list)
+static SCM ret_tasks(SCM proj_list)
 {
-	GttGhtml *ghtml = ghtml_guile_global_hack;
-	return do_apply_on_project (ghtml, proj_list, do_ret_tasks);
+    GttGhtml *ghtml = ghtml_guile_global_hack;
+    return do_apply_on_project(ghtml, proj_list, do_ret_tasks);
 }
 
 /* ============================================================== */
 /* Return a list of all of the intervals of a task */
 
-static SCM
-do_ret_intervals (GttGhtml *ghtml, GttTask *tsk)
+static SCM do_ret_intervals(GttGhtml *ghtml, GttTask *tsk)
 {
-	SCM rc;
-	GList *n, *ivl_list;
+    SCM rc;
+    GList *n, *ivl_list;
 
-	/* Oddball hack to make interval datestamp printing work nicely */
-	ghtml->last_ivl_time = 0;
+    /* Oddball hack to make interval datestamp printing work nicely */
+    ghtml->last_ivl_time = 0;
 
-	/* Get a pointer to null */
-	rc = SCM_EOL;
-	if (!tsk) return rc;
+    /* Get a pointer to null */
+    rc = SCM_EOL;
+    if (!tsk)
+        return rc;
 
-	/* XXX should use g_list_to_scm() here */
-	/* Get list of intervals, then get tail */
-	ivl_list = gtt_task_get_intervals (tsk);
-	if (!ivl_list) return rc;
+    /* XXX should use g_list_to_scm() here */
+    /* Get list of intervals, then get tail */
+    ivl_list = gtt_task_get_intervals(tsk);
+    if (!ivl_list)
+        return rc;
 
-	for (n= ivl_list; n->next; n=n->next) {}
-	ivl_list = n;
+    for (n = ivl_list; n->next; n = n->next)
+    {
+    }
+    ivl_list = n;
 
-	/* Walk backwards, creating a scheme list */
-	for (n= ivl_list; n; n=n->prev)
-	{
-		GttInterval *ivl = n->data;
-		SCM node;
+    /* Walk backwards, creating a scheme list */
+    for (n = ivl_list; n; n = n->prev)
+    {
+        GttInterval *ivl = n->data;
+        SCM node;
 
-		node = scm_from_ulong ((unsigned long) ivl);
-		rc = scm_cons (node, rc);
-	}
-	return rc;
+        node = scm_from_ulong((unsigned long) ivl);
+        rc = scm_cons(node, rc);
+    }
+    return rc;
 }
 
-static SCM
-ret_intervals (SCM task_list)
+static SCM ret_intervals(SCM task_list)
 {
-	GttGhtml *ghtml = ghtml_guile_global_hack;
-	return do_apply_on_task (ghtml, task_list, do_ret_intervals);
+    GttGhtml *ghtml = ghtml_guile_global_hack;
+    return do_apply_on_task(ghtml, task_list, do_ret_intervals);
 }
-
 
 /* ============================================================== */
 /* Return a list of date handles for accessing daily totals */
 
-static SCM
-do_ret_daily_totals (GttGhtml *ghtml, GttProject *prj)
+static SCM do_ret_daily_totals(GttGhtml *ghtml, GttProject *prj)
 {
-	SCM rc, rpt;
-	int i;
-	GArray *arr;
-	time_t earliest;
-	struct tm tday;
+    SCM rc, rpt;
+    int i;
+    GArray *arr;
+    time_t earliest;
+    struct tm tday;
 
-	/* Get a pointer to null */
-	rc = SCM_EOL;
-	if (!prj) return rc;
+    /* Get a pointer to null */
+    rc = SCM_EOL;
+    if (!prj)
+        return rc;
 
-	/* Get the project data */
-	arr = gtt_project_get_daily_buckets (prj, TRUE);
-	if (!arr) return rc;
-	earliest = gtt_project_get_earliest_start (prj, TRUE);
+    /* Get the project data */
+    arr = gtt_project_get_daily_buckets(prj, TRUE);
+    if (!arr)
+        return rc;
+    earliest = gtt_project_get_earliest_start(prj, TRUE);
 
-	/* Format the start date */
-	localtime_r (&earliest, &tday);
-	tday.tm_mday --;
+    /* Format the start date */
+    localtime_r(&earliest, &tday);
+    tday.tm_mday--;
 
-	for (i=0; i< arr->len; i++)
-	{
-		GttBucket *bu;
-		char buff[100];
-		SCM node;
-		time_t rptdate, secs;
+    for (i = 0; i < arr->len; i++)
+    {
+        GttBucket *bu;
+        char buff[100];
+        SCM node;
+        time_t rptdate, secs;
 
-		tday.tm_mday ++;
-		bu = & g_array_index (arr, GttBucket, i);
-		secs = bu->total;
+        tday.tm_mday++;
+        bu = &g_array_index(arr, GttBucket, i);
+        secs = bu->total;
 
-		/* Skip days for which no time has been spent */
-		if (0 == secs) continue;
+        /* Skip days for which no time has been spent */
+        if (0 == secs)
+            continue;
 
-		rpt = SCM_EOL;
-		/* Append the list of tasks and intervals for this day */
-		node = g_list_to_scm (bu->intervals, "gtt-interval-list");
-		rpt = scm_cons (node, rpt);
-		node = g_list_to_scm (bu->tasks, "gtt-task-list");
-		rpt = scm_cons (node, rpt);
+        rpt = SCM_EOL;
+        /* Append the list of tasks and intervals for this day */
+        node = g_list_to_scm(bu->intervals, "gtt-interval-list");
+        rpt = scm_cons(node, rpt);
+        node = g_list_to_scm(bu->tasks, "gtt-task-list");
+        rpt = scm_cons(node, rpt);
 
-		/* XXX should use time_t, and srfi-19 to print, and have a type label */
-		/* Print time spent on project this day */
-		xxxqof_print_hours_elapsed_buff (buff, 100, secs, TRUE);
-		node = scm_from_locale_string (buff);
-		rpt = scm_cons (node, rpt);
+        /* XXX should use time_t, and srfi-19 to print, and have a type label */
+        /* Print time spent on project this day */
+        xxxqof_print_hours_elapsed_buff(buff, 100, secs, TRUE);
+        node = scm_from_locale_string(buff);
+        rpt = scm_cons(node, rpt);
 
-		/* XXX report date should be time_t in the middle of the interval */
-		/* Print date */
-		rptdate = mktime (&tday);
-		xxxqof_print_date_buff (buff, 100, rptdate);
-		node = scm_from_locale_string (buff);
-		rpt = scm_cons (node, rpt);
+        /* XXX report date should be time_t in the middle of the interval */
+        /* Print date */
+        rptdate = mktime(&tday);
+        xxxqof_print_date_buff(buff, 100, rptdate);
+        node = scm_from_locale_string(buff);
+        rpt = scm_cons(node, rpt);
 
-		/* Put a data type in the cdr slot */
-		node = scm_from_locale_string ("gtt-daily");
-		rpt = scm_cons (rpt, node);
+        /* Put a data type in the cdr slot */
+        node = scm_from_locale_string("gtt-daily");
+        rpt = scm_cons(rpt, node);
 
-		rc = scm_cons (rpt, rc);
-	}
-	g_array_free (arr, TRUE);
+        rc = scm_cons(rpt, rc);
+    }
+    g_array_free(arr, TRUE);
 
-	return rc;
+    return rc;
 }
 
-static SCM
-ret_daily_totals (SCM proj_list)
+static SCM ret_daily_totals(SCM proj_list)
 {
-	GttGhtml *ghtml = ghtml_guile_global_hack;
-	return do_apply_on_project (ghtml, proj_list, do_ret_daily_totals);
+    GttGhtml *ghtml = ghtml_guile_global_hack;
+    return do_apply_on_project(ghtml, proj_list, do_ret_daily_totals);
 }
-
 
 /* ============================================================== */
 /* Define a set of subroutines that accept a scheme list of projects,
@@ -818,57 +797,48 @@ ret_daily_totals (SCM proj_list)
  * a scheme list of the project titles.
  */
 
-#define RET_PROJECT_SIMPLE(RET_FUNC,DO_SIMPLE)                      \
-static SCM                                                          \
-RET_FUNC (SCM proj_list)                                            \
-{                                                                   \
-	GttGhtml *ghtml = ghtml_guile_global_hack;                       \
-	return do_apply_on_project (ghtml, proj_list, DO_SIMPLE);        \
-}
+#define RET_PROJECT_SIMPLE(RET_FUNC, DO_SIMPLE)                  \
+    static SCM RET_FUNC(SCM proj_list)                           \
+    {                                                            \
+        GttGhtml *ghtml = ghtml_guile_global_hack;               \
+        return do_apply_on_project(ghtml, proj_list, DO_SIMPLE); \
+    }
 
+#define RET_PROJECT_STR(RET_FUNC, GTT_GETTER)                     \
+    static SCM GTT_GETTER##_scm(GttGhtml *ghtml, GttProject *prj) \
+    {                                                             \
+        const char *str = GTT_GETTER(prj);                        \
+        if (NULL == str)                                          \
+            return SCM_EOL;                                       \
+        return scm_from_locale_string(str);                       \
+    }                                                             \
+    RET_PROJECT_SIMPLE(RET_FUNC, GTT_GETTER##_scm)
 
-#define RET_PROJECT_STR(RET_FUNC,GTT_GETTER)                        \
-static SCM                                                          \
-GTT_GETTER##_scm (GttGhtml *ghtml, GttProject *prj)                 \
-{                                                                   \
-	const char * str = GTT_GETTER (prj);                             \
-	if (NULL == str) return SCM_EOL;                                 \
-	return scm_from_locale_string (str);                             \
-}                                                                   \
-RET_PROJECT_SIMPLE(RET_FUNC,GTT_GETTER##_scm)
+#define RET_PROJECT_LONG(RET_FUNC, GTT_GETTER)                    \
+    static SCM GTT_GETTER##_scm(GttGhtml *ghtml, GttProject *prj) \
+    {                                                             \
+        long i = GTT_GETTER(prj);                                 \
+        return scm_from_long(i);                                  \
+    }                                                             \
+    RET_PROJECT_SIMPLE(RET_FUNC, GTT_GETTER##_scm)
 
+#define RET_PROJECT_ULONG(RET_FUNC, GTT_GETTER)                   \
+    static SCM GTT_GETTER##_scm(GttGhtml *ghtml, GttProject *prj) \
+    {                                                             \
+        unsigned long i = GTT_GETTER(prj);                        \
+        return scm_from_ulong(i);                                 \
+    }                                                             \
+    RET_PROJECT_SIMPLE(RET_FUNC, GTT_GETTER##_scm)
 
-#define RET_PROJECT_LONG(RET_FUNC,GTT_GETTER)                       \
-static SCM                                                          \
-GTT_GETTER##_scm (GttGhtml *ghtml, GttProject *prj)                 \
-{                                                                   \
-	long i = GTT_GETTER (prj);                                       \
-	return scm_from_long (i);                                        \
-}                                                                   \
-RET_PROJECT_SIMPLE(RET_FUNC,GTT_GETTER##_scm)
+RET_PROJECT_STR(ret_project_title, gtt_project_get_title)
+RET_PROJECT_STR(ret_project_desc, gtt_project_get_desc)
+RET_PROJECT_STR(ret_project_notes, gtt_project_get_notes)
+RET_PROJECT_ULONG(ret_project_est_start, gtt_project_get_estimated_start)
+RET_PROJECT_ULONG(ret_project_est_end, gtt_project_get_estimated_end)
+RET_PROJECT_ULONG(ret_project_due_date, gtt_project_get_due_date)
 
-
-#define RET_PROJECT_ULONG(RET_FUNC,GTT_GETTER)                      \
-static SCM                                                          \
-GTT_GETTER##_scm (GttGhtml *ghtml, GttProject *prj)                 \
-{                                                                   \
-	unsigned long i = GTT_GETTER (prj);                              \
-	return scm_from_ulong (i);                                       \
-}                                                                   \
-RET_PROJECT_SIMPLE(RET_FUNC,GTT_GETTER##_scm)
-
-
-
-RET_PROJECT_STR   (ret_project_title, gtt_project_get_title)
-RET_PROJECT_STR   (ret_project_desc,  gtt_project_get_desc)
-RET_PROJECT_STR   (ret_project_notes, gtt_project_get_notes)
-RET_PROJECT_ULONG (ret_project_est_start, gtt_project_get_estimated_start)
-RET_PROJECT_ULONG (ret_project_est_end,   gtt_project_get_estimated_end)
-RET_PROJECT_ULONG (ret_project_due_date,  gtt_project_get_due_date)
-
-RET_PROJECT_LONG  (ret_project_sizing,  gtt_project_get_sizing)
-RET_PROJECT_LONG  (ret_project_percent, gtt_project_get_percent_complete)
-
+RET_PROJECT_LONG(ret_project_sizing, gtt_project_get_sizing)
+RET_PROJECT_LONG(ret_project_percent, gtt_project_get_percent_complete)
 
 /* ============================================================== */
 /* Handle ret_project_title_link in the almost-standard way,
@@ -876,76 +846,86 @@ RET_PROJECT_LONG  (ret_project_percent, gtt_project_get_percent_complete)
  * RET_PROJECT_STR (ret_project_title, gtt_project_get_title)
  * except that we need to handle url links as well.
  */
-static SCM
-get_project_title_link_scm (GttGhtml *ghtml, GttProject *prj)
+static SCM get_project_title_link_scm(GttGhtml *ghtml, GttProject *prj)
 {
-	if (ghtml->show_links)
-	{
-		GString *str;
-		str = g_string_new (NULL);
-		g_string_append_printf (str, "<a href=\"gtt:proj:0x%lx\">", (long) prj);
-		g_string_append (str, gtt_project_get_title (prj));
-		g_string_append (str, "</a>");
-		return scm_from_locale_string (str->str);
-	}
-	else
-	{
-		const char * str = gtt_project_get_title (prj);
-		return scm_from_locale_string (str);
-	}
+    if (ghtml->show_links)
+    {
+        GString *str;
+        str = g_string_new(NULL);
+        g_string_append_printf(str, "<a href=\"gtt:proj:0x%lx\">", (long) prj);
+        g_string_append(str, gtt_project_get_title(prj));
+        g_string_append(str, "</a>");
+        return scm_from_locale_string(str->str);
+    }
+    else
+    {
+        const char *str = gtt_project_get_title(prj);
+        return scm_from_locale_string(str);
+    }
 }
 
-RET_PROJECT_SIMPLE (ret_project_title_link, get_project_title_link_scm)
+RET_PROJECT_SIMPLE(ret_project_title_link, get_project_title_link_scm)
 
 /* ============================================================== */
 
-static const char *
-get_urgency (GttProject *prj)
+static const char *get_urgency(GttProject *prj)
 {
-	GttRank rank = gtt_project_get_urgency (prj);
-	switch (rank)
-	{
-		case GTT_LOW:       return _("Low");
-		case GTT_MEDIUM:    return _("Normal");
-		case GTT_HIGH:      return _("Urgent");
-		case GTT_UNDEFINED: return _("Undefined");
-	}
-	return _("Undefined");
+    GttRank rank = gtt_project_get_urgency(prj);
+    switch (rank)
+    {
+    case GTT_LOW:
+        return _("Low");
+    case GTT_MEDIUM:
+        return _("Normal");
+    case GTT_HIGH:
+        return _("Urgent");
+    case GTT_UNDEFINED:
+        return _("Undefined");
+    }
+    return _("Undefined");
 }
 
-static const char *
-get_importance (GttProject *prj)
+static const char *get_importance(GttProject *prj)
 {
-	GttRank rank = gtt_project_get_importance (prj);
-	switch (rank)
-	{
-		case GTT_LOW:       return _("Low");
-		case GTT_MEDIUM:    return _("Medium");
-		case GTT_HIGH:      return _("Important");
-		case GTT_UNDEFINED: return _("Undefined");
-	}
-	return _("Undefined");
+    GttRank rank = gtt_project_get_importance(prj);
+    switch (rank)
+    {
+    case GTT_LOW:
+        return _("Low");
+    case GTT_MEDIUM:
+        return _("Medium");
+    case GTT_HIGH:
+        return _("Important");
+    case GTT_UNDEFINED:
+        return _("Undefined");
+    }
+    return _("Undefined");
 }
 
-static const char *
-get_status (GttProject *prj)
+static const char *get_status(GttProject *prj)
 {
-	GttProjectStatus status = gtt_project_get_status (prj);
-	switch (status)
-	{
-		case GTT_NO_STATUS:    return _("No Status");
-		case GTT_NOT_STARTED:  return _("Not Started");
-		case GTT_IN_PROGRESS:  return _("In Progress");
-		case GTT_ON_HOLD:      return _("On Hold");
-		case GTT_CANCELLED:    return _("Cancelled");
-		case GTT_COMPLETED:    return _("Completed");
-	}
-	return _("Undefined");
+    GttProjectStatus status = gtt_project_get_status(prj);
+    switch (status)
+    {
+    case GTT_NO_STATUS:
+        return _("No Status");
+    case GTT_NOT_STARTED:
+        return _("Not Started");
+    case GTT_IN_PROGRESS:
+        return _("In Progress");
+    case GTT_ON_HOLD:
+        return _("On Hold");
+    case GTT_CANCELLED:
+        return _("Cancelled");
+    case GTT_COMPLETED:
+        return _("Completed");
+    }
+    return _("Undefined");
 }
 
-RET_PROJECT_STR (ret_project_urgency,    get_urgency)
-RET_PROJECT_STR (ret_project_importance, get_importance)
-RET_PROJECT_STR (ret_project_status,     get_status)
+RET_PROJECT_STR(ret_project_urgency, get_urgency)
+RET_PROJECT_STR(ret_project_importance, get_importance)
+RET_PROJECT_STR(ret_project_status, get_status)
 
 /* ============================================================== */
 /* Define a set of subroutines that accept a scheme list of tasks,
@@ -957,30 +937,27 @@ RET_PROJECT_STR (ret_project_status,     get_status)
  * a scheme list of the task memos.
  */
 
-#define RET_TASK_SIMPLE(RET_FUNC,GTT_GETTER)                        \
-static SCM                                                          \
-RET_FUNC (SCM task_list)                                            \
-{                                                                   \
-	GttGhtml *ghtml = ghtml_guile_global_hack;                       \
-	return do_apply_on_task (ghtml, task_list, GTT_GETTER##_scm);    \
-}
+#define RET_TASK_SIMPLE(RET_FUNC, GTT_GETTER)                        \
+    static SCM RET_FUNC(SCM task_list)                               \
+    {                                                                \
+        GttGhtml *ghtml = ghtml_guile_global_hack;                   \
+        return do_apply_on_task(ghtml, task_list, GTT_GETTER##_scm); \
+    }
 
-#define RET_TASK_STR(RET_FUNC,GTT_GETTER)                           \
-static SCM                                                          \
-GTT_GETTER##_scm (GttGhtml *ghtml, GttTask *tsk)                    \
-{                                                                   \
-	const char * str = GTT_GETTER (tsk);                             \
-	return scm_from_locale_string (str);                             \
-}                                                                   \
-                                                                    \
-static SCM                                                          \
-RET_FUNC (SCM task_list)                                            \
-{                                                                   \
-	GttGhtml *ghtml = ghtml_guile_global_hack;                       \
-	return do_apply_on_task (ghtml, task_list, GTT_GETTER##_scm);    \
-}
+#define RET_TASK_STR(RET_FUNC, GTT_GETTER)                           \
+    static SCM GTT_GETTER##_scm(GttGhtml *ghtml, GttTask *tsk)       \
+    {                                                                \
+        const char *str = GTT_GETTER(tsk);                           \
+        return scm_from_locale_string(str);                          \
+    }                                                                \
+                                                                     \
+    static SCM RET_FUNC(SCM task_list)                               \
+    {                                                                \
+        GttGhtml *ghtml = ghtml_guile_global_hack;                   \
+        return do_apply_on_task(ghtml, task_list, GTT_GETTER##_scm); \
+    }
 
-RET_TASK_STR (ret_task_notes,   gtt_task_get_notes)
+RET_TASK_STR(ret_task_notes, gtt_task_get_notes)
 
 /* ============================================================== */
 /* Handle ret_task_memo in the almost-standard way,
@@ -988,521 +965,539 @@ RET_TASK_STR (ret_task_notes,   gtt_task_get_notes)
  * RET_TASK_STR (ret_task_memo, gtt_task_get_memo)
  * except that we need to handle url links as well.
  */
-static SCM
-get_task_memo_scm (GttGhtml *ghtml, GttTask *tsk)
+static SCM get_task_memo_scm(GttGhtml *ghtml, GttTask *tsk)
 {
-	if (ghtml && ghtml->show_links)
-	{
-		GString *str;
-		str = g_string_new (NULL);
-		g_string_append_printf (str, "<a href=\"gtt:task:0x%lx\">", (long)tsk);
-		g_string_append (str, gtt_task_get_memo (tsk));
-		g_string_append (str, "</a>");
-		return scm_from_locale_string (str->str);
-	}
-	else
-	{
-		const char * str = gtt_task_get_memo (tsk);
-		return scm_from_locale_string (str);
-	}
+    if (ghtml && ghtml->show_links)
+    {
+        GString *str;
+        str = g_string_new(NULL);
+        g_string_append_printf(str, "<a href=\"gtt:task:0x%lx\">", (long) tsk);
+        g_string_append(str, gtt_task_get_memo(tsk));
+        g_string_append(str, "</a>");
+        return scm_from_locale_string(str->str);
+    }
+    else
+    {
+        const char *str = gtt_task_get_memo(tsk);
+        return scm_from_locale_string(str);
+    }
 }
 
-static SCM
-ret_task_memo (SCM task_list)
+static SCM ret_task_memo(SCM task_list)
 {
-	GttGhtml *ghtml = ghtml_guile_global_hack;
-	return do_apply_on_task (ghtml, task_list, get_task_memo_scm);
+    GttGhtml *ghtml = ghtml_guile_global_hack;
+    return do_apply_on_task(ghtml, task_list, get_task_memo_scm);
 }
 
 /* ============================================================== */
 /* Handle ret_task_parent in the almost-standard way,
  * except that we return a pointer object.
  */
-static SCM
-get_task_parent_scm (GttGhtml *ghtml, GttTask *tsk)
+static SCM get_task_parent_scm(GttGhtml *ghtml, GttTask *tsk)
 {
-	GttProject *prj = gtt_task_get_parent (tsk);
-	return do_ret_project (ghtml, prj);
+    GttProject *prj = gtt_task_get_parent(tsk);
+    return do_ret_project(ghtml, prj);
 }
 
-static SCM
-ret_task_parent (SCM task_list)
+static SCM ret_task_parent(SCM task_list)
 {
-	GttGhtml *ghtml = ghtml_guile_global_hack;
-	return do_apply_on_task (ghtml, task_list, get_task_parent_scm);
+    GttGhtml *ghtml = ghtml_guile_global_hack;
+    return do_apply_on_task(ghtml, task_list, get_task_parent_scm);
 }
 
 /* ============================================================== */
 
-static const char *
-task_get_billstatus (GttTask *tsk)
+static const char *task_get_billstatus(GttTask *tsk)
 {
-	switch (gtt_task_get_billstatus (tsk))
-	{
-		case GTT_HOLD: return _("Hold");
-		case GTT_BILL: return _("Bill");
-		case GTT_PAID: return _("Paid");
-		default: return "";
-	}
-	return "";
+    switch (gtt_task_get_billstatus(tsk))
+    {
+    case GTT_HOLD:
+        return _("Hold");
+    case GTT_BILL:
+        return _("Bill");
+    case GTT_PAID:
+        return _("Paid");
+    default:
+        return "";
+    }
+    return "";
 };
 
-static const char *
-task_get_billable (GttTask *tsk)
+static const char *task_get_billable(GttTask *tsk)
 {
-	switch (gtt_task_get_billable (tsk))
-	{
-		case GTT_BILLABLE: return _("Billable");
-		case GTT_NOT_BILLABLE: return _("Not Billable");
-		case GTT_NO_CHARGE: return _("No Charge");
-		default: return "";
-	}
-	return "";
+    switch (gtt_task_get_billable(tsk))
+    {
+    case GTT_BILLABLE:
+        return _("Billable");
+    case GTT_NOT_BILLABLE:
+        return _("Not Billable");
+    case GTT_NO_CHARGE:
+        return _("No Charge");
+    default:
+        return "";
+    }
+    return "";
 };
 
-static const char *
-task_get_billrate (GttTask *tsk)
+static const char *task_get_billrate(GttTask *tsk)
 {
-	switch (gtt_task_get_billrate (tsk))
-	{
-		case GTT_REGULAR: return _("Regular");
-		case GTT_OVERTIME: return _("Overtime");
-		case GTT_OVEROVER: return _("Double Overtime");
-		case GTT_FLAT_FEE: return _("Flat Fee");
-		default: return "";
-	}
-	return "";
+    switch (gtt_task_get_billrate(tsk))
+    {
+    case GTT_REGULAR:
+        return _("Regular");
+    case GTT_OVERTIME:
+        return _("Overtime");
+    case GTT_OVEROVER:
+        return _("Double Overtime");
+    case GTT_FLAT_FEE:
+        return _("Flat Fee");
+    default:
+        return "";
+    }
+    return "";
 };
 
-static SCM
-task_get_time_str_scm (GttGhtml *ghtml, GttTask *tsk)
+static SCM task_get_time_str_scm(GttGhtml *ghtml, GttTask *tsk)
 {
-	time_t task_secs;
-	char buff[100];
+    time_t task_secs;
+    char buff[100];
 
-	task_secs = gtt_task_get_secs_ever(tsk);
-	xxxqof_print_hours_elapsed_buff (buff, 100, task_secs, TRUE);
-	return scm_from_locale_string (buff);
+    task_secs = gtt_task_get_secs_ever(tsk);
+    xxxqof_print_hours_elapsed_buff(buff, 100, task_secs, TRUE);
+    return scm_from_locale_string(buff);
 }
 
-static SCM
-task_get_blocktime_str_scm (GttGhtml *ghtml, GttTask *tsk)
+static SCM task_get_blocktime_str_scm(GttGhtml *ghtml, GttTask *tsk)
 {
-	time_t task_secs;
-	char buff[100];
-	int bill_unit;
-	time_t value;
+    time_t task_secs;
+    char buff[100];
+    int bill_unit;
+    time_t value;
 
-	task_secs = gtt_task_get_secs_ever(tsk);
-	bill_unit = gtt_task_get_bill_unit(tsk);
+    task_secs = gtt_task_get_secs_ever(tsk);
+    bill_unit = gtt_task_get_bill_unit(tsk);
 
-	value = (time_t) (lround( ((double) task_secs) / bill_unit ) * bill_unit);
+    value = (time_t) (lround(((double) task_secs) / bill_unit) * bill_unit);
 
-	xxxqof_print_hours_elapsed_buff (buff, 100, value, TRUE);
-	// return scm_mem2string (buff, strlen (buff));
-	return scm_from_locale_string (buff);
+    xxxqof_print_hours_elapsed_buff(buff, 100, value, TRUE);
+    // return scm_mem2string (buff, strlen (buff));
+    return scm_from_locale_string(buff);
 }
 
-static SCM
-task_get_earliest_str_scm (GttGhtml *ghtml, GttTask *tsk)
+static SCM task_get_earliest_str_scm(GttGhtml *ghtml, GttTask *tsk)
 {
-	char buff[100];
+    char buff[100];
 
-	time_t task_date = gtt_task_get_secs_earliest(tsk);
-	// size_t len;
-	
-	if (task_date > 0) {
-		// len = xxxqof_print_date_time_buff (buff, 100, task_date);
-		xxxqof_print_date_time_buff (buff, 100, task_date);
-	} else {
-		// len = g_snprintf(buff, 100, "%s", _("No activity"));
-		g_snprintf(buff, 100, "%s", _("No activity"));
-	}
-	return scm_from_locale_string (buff);
+    time_t task_date = gtt_task_get_secs_earliest(tsk);
+    // size_t len;
+
+    if (task_date > 0)
+    {
+        // len = xxxqof_print_date_time_buff (buff, 100, task_date);
+        xxxqof_print_date_time_buff(buff, 100, task_date);
+    }
+    else
+    {
+        // len = g_snprintf(buff, 100, "%s", _("No activity"));
+        g_snprintf(buff, 100, "%s", _("No activity"));
+    }
+    return scm_from_locale_string(buff);
 }
 
-static SCM
-task_get_latest_str_scm (GttGhtml *ghtml, GttTask *tsk)
+static SCM task_get_latest_str_scm(GttGhtml *ghtml, GttTask *tsk)
 {
-	char buff[100];
+    char buff[100];
 
-	time_t task_date = gtt_task_get_secs_latest(tsk);
-	// size_t len;
+    time_t task_date = gtt_task_get_secs_latest(tsk);
+    // size_t len;
 
-	if (task_date > 0) {
-		// len = xxxqof_print_date_time_buff (buff, 100, task_date);
-		xxxqof_print_date_time_buff (buff, 100, task_date);
-	} else {
-		// len = g_snprintf(buff, 100, "%s", _("No activity"));
-		g_snprintf(buff, 100, "%s", _("No activity"));
-	}
-	return scm_from_locale_string (buff);
+    if (task_date > 0)
+    {
+        // len = xxxqof_print_date_time_buff (buff, 100, task_date);
+        xxxqof_print_date_time_buff(buff, 100, task_date);
+    }
+    else
+    {
+        // len = g_snprintf(buff, 100, "%s", _("No activity"));
+        g_snprintf(buff, 100, "%s", _("No activity"));
+    }
+    return scm_from_locale_string(buff);
 }
 
-static SCM
-task_get_value_str_scm (GttGhtml *ghtml, GttTask *tsk)
+static SCM task_get_value_str_scm(GttGhtml *ghtml, GttTask *tsk)
 {
-	time_t task_secs;
-	char buff[100];
-	double value;
-	GttProject *prj;
+    time_t task_secs;
+    char buff[100];
+    double value;
+    GttProject *prj;
 
-	task_secs = gtt_task_get_secs_ever(tsk);
-	value = ((double) task_secs) / 3600.0;
+    task_secs = gtt_task_get_secs_ever(tsk);
+    value = ((double) task_secs) / 3600.0;
 
-	prj = gtt_task_get_parent (tsk);
-	
-	switch (gtt_task_get_billrate (tsk))
-	{
-		case GTT_REGULAR: value *= gtt_project_get_billrate (prj); break;
-		case GTT_OVERTIME: value *= gtt_project_get_overtime_rate (prj); break;
-		case GTT_OVEROVER: value *= gtt_project_get_overover_rate (prj); break;
-		case GTT_FLAT_FEE: value = gtt_project_get_flat_fee (prj); break;
-		default: value = 0.0;
-	}
+    prj = gtt_task_get_parent(tsk);
 
-	if (!config_currency_use_locale) {
-		setlocale(LC_MONETARY, "C");
-		setlocale(LC_NUMERIC, "C");
-		snprintf (buff, 100, "%s %.2f", config_currency_symbol, value+0.0049);
-	} else {
-		setlocale(LC_ALL, "");
-		strfmon(buff, 100, "%n", value);
-	}
+    switch (gtt_task_get_billrate(tsk))
+    {
+    case GTT_REGULAR:
+        value *= gtt_project_get_billrate(prj);
+        break;
+    case GTT_OVERTIME:
+        value *= gtt_project_get_overtime_rate(prj);
+        break;
+    case GTT_OVEROVER:
+        value *= gtt_project_get_overover_rate(prj);
+        break;
+    case GTT_FLAT_FEE:
+        value = gtt_project_get_flat_fee(prj);
+        break;
+    default:
+        value = 0.0;
+    }
 
-	return scm_from_locale_string (buff);
+    if (!config_currency_use_locale)
+    {
+        setlocale(LC_MONETARY, "C");
+        setlocale(LC_NUMERIC, "C");
+        snprintf(buff, 100, "%s %.2f", config_currency_symbol, value + 0.0049);
+    }
+    else
+    {
+        setlocale(LC_ALL, "");
+        strfmon(buff, 100, "%n", value);
+    }
+
+    return scm_from_locale_string(buff);
 }
 
-static SCM
-task_get_blockvalue_str_scm (GttGhtml *ghtml, GttTask *tsk)
+static SCM task_get_blockvalue_str_scm(GttGhtml *ghtml, GttTask *tsk)
 {
-	time_t task_secs;
-	char buff[100];
-	double value;
-	GttProject *prj;
-	int bill_unit;
+    time_t task_secs;
+    char buff[100];
+    double value;
+    GttProject *prj;
+    int bill_unit;
 
-	task_secs = gtt_task_get_secs_ever(tsk);
-	bill_unit = gtt_task_get_bill_unit(tsk);
+    task_secs = gtt_task_get_secs_ever(tsk);
+    bill_unit = gtt_task_get_bill_unit(tsk);
 
-	value = (round( ((double) task_secs) / bill_unit ) * bill_unit) / 3600.0;
+    value = (round(((double) task_secs) / bill_unit) * bill_unit) / 3600.0;
 
-	prj = gtt_task_get_parent (tsk);
-	
-	switch (gtt_task_get_billrate (tsk))
-	{
-		case GTT_REGULAR: value *= gtt_project_get_billrate (prj); break;
-		case GTT_OVERTIME: value *= gtt_project_get_overtime_rate (prj); break;
-		case GTT_OVEROVER: value *= gtt_project_get_overover_rate (prj); break;
-		case GTT_FLAT_FEE: value = gtt_project_get_flat_fee (prj); break;
-		default: value = 0.0;
-	}
+    prj = gtt_task_get_parent(tsk);
 
-	if (!config_currency_use_locale) {
-		setlocale(LC_MONETARY, "C");
-		setlocale(LC_NUMERIC, "C");
-		snprintf (buff, 100, "%s %.2f", config_currency_symbol, value+0.0049);
-	} else {
-		setlocale(LC_ALL, "");
-		strfmon(buff, 100, "%n", value);
-	}
+    switch (gtt_task_get_billrate(tsk))
+    {
+    case GTT_REGULAR:
+        value *= gtt_project_get_billrate(prj);
+        break;
+    case GTT_OVERTIME:
+        value *= gtt_project_get_overtime_rate(prj);
+        break;
+    case GTT_OVEROVER:
+        value *= gtt_project_get_overover_rate(prj);
+        break;
+    case GTT_FLAT_FEE:
+        value = gtt_project_get_flat_fee(prj);
+        break;
+    default:
+        value = 0.0;
+    }
 
-	// return scm_mem2string (buff, strlen (buff));
-	return scm_from_locale_string (buff);
+    if (!config_currency_use_locale)
+    {
+        setlocale(LC_MONETARY, "C");
+        setlocale(LC_NUMERIC, "C");
+        snprintf(buff, 100, "%s %.2f", config_currency_symbol, value + 0.0049);
+    }
+    else
+    {
+        setlocale(LC_ALL, "");
+        strfmon(buff, 100, "%n", value);
+    }
+
+    // return scm_mem2string (buff, strlen (buff));
+    return scm_from_locale_string(buff);
 }
 
-RET_TASK_STR (ret_task_billstatus,      task_get_billstatus)
-RET_TASK_STR (ret_task_billable,        task_get_billable)
-RET_TASK_STR (ret_task_billrate,        task_get_billrate)
-RET_TASK_SIMPLE (ret_task_time_str,     task_get_time_str)
-RET_TASK_SIMPLE (ret_task_blocktime_str,task_get_blocktime_str)
-RET_TASK_SIMPLE (ret_task_earliest_str, task_get_earliest_str)
-RET_TASK_SIMPLE (ret_task_latest_str,   task_get_latest_str)
-RET_TASK_SIMPLE (ret_task_value_str,    task_get_value_str)
-RET_TASK_SIMPLE (ret_task_blockvalue_str,task_get_blockvalue_str)
+RET_TASK_STR(ret_task_billstatus, task_get_billstatus)
+RET_TASK_STR(ret_task_billable, task_get_billable)
+RET_TASK_STR(ret_task_billrate, task_get_billrate)
+RET_TASK_SIMPLE(ret_task_time_str, task_get_time_str)
+RET_TASK_SIMPLE(ret_task_blocktime_str, task_get_blocktime_str)
+RET_TASK_SIMPLE(ret_task_earliest_str, task_get_earliest_str)
+RET_TASK_SIMPLE(ret_task_latest_str, task_get_latest_str)
+RET_TASK_SIMPLE(ret_task_value_str, task_get_value_str)
+RET_TASK_SIMPLE(ret_task_blockvalue_str, task_get_blockvalue_str)
 
 /* ============================================================== */
 
-#define RET_IVL_SIMPLE(RET_FUNC,GTT_GETTER)                         \
-static SCM                                                          \
-RET_FUNC (SCM ivl_list)                                             \
-{                                                                   \
-	GttGhtml *ghtml = ghtml_guile_global_hack;                       \
-	return do_apply_on_interval (ghtml, ivl_list, GTT_GETTER##_scm); \
-}
+#define RET_IVL_SIMPLE(RET_FUNC, GTT_GETTER)                            \
+    static SCM RET_FUNC(SCM ivl_list)                                   \
+    {                                                                   \
+        GttGhtml *ghtml = ghtml_guile_global_hack;                      \
+        return do_apply_on_interval(ghtml, ivl_list, GTT_GETTER##_scm); \
+    }
 
+#define RET_IVL_STR(RET_FUNC, GTT_GETTER)                          \
+    static SCM GTT_GETTER##_scm(GttGhtml *ghtml, GttInterval *ivl) \
+    {                                                              \
+        const char *str = GTT_GETTER(ivl);                         \
+        return scm_from_locale_string(str);                        \
+    }                                                              \
+    RET_IVL_SIMPLE(RET_FUNC, GTT_GETTER)
 
-#define RET_IVL_STR(RET_FUNC,GTT_GETTER)                            \
-static SCM                                                          \
-GTT_GETTER##_scm (GttGhtml *ghtml, GttInterval *ivl)                \
-{                                                                   \
-	const char * str = GTT_GETTER (ivl);                             \
-	return scm_from_locale_string (str);		 \
-}                                                                   \
-RET_IVL_SIMPLE(RET_FUNC,GTT_GETTER)
+#define RET_IVL_ULONG(RET_FUNC, GTT_GETTER)                        \
+    static SCM GTT_GETTER##_scm(GttGhtml *ghtml, GttInterval *ivl) \
+    {                                                              \
+        unsigned long i = GTT_GETTER(ivl);                         \
+        return scm_from_ulong(i);                                  \
+    }                                                              \
+    RET_IVL_SIMPLE(RET_FUNC, GTT_GETTER)
 
+RET_IVL_ULONG(ret_ivl_start, gtt_interval_get_start)
+RET_IVL_ULONG(ret_ivl_stop, gtt_interval_get_stop)
+RET_IVL_ULONG(ret_ivl_fuzz, gtt_interval_get_fuzz)
 
-#define RET_IVL_ULONG(RET_FUNC,GTT_GETTER)                          \
-static SCM                                                          \
-GTT_GETTER##_scm (GttGhtml *ghtml, GttInterval *ivl)                \
-{                                                                   \
-	unsigned long i = GTT_GETTER (ivl);                              \
-	return scm_from_ulong (i);                                       \
-}                                                                   \
-RET_IVL_SIMPLE(RET_FUNC,GTT_GETTER)
-
-
-RET_IVL_ULONG (ret_ivl_start, gtt_interval_get_start)
-RET_IVL_ULONG (ret_ivl_stop,  gtt_interval_get_stop)
-RET_IVL_ULONG (ret_ivl_fuzz,  gtt_interval_get_fuzz)
-
-static SCM
-get_ivl_elapsed_str_scm (GttGhtml *ghtml, GttInterval *ivl)
+static SCM get_ivl_elapsed_str_scm(GttGhtml *ghtml, GttInterval *ivl)
 {
-	char buff[100];
-	time_t elapsed;
-	elapsed = gtt_interval_get_stop (ivl);
-	elapsed -= gtt_interval_get_start (ivl);
-	xxxqof_print_hours_elapsed_buff (buff, 100, elapsed, TRUE);
-	return scm_from_locale_string (buff);
+    char buff[100];
+    time_t elapsed;
+    elapsed = gtt_interval_get_stop(ivl);
+    elapsed -= gtt_interval_get_start(ivl);
+    xxxqof_print_hours_elapsed_buff(buff, 100, elapsed, TRUE);
+    return scm_from_locale_string(buff);
 }
 
-RET_IVL_SIMPLE (ret_ivl_elapsed_str, get_ivl_elapsed_str);
+RET_IVL_SIMPLE(ret_ivl_elapsed_str, get_ivl_elapsed_str);
 
-static SCM
-get_ivl_start_stop_common_str_scm (GttGhtml *ghtml, GttInterval *ivl,
-					 time_t starp, gboolean prt_date)
+static SCM get_ivl_start_stop_common_str_scm(
+    GttGhtml *ghtml, GttInterval *ivl, time_t starp, gboolean prt_date
+)
 {
-	char buff[100];
+    char buff[100];
 
-	if (prt_date) {
-		xxxqof_print_date_buff (buff, 100, starp);
-	} else {
-		switch (config_time_format)
-		{
-			case TIME_FORMAT_AM_PM: {
-				strftime (buff, 100, "%r", localtime (&starp));
-				break;
-			}
-			case TIME_FORMAT_24_HS: {
-				strftime (buff, 100, "%T", localtime (&starp));
-				break;
-			}
-			case TIME_FORMAT_LOCALE: {
-				xxxqof_print_time_buff (buff, 100, starp);
-				break;
-			}
-		}
-	}
+    if (prt_date)
+    {
+        xxxqof_print_date_buff(buff, 100, starp);
+    }
+    else
+    {
+        switch (config_time_format)
+        {
+        case TIME_FORMAT_AM_PM:
+        {
+            strftime(buff, 100, "%r", localtime(&starp));
+            break;
+        }
+        case TIME_FORMAT_24_HS:
+        {
+            strftime(buff, 100, "%T", localtime(&starp));
+            break;
+        }
+        case TIME_FORMAT_LOCALE:
+        {
+            xxxqof_print_time_buff(buff, 100, starp);
+            break;
+        }
+        }
+    }
 
-	GString *str;
-	str = g_string_new (NULL);
+    GString *str;
+    str = g_string_new(NULL);
 
-	if (ghtml->show_links)
-	{
+    if (ghtml->show_links)
+    {
 
-		g_string_append_printf (str, "<a href=\"gtt:interval:0x%lx\">", (long) ivl);
-	}
-	g_string_append (str, buff);
+        g_string_append_printf(str, "<a href=\"gtt:interval:0x%lx\">", (long) ivl);
+    }
+    g_string_append(str, buff);
 
-	if (ghtml->show_links)
-	{
-		g_string_append (str, "</a>");
-	}
+    if (ghtml->show_links)
+    {
+        g_string_append(str, "</a>");
+    }
 
-	return scm_from_locale_string (str->str);
+    return scm_from_locale_string(str->str);
 }
 
-static SCM
-get_ivl_same_day_start_scm (GttGhtml *ghtml, GttInterval *ivl)
+static SCM get_ivl_same_day_start_scm(GttGhtml *ghtml, GttInterval *ivl)
 {
-	gboolean prt_date = TRUE;
-	time_t start, prev_stop;
+    gboolean prt_date = TRUE;
+    time_t start, prev_stop;
 
-	/* Caution! use of the last_ivl_time thing makes this
-	 * stateful in a way that may be surprising !
-	 */
-	start = gtt_interval_get_start (ivl);
-	prev_stop = ghtml->last_ivl_time;
-	ghtml->last_ivl_time = start;
+    /* Caution! use of the last_ivl_time thing makes this
+     * stateful in a way that may be surprising !
+     */
+    start = gtt_interval_get_start(ivl);
+    prev_stop = ghtml->last_ivl_time;
+    ghtml->last_ivl_time = start;
 
-	if (0 != prev_stop)
-	{
-		prt_date = xxxqof_is_same_day(start, prev_stop);
-	}
-	return scm_from_bool (prt_date);
+    if (0 != prev_stop)
+    {
+        prt_date = xxxqof_is_same_day(start, prev_stop);
+    }
+    return scm_from_bool(prt_date);
 }
-RET_IVL_SIMPLE (ret_ivl_same_day_start, get_ivl_same_day_start);
+RET_IVL_SIMPLE(ret_ivl_same_day_start, get_ivl_same_day_start);
 
-static SCM
-get_ivl_same_day_stop_scm (GttGhtml *ghtml, GttInterval *ivl)
+static SCM get_ivl_same_day_stop_scm(GttGhtml *ghtml, GttInterval *ivl)
 {
-	gboolean prt_date = TRUE;
-	time_t stop, prev_start;
+    gboolean prt_date = TRUE;
+    time_t stop, prev_start;
 
-	/* Caution! use of the last_ivl_time thing makes this
-	 * stateful in a way that may be surprising !
-	 */
-	stop = gtt_interval_get_stop (ivl);
-	prev_start = ghtml->last_ivl_time;
-	ghtml->last_ivl_time = stop;
-	if (0 != prev_start)
-	{
-		prt_date = xxxqof_is_same_day(prev_start, stop);
-	}
-	return scm_from_bool (prt_date);
+    /* Caution! use of the last_ivl_time thing makes this
+     * stateful in a way that may be surprising !
+     */
+    stop = gtt_interval_get_stop(ivl);
+    prev_start = ghtml->last_ivl_time;
+    ghtml->last_ivl_time = stop;
+    if (0 != prev_start)
+    {
+        prt_date = xxxqof_is_same_day(prev_start, stop);
+    }
+    return scm_from_bool(prt_date);
 }
-RET_IVL_SIMPLE (ret_ivl_same_day_stop, get_ivl_same_day_stop);
+RET_IVL_SIMPLE(ret_ivl_same_day_stop, get_ivl_same_day_stop);
 
-static SCM
-get_ivl_start_date_str_scm (GttGhtml *ghtml, GttInterval *ivl)
+static SCM get_ivl_start_date_str_scm(GttGhtml *ghtml, GttInterval *ivl)
 {
-	time_t start = gtt_interval_get_start (ivl);
-	return get_ivl_start_stop_common_str_scm (ghtml, ivl, start, 1);
+    time_t start = gtt_interval_get_start(ivl);
+    return get_ivl_start_stop_common_str_scm(ghtml, ivl, start, 1);
 }
-RET_IVL_SIMPLE (ret_ivl_start_date_str, get_ivl_start_date_str);
+RET_IVL_SIMPLE(ret_ivl_start_date_str, get_ivl_start_date_str);
 
-static SCM
-get_ivl_start_time_str_scm (GttGhtml *ghtml, GttInterval *ivl)
+static SCM get_ivl_start_time_str_scm(GttGhtml *ghtml, GttInterval *ivl)
 {
-	time_t start = gtt_interval_get_start (ivl);
-	return get_ivl_start_stop_common_str_scm (ghtml, ivl, start, 0);
+    time_t start = gtt_interval_get_start(ivl);
+    return get_ivl_start_stop_common_str_scm(ghtml, ivl, start, 0);
 }
-RET_IVL_SIMPLE (ret_ivl_start_time_str, get_ivl_start_time_str);
+RET_IVL_SIMPLE(ret_ivl_start_time_str, get_ivl_start_time_str);
 
-static SCM
-get_ivl_stop_date_str_scm (GttGhtml *ghtml, GttInterval *ivl)
+static SCM get_ivl_stop_date_str_scm(GttGhtml *ghtml, GttInterval *ivl)
 {
-	time_t stop = gtt_interval_get_stop (ivl);
-	return get_ivl_start_stop_common_str_scm (ghtml, ivl, stop, 1);
+    time_t stop = gtt_interval_get_stop(ivl);
+    return get_ivl_start_stop_common_str_scm(ghtml, ivl, stop, 1);
 }
-RET_IVL_SIMPLE (ret_ivl_stop_date_str, get_ivl_stop_date_str);
+RET_IVL_SIMPLE(ret_ivl_stop_date_str, get_ivl_stop_date_str);
 
-static SCM
-get_ivl_stop_time_str_scm (GttGhtml *ghtml, GttInterval *ivl)
+static SCM get_ivl_stop_time_str_scm(GttGhtml *ghtml, GttInterval *ivl)
 {
-	time_t stop = gtt_interval_get_stop (ivl);
-	return get_ivl_start_stop_common_str_scm (ghtml, ivl, stop, 0);
+    time_t stop = gtt_interval_get_stop(ivl);
+    return get_ivl_start_stop_common_str_scm(ghtml, ivl, stop, 0);
 }
-RET_IVL_SIMPLE (ret_ivl_stop_time_str, get_ivl_stop_time_str);
+RET_IVL_SIMPLE(ret_ivl_stop_time_str, get_ivl_stop_time_str);
 
-static SCM
-get_ivl_fuzz_str_scm (GttGhtml *ghtml, GttInterval *ivl)
+static SCM get_ivl_fuzz_str_scm(GttGhtml *ghtml, GttInterval *ivl)
 {
-	char buff[100];
+    char buff[100];
 
-	xxxqof_print_hours_elapsed_buff (buff, 100, gtt_interval_get_fuzz (ivl), TRUE);
-	return scm_from_locale_string (buff);
+    xxxqof_print_hours_elapsed_buff(buff, 100, gtt_interval_get_fuzz(ivl), TRUE);
+    return scm_from_locale_string(buff);
 }
-RET_IVL_SIMPLE (ret_ivl_fuzz_str, get_ivl_fuzz_str);
+RET_IVL_SIMPLE(ret_ivl_fuzz_str, get_ivl_fuzz_str);
 
 /* ============================================================== */
 
 SCM captured_stack = SCM_BOOL_F;
 
-static SCM
-my_preunwind_handler (void *data, SCM tag, SCM throw_args)
+static SCM my_preunwind_handler(void *data, SCM tag, SCM throw_args)
 {
-	// We can only record the stack before it is unwound.
-	// The normal catch handler body runs only *after* the stack
-	// has been unwound.
-	captured_stack = scm_make_stack (SCM_BOOL_T, SCM_EOL);
-	return SCM_EOL;
+    // We can only record the stack before it is unwound.
+    // The normal catch handler body runs only *after* the stack
+    // has been unwound.
+    captured_stack = scm_make_stack(SCM_BOOL_T, SCM_EOL);
+    return SCM_EOL;
 }
 
-static SCM
-my_catch_handler (void *data, SCM tag, SCM throw_args)
+static SCM my_catch_handler(void *data, SCM tag, SCM throw_args)
 {
 
-	printf ("Error: GnoTime caught an error during scheme parse\n");
+    printf("Error: GnoTime caught an error during scheme parse\n");
 
-	/* create string port into which we write the error message and
-	   stack. */
-	SCM port = scm_current_output_port();
-	/* throw args seem to be: (FN FORMAT ARGS #f). split the pieces into
-	   local vars. */
-	if (scm_is_true(scm_list_p(throw_args))
-	    && (scm_ilength(throw_args) >= 1))
-	{
-		long nargs = scm_ilength(throw_args);
-		SCM fn = scm_car(throw_args);
-		SCM format = SCM_EOL;
-		if (nargs >= 2)
-			 format = scm_cadr(throw_args);
+    /* create string port into which we write the error message and
+       stack. */
+    SCM port = scm_current_output_port();
+    /* throw args seem to be: (FN FORMAT ARGS #f). split the pieces into
+       local vars. */
+    if (scm_is_true(scm_list_p(throw_args)) && (scm_ilength(throw_args) >= 1))
+    {
+        long nargs = scm_ilength(throw_args);
+        SCM fn = scm_car(throw_args);
+        SCM format = SCM_EOL;
+        if (nargs >= 2)
+            format = scm_cadr(throw_args);
 
-		SCM parts = SCM_EOL;
-		if (nargs >= 3)
-			parts = scm_caddr(throw_args);
+        SCM parts = SCM_EOL;
+        if (nargs >= 3)
+            parts = scm_caddr(throw_args);
 
-		SCM rest = SCM_EOL;
-		if (nargs >= 4)
-			rest = scm_car(scm_cdddr(throw_args));
-		
+        SCM rest = SCM_EOL;
+        if (nargs >= 4)
+            rest = scm_car(scm_cdddr(throw_args));
+
 #if OLD_GUILE_18_STUFF
-		/* This is some old code that mostly(?) worked under guile-1.8,
-		 * but uses a deprecated API's.  The new guile code below is
-		 * better, and it works with guile-2.0 */
-		if (fn != SCM_BOOL_F)
-		{ /* display the function name and tag */
-			scm_puts("Function: ", port);
-			scm_display(fn, port);
-			scm_puts(", ", port);
-			scm_display(tag, port);
-			scm_newline(port);
-		}
+        /* This is some old code that mostly(?) worked under guile-1.8,
+         * but uses a deprecated API's.  The new guile code below is
+         * better, and it works with guile-2.0 */
+        if (fn != SCM_BOOL_F)
+        { /* display the function name and tag */
+            scm_puts("Function: ", port);
+            scm_display(fn, port);
+            scm_puts(", ", port);
+            scm_display(tag, port);
+            scm_newline(port);
+        }
 
-		if (scm_string_p(format))
-		{ /* conditionally display the error message using format */
-			scm_puts("Error: ", port);
-			scm_display_error_message(format, parts, port);
-		}
-		if (rest != SCM_EOL)
-		{
-			scm_puts("Other Data: ", port);
-			scm_display(rest, port);
-			scm_newline(port);
-			scm_newline(port);
-		}
-	}
+        if (scm_string_p(format))
+        { /* conditionally display the error message using format */
+            scm_puts("Error: ", port);
+            scm_display_error_message(format, parts, port);
+        }
+        if (rest != SCM_EOL)
+        {
+            scm_puts("Other Data: ", port);
+            scm_display(rest, port);
+            scm_newline(port);
+            scm_newline(port);
+        }
+    }
 
-	/* find the stack, and conditionally display it */
-	SCM the_stack = scm_fluid_ref(SCM_CDR(scm_the_last_stack_fluid_var));
-	if (the_stack != SCM_BOOL_F)
-	{
-		scm_display_backtrace(the_stack, port, SCM_UNDEFINED, SCM_UNDEFINED);
-	}
+    /* find the stack, and conditionally display it */
+    SCM the_stack = scm_fluid_ref(SCM_CDR(scm_the_last_stack_fluid_var));
+    if (the_stack != SCM_BOOL_F)
+    {
+        scm_display_backtrace(the_stack, port, SCM_UNDEFINED, SCM_UNDEFINED);
+    }
 
-	return SCM_EOL;
+    return SCM_EOL;
 #else /* OLD_GUILE_18_STUFF */
-		if (scm_is_true (captured_stack))
-		{
-			SCM highlights;
+        if (scm_is_true(captured_stack))
+        {
+            SCM highlights;
 
-			if (scm_is_eq (tag, scm_arg_type_key) ||
-				scm_is_eq (tag, scm_out_of_range_key))
-				highlights = rest;
-			else
-				highlights = SCM_EOL;
+            if (scm_is_eq(tag, scm_arg_type_key) || scm_is_eq(tag, scm_out_of_range_key))
+                highlights = rest;
+            else
+                highlights = SCM_EOL;
 
-			scm_puts ("Backtrace:\n", port);
-			scm_display_backtrace_with_highlights (captured_stack, port,
-													SCM_BOOL_F, SCM_BOOL_F,
-													highlights);
-			scm_newline (port);
-		}
-		scm_display_error (captured_stack, port, fn, format, parts, rest);
-	}
-	else
-	{
-		scm_puts ("ERROR: throw args are unexpectedly short!\n", port);
-	}
-	scm_puts("ABORT: ", port);
-	SCM re = scm_symbol_to_string(tag);
-	char * restr = scm_to_locale_string(re);
-	scm_puts(restr, port);
-	free(restr);
+            scm_puts("Backtrace:\n", port);
+            scm_display_backtrace_with_highlights(
+                captured_stack, port, SCM_BOOL_F, SCM_BOOL_F, highlights
+            );
+            scm_newline(port);
+        }
+        scm_display_error(captured_stack, port, fn, format, parts, rest);
+    }
+    else
+    {
+        scm_puts("ERROR: throw args are unexpectedly short!\n", port);
+    }
+    scm_puts("ABORT: ", port);
+    SCM re = scm_symbol_to_string(tag);
+    char *restr = scm_to_locale_string(re);
+    scm_puts(restr, port);
+    free(restr);
 
-	return SCM_BOOL_F;
+    return SCM_BOOL_F;
 #endif
 }
 
@@ -1511,192 +1506,194 @@ my_catch_handler (void *data, SCM tag, SCM throw_args)
  * <link rel="stylesheet" href="some_kind_of.css" type="text/css">
  */
 
-static void
-process_link (GttGhtml *ghtml, const gchar *str)
+static void process_link(GttGhtml *ghtml, const gchar *str)
 {
-	/* no-op for now, just copy it into the window  */
-	if (ghtml->write_stream)
-	{
-		(ghtml->write_stream) (ghtml, "<link", 5, ghtml->user_data);
-		size_t nr = strlen (str);
-		(ghtml->write_stream) (ghtml, str, nr, ghtml->user_data);
-		(ghtml->write_stream) (ghtml, ">", 1, ghtml->user_data);
-	}
+    /* no-op for now, just copy it into the window  */
+    if (ghtml->write_stream)
+    {
+        (ghtml->write_stream)(ghtml, "<link", 5, ghtml->user_data);
+        size_t nr = strlen(str);
+        (ghtml->write_stream)(ghtml, str, nr, ghtml->user_data);
+        (ghtml->write_stream)(ghtml, ">", 1, ghtml->user_data);
+    }
 }
 
 /* ============================================================== */
 
-void
-gtt_ghtml_display (GttGhtml *ghtml, const char *filepath,
-                   GttProject *prj)
+void gtt_ghtml_display(GttGhtml *ghtml, const char *filepath, GttProject *prj)
 {
-	GString *template;
-	char *start, *end, *scmstart, *comstart, *linkstart;
-	size_t nr;
+    GString *template;
+    char *start, *end, *scmstart, *comstart, *linkstart;
+    size_t nr;
 
-	if (!ghtml) return;
-	if (prj) ghtml->prj = prj;
+    if (!ghtml)
+        return;
+    if (prj)
+        ghtml->prj = prj;
 
-	if (!filepath && (0==ghtml->open_count))
-	{
-		if (ghtml->error)
-		{
-			(ghtml->error) (ghtml, 404, NULL, ghtml->user_data);
-		}
-		return;
-	}
+    if (!filepath && (0 == ghtml->open_count))
+    {
+        if (ghtml->error)
+        {
+            (ghtml->error)(ghtml, 404, NULL, ghtml->user_data);
+        }
+        return;
+    }
 
-	/* Try to get the ghtml file ... */
-	GnomeVFSResult    result;
-	GnomeVFSHandle   *handle;
-	result = gnome_vfs_open (&handle, filepath, GNOME_VFS_OPEN_READ);
-	if ((GNOME_VFS_OK != result) && (0==ghtml->open_count))
-	{
-		if (ghtml->error)
-		{
-			(ghtml->error) (ghtml, 404, filepath, ghtml->user_data);
-		}
-		return;
-	}
-	ghtml->ref_path = filepath;
+    /* Try to get the ghtml file ... */
+    GnomeVFSResult result;
+    GnomeVFSHandle *handle;
+    result = gnome_vfs_open(&handle, filepath, GNOME_VFS_OPEN_READ);
+    if ((GNOME_VFS_OK != result) && (0 == ghtml->open_count))
+    {
+        if (ghtml->error)
+        {
+            (ghtml->error)(ghtml, 404, filepath, ghtml->user_data);
+        }
+        return;
+    }
+    ghtml->ref_path = filepath;
 
-	/* Read in the whole file.  Hopefully its not huge */
-	template = g_string_new (NULL);
-	while (GNOME_VFS_OK == result)
-	{
+    /* Read in the whole file.  Hopefully its not huge */
+    template = g_string_new(NULL);
+    while (GNOME_VFS_OK == result)
+    {
 #define BUFF_SIZE 4000
-		char buff[BUFF_SIZE+1];
-		GnomeVFSFileSize  bytes_read;
-		result = gnome_vfs_read (handle, buff, BUFF_SIZE, &bytes_read);
-		if (0 >= bytes_read) break;  /* EOF I presume */
-		buff[bytes_read] = 0x0;
-		g_string_append (template, buff);
-	}
-	gnome_vfs_close (handle);
+        char buff[BUFF_SIZE + 1];
+        GnomeVFSFileSize bytes_read;
+        result = gnome_vfs_read(handle, buff, BUFF_SIZE, &bytes_read);
+        if (0 >= bytes_read)
+            break; /* EOF I presume */
+        buff[bytes_read] = 0x0;
+        g_string_append(template, buff);
+    }
+    gnome_vfs_close(handle);
 
-	/* ugh. gag. choke. puke. */
-	ghtml_guile_global_hack = ghtml;
+    /* ugh. gag. choke. puke. */
+    ghtml_guile_global_hack = ghtml;
 
 #ifdef DEBUG
-	/* Load predefined scheme forms. We do this here only when debugging,
-	 * since they may have changed since just a few minutes ago. */
-	scm_c_primitive_load (gtt_ghtml_resolve_path("gtt.scm", NULL));
+    /* Load predefined scheme forms. We do this here only when debugging,
+     * since they may have changed since just a few minutes ago. */
+    scm_c_primitive_load(gtt_ghtml_resolve_path("gtt.scm", NULL));
 #endif
 
-	/* Now open the output stream for writing */
-	if (ghtml->open_stream && (0==ghtml->open_count))
-	{
-		(ghtml->open_stream) (ghtml, ghtml->user_data);
-	}
+    /* Now open the output stream for writing */
+    if (ghtml->open_stream && (0 == ghtml->open_count))
+    {
+        (ghtml->open_stream)(ghtml, ghtml->user_data);
+    }
 
-	ghtml->open_count ++;
+    ghtml->open_count++;
 
-	/* Loop over input text, looking for scheme markup and
-	 * sgml comments. */
-	start = template->str;
-	while (start)
-	{
-		/* Look for scheme markup */
-		scmstart = strstr (start, "<?scm");
+    /* Loop over input text, looking for scheme markup and
+     * sgml comments. */
+    start = template->str;
+    while (start)
+    {
+        /* Look for scheme markup */
+        scmstart = strstr(start, "<?scm");
 
-		/* Look for comments, and blow past them. */
-		comstart = strstr (start, "<!--");
+        /* Look for comments, and blow past them. */
+        comstart = strstr(start, "<!--");
 
-		/* Look for <link>, and try to handle stylesheets. */
-		linkstart = strstr (start, "<link");
+        /* Look for <link>, and try to handle stylesheets. */
+        linkstart = strstr(start, "<link");
 
-		/* which comes first ? */
-		end = 0;
-		if (scmstart) end = scmstart;
-		if (comstart && comstart < end) end = comstart;
-		if (linkstart && linkstart < end) end = linkstart;
+        /* which comes first ? */
+        end = 0;
+        if (scmstart)
+            end = scmstart;
+        if (comstart && comstart < end)
+            end = comstart;
+        if (linkstart && linkstart < end)
+            end = linkstart;
 
-		/* Look for comments, and blow past them. */
-		if (comstart && comstart == end)
-		{
-			end = strstr (comstart, "-->");
-			if (end)
-			{
-				end +=3;
-			}
+        /* Look for comments, and blow past them. */
+        if (comstart && comstart == end)
+        {
+            end = strstr(comstart, "-->");
+            if (end)
+            {
+                end += 3;
+            }
 
-			/* write everything that we got before the markup */
-			if (ghtml->write_stream)
-			{
-				nr = comstart - start;
-				(ghtml->write_stream) (ghtml, start, nr, ghtml->user_data);
-			}
-			start = end;
-			continue;
-		}
+            /* write everything that we got before the markup */
+            if (ghtml->write_stream)
+            {
+                nr = comstart - start;
+                (ghtml->write_stream)(ghtml, start, nr, ghtml->user_data);
+            }
+            start = end;
+            continue;
+        }
 
-		/* Look for <link>, and try to handle stylesheets. */
-		if (linkstart && linkstart == end)
-		{
-			end = strstr (linkstart, ">");
-			if (end)
-			{
-				*end = 0;
-				end += 1;
-			}
+        /* Look for <link>, and try to handle stylesheets. */
+        if (linkstart && linkstart == end)
+        {
+            end = strstr(linkstart, ">");
+            if (end)
+            {
+                *end = 0;
+                end += 1;
+            }
 
-			/* write everything that we got before the markup */
-			if (ghtml->write_stream)
-			{
-				nr = linkstart - start;
-				(ghtml->write_stream) (ghtml, start, nr, ghtml->user_data);
-			}
+            /* write everything that we got before the markup */
+            if (ghtml->write_stream)
+            {
+                nr = linkstart - start;
+                (ghtml->write_stream)(ghtml, start, nr, ghtml->user_data);
+            }
 
-			/* dispatch and handle */
-			process_link (ghtml, linkstart+5);
-			start = end;
-			continue;
-		}
+            /* dispatch and handle */
+            process_link(ghtml, linkstart + 5);
+            start = end;
+            continue;
+        }
 
-		/* Look for  termination of scm markup */
-		if (scmstart && scmstart == end)
-		{
-			end = strstr (scmstart, "?>");
-			if (end)
-			{
-				*end = 0;
-				end += 2;
-			}
+        /* Look for  termination of scm markup */
+        if (scmstart && scmstart == end)
+        {
+            end = strstr(scmstart, "?>");
+            if (end)
+            {
+                *end = 0;
+                end += 2;
+            }
 
-			/* write everything that we got before the markup */
-			if (ghtml->write_stream)
-			{
-				nr = scmstart - start;
-				(ghtml->write_stream) (ghtml, start, nr, ghtml->user_data);
-			}
+            /* write everything that we got before the markup */
+            if (ghtml->write_stream)
+            {
+                nr = scmstart - start;
+                (ghtml->write_stream)(ghtml, start, nr, ghtml->user_data);
+            }
 
-			/* dispatch and handle */
-			scmstart += 5;
-			captured_stack = SCM_BOOL_F;
-			scm_c_catch (SCM_BOOL_T,
-			             (scm_t_catch_body) scm_c_eval_string,
-			             scmstart,
-			             my_catch_handler, NULL,
-			             my_preunwind_handler, NULL);
+            /* dispatch and handle */
+            scmstart += 5;
+            captured_stack = SCM_BOOL_F;
+            scm_c_catch(
+                SCM_BOOL_T, (scm_t_catch_body) scm_c_eval_string, scmstart, my_catch_handler,
+                NULL, my_preunwind_handler, NULL
+            );
 
-			start = end;
-			continue;
-		}
+            start = end;
+            continue;
+        }
 
-		/* If we got to here, we didn't find any tags. Just output */
-		if (ghtml->write_stream)
-		{
-			nr = strlen (start);
-			(ghtml->write_stream) (ghtml, start, nr, ghtml->user_data);
-		}
-		break;
-	}
+        /* If we got to here, we didn't find any tags. Just output */
+        if (ghtml->write_stream)
+        {
+            nr = strlen(start);
+            (ghtml->write_stream)(ghtml, start, nr, ghtml->user_data);
+        }
+        break;
+    }
 
-	ghtml->open_count --;
-	if (ghtml->close_stream && (0==ghtml->open_count))
-	{
-		(ghtml->close_stream) (ghtml, ghtml->user_data);
-	}
+    ghtml->open_count--;
+    if (ghtml->close_stream && (0 == ghtml->open_count))
+    {
+        (ghtml->close_stream)(ghtml, ghtml->user_data);
+    }
 }
 
 /* ============================================================== */
@@ -1706,136 +1703,132 @@ gtt_ghtml_display (GttGhtml *ghtml, const char *filepath,
 
 static int is_inited = 0;
 
-static void
-register_procs (void)
+static void register_procs(void)
 {
-	scm_c_define_gsubr("gtt-show",               1, 0, 0, show_scm);
-	scm_c_define_gsubr("gtt-include",            1, 0, 0, include_file_scm);
-	scm_c_define_gsubr("gtt-kvp-str",            1, 0, 0, ret_kvp_str);
-	scm_c_define_gsubr("gtt-linked-project",     0, 0, 0, ret_linked_project);
-	scm_c_define_gsubr("gtt-selected-project",   0, 0, 0, ret_selected_project);
-	scm_c_define_gsubr("gtt-projects",           0, 0, 0, ret_projects);
-	scm_c_define_gsubr("gtt-query-results",      0, 0, 0, ret_query_projects);
-	scm_c_define_gsubr("gtt-did-query",          0, 0, 0, ret_did_query);
+    scm_c_define_gsubr("gtt-show", 1, 0, 0, show_scm);
+    scm_c_define_gsubr("gtt-include", 1, 0, 0, include_file_scm);
+    scm_c_define_gsubr("gtt-kvp-str", 1, 0, 0, ret_kvp_str);
+    scm_c_define_gsubr("gtt-linked-project", 0, 0, 0, ret_linked_project);
+    scm_c_define_gsubr("gtt-selected-project", 0, 0, 0, ret_selected_project);
+    scm_c_define_gsubr("gtt-projects", 0, 0, 0, ret_projects);
+    scm_c_define_gsubr("gtt-query-results", 0, 0, 0, ret_query_projects);
+    scm_c_define_gsubr("gtt-did-query", 0, 0, 0, ret_did_query);
 
-	scm_c_define_gsubr("gtt-tasks",              1, 0, 0, ret_tasks);
-	scm_c_define_gsubr("gtt-intervals",          1, 0, 0, ret_intervals);
-	scm_c_define_gsubr("gtt-daily-totals",       1, 0, 0, ret_daily_totals);
+    scm_c_define_gsubr("gtt-tasks", 1, 0, 0, ret_tasks);
+    scm_c_define_gsubr("gtt-intervals", 1, 0, 0, ret_intervals);
+    scm_c_define_gsubr("gtt-daily-totals", 1, 0, 0, ret_daily_totals);
 
-	scm_c_define_gsubr("gtt-links-on",           0, 0, 0, set_links_on);
-	scm_c_define_gsubr("gtt-links-off",          0, 0, 0, set_links_off);
+    scm_c_define_gsubr("gtt-links-on", 0, 0, 0, set_links_on);
+    scm_c_define_gsubr("gtt-links-off", 0, 0, 0, set_links_off);
 
-	scm_c_define_gsubr("gtt-project-subprojects", 1, 0, 0, ret_project_subprjs);
-	scm_c_define_gsubr("gtt-project-parent",     1, 0, 0, ret_project_parent);
-	scm_c_define_gsubr("gtt-project-title",      1, 0, 0, ret_project_title);
-	scm_c_define_gsubr("gtt-project-title-link", 1, 0, 0, ret_project_title_link);
-	scm_c_define_gsubr("gtt-project-desc",       1, 0, 0, ret_project_desc);
-	scm_c_define_gsubr("gtt-project-notes",      1, 0, 0, ret_project_notes);
-	scm_c_define_gsubr("gtt-project-urgency",    1, 0, 0, ret_project_urgency);
-	scm_c_define_gsubr("gtt-project-importance", 1, 0, 0, ret_project_importance);
-	scm_c_define_gsubr("gtt-project-status",     1, 0, 0, ret_project_status);
-	scm_c_define_gsubr("gtt-project-estimated-start", 1, 0, 0, ret_project_est_start);
-	scm_c_define_gsubr("gtt-project-estimated-end", 1, 0, 0, ret_project_est_end);
-	scm_c_define_gsubr("gtt-project-due-date",   1, 0, 0, ret_project_due_date);
-	scm_c_define_gsubr("gtt-project-sizing",     1, 0, 0, ret_project_sizing);
-	scm_c_define_gsubr("gtt-project-percent-complete", 1, 0, 0, ret_project_percent);
+    scm_c_define_gsubr("gtt-project-subprojects", 1, 0, 0, ret_project_subprjs);
+    scm_c_define_gsubr("gtt-project-parent", 1, 0, 0, ret_project_parent);
+    scm_c_define_gsubr("gtt-project-title", 1, 0, 0, ret_project_title);
+    scm_c_define_gsubr("gtt-project-title-link", 1, 0, 0, ret_project_title_link);
+    scm_c_define_gsubr("gtt-project-desc", 1, 0, 0, ret_project_desc);
+    scm_c_define_gsubr("gtt-project-notes", 1, 0, 0, ret_project_notes);
+    scm_c_define_gsubr("gtt-project-urgency", 1, 0, 0, ret_project_urgency);
+    scm_c_define_gsubr("gtt-project-importance", 1, 0, 0, ret_project_importance);
+    scm_c_define_gsubr("gtt-project-status", 1, 0, 0, ret_project_status);
+    scm_c_define_gsubr("gtt-project-estimated-start", 1, 0, 0, ret_project_est_start);
+    scm_c_define_gsubr("gtt-project-estimated-end", 1, 0, 0, ret_project_est_end);
+    scm_c_define_gsubr("gtt-project-due-date", 1, 0, 0, ret_project_due_date);
+    scm_c_define_gsubr("gtt-project-sizing", 1, 0, 0, ret_project_sizing);
+    scm_c_define_gsubr("gtt-project-percent-complete", 1, 0, 0, ret_project_percent);
 
-	scm_c_define_gsubr("gtt-task-memo",          1, 0, 0, ret_task_memo);
-	scm_c_define_gsubr("gtt-task-notes",         1, 0, 0, ret_task_notes);
-	scm_c_define_gsubr("gtt-task-billstatus",    1, 0, 0, ret_task_billstatus);
-	scm_c_define_gsubr("gtt-task-billable",      1, 0, 0, ret_task_billable);
-	scm_c_define_gsubr("gtt-task-billrate",      1, 0, 0, ret_task_billrate);
-	scm_c_define_gsubr("gtt-task-time-str",      1, 0, 0, ret_task_time_str);
-	scm_c_define_gsubr("gtt-task-blocktime-str", 1, 0, 0, ret_task_blocktime_str);
-	scm_c_define_gsubr("gtt-task-earliest-str",  1, 0, 0, ret_task_earliest_str);
-	scm_c_define_gsubr("gtt-task-latest-str",    1, 0, 0, ret_task_latest_str);
-	scm_c_define_gsubr("gtt-task-value-str",     1, 0, 0, ret_task_value_str);
-	scm_c_define_gsubr("gtt-task-blockvalue-str",1, 0, 0, ret_task_blockvalue_str);
-	scm_c_define_gsubr("gtt-task-parent",        1, 0, 0, ret_task_parent);
+    scm_c_define_gsubr("gtt-task-memo", 1, 0, 0, ret_task_memo);
+    scm_c_define_gsubr("gtt-task-notes", 1, 0, 0, ret_task_notes);
+    scm_c_define_gsubr("gtt-task-billstatus", 1, 0, 0, ret_task_billstatus);
+    scm_c_define_gsubr("gtt-task-billable", 1, 0, 0, ret_task_billable);
+    scm_c_define_gsubr("gtt-task-billrate", 1, 0, 0, ret_task_billrate);
+    scm_c_define_gsubr("gtt-task-time-str", 1, 0, 0, ret_task_time_str);
+    scm_c_define_gsubr("gtt-task-blocktime-str", 1, 0, 0, ret_task_blocktime_str);
+    scm_c_define_gsubr("gtt-task-earliest-str", 1, 0, 0, ret_task_earliest_str);
+    scm_c_define_gsubr("gtt-task-latest-str", 1, 0, 0, ret_task_latest_str);
+    scm_c_define_gsubr("gtt-task-value-str", 1, 0, 0, ret_task_value_str);
+    scm_c_define_gsubr("gtt-task-blockvalue-str", 1, 0, 0, ret_task_blockvalue_str);
+    scm_c_define_gsubr("gtt-task-parent", 1, 0, 0, ret_task_parent);
 
-	scm_c_define_gsubr("gtt-interval-start",     1, 0, 0, ret_ivl_start);
-	scm_c_define_gsubr("gtt-interval-stop",      1, 0, 0, ret_ivl_stop);
-	scm_c_define_gsubr("gtt-interval-fuzz",      1, 0, 0, ret_ivl_fuzz);
-	scm_c_define_gsubr("gtt-interval-elapsed-str", 1, 0, 0, ret_ivl_elapsed_str);
-	scm_c_define_gsubr("gtt-interval-start-date-str", 1, 0, 0, ret_ivl_start_date_str);
-	scm_c_define_gsubr("gtt-interval-start-time-str", 1, 0, 0, ret_ivl_start_time_str);
-	scm_c_define_gsubr("gtt-interval-stop-date-str",  1, 0, 0, ret_ivl_stop_date_str);
-	scm_c_define_gsubr("gtt-interval-stop-time-str",  1, 0, 0, ret_ivl_stop_time_str);
-	scm_c_define_gsubr("gtt-interval-same-day-start", 1, 0, 0, ret_ivl_same_day_start);
-	scm_c_define_gsubr("gtt-interval-same-day-stop",  1, 0, 0, ret_ivl_same_day_stop);
-	scm_c_define_gsubr("gtt-interval-fuzz-str",  1, 0, 0, ret_ivl_fuzz_str);
-
+    scm_c_define_gsubr("gtt-interval-start", 1, 0, 0, ret_ivl_start);
+    scm_c_define_gsubr("gtt-interval-stop", 1, 0, 0, ret_ivl_stop);
+    scm_c_define_gsubr("gtt-interval-fuzz", 1, 0, 0, ret_ivl_fuzz);
+    scm_c_define_gsubr("gtt-interval-elapsed-str", 1, 0, 0, ret_ivl_elapsed_str);
+    scm_c_define_gsubr("gtt-interval-start-date-str", 1, 0, 0, ret_ivl_start_date_str);
+    scm_c_define_gsubr("gtt-interval-start-time-str", 1, 0, 0, ret_ivl_start_time_str);
+    scm_c_define_gsubr("gtt-interval-stop-date-str", 1, 0, 0, ret_ivl_stop_date_str);
+    scm_c_define_gsubr("gtt-interval-stop-time-str", 1, 0, 0, ret_ivl_stop_time_str);
+    scm_c_define_gsubr("gtt-interval-same-day-start", 1, 0, 0, ret_ivl_same_day_start);
+    scm_c_define_gsubr("gtt-interval-same-day-stop", 1, 0, 0, ret_ivl_same_day_stop);
+    scm_c_define_gsubr("gtt-interval-fuzz-str", 1, 0, 0, ret_ivl_fuzz_str);
 }
-
 
 /* ============================================================== */
 
-GttGhtml *
-gtt_ghtml_new (void)
+GttGhtml *gtt_ghtml_new(void)
 {
-	GttGhtml *p;
+    GttGhtml *p;
 
-	if (!is_inited)
-	{
-		is_inited = 1;
-		register_procs();
+    if (!is_inited)
+    {
+        is_inited = 1;
+        register_procs();
 
-		/* Initialize guile interpreter */
-		scm_init_guile();
+        /* Initialize guile interpreter */
+        scm_init_guile();
 
-		/* Load predefined scheme forms */
-		scm_c_primitive_load (gtt_ghtml_resolve_path("gtt.scm", NULL));
-	}
+        /* Load predefined scheme forms */
+        scm_c_primitive_load(gtt_ghtml_resolve_path("gtt.scm", NULL));
+    }
 
-	p = g_new0 (GttGhtml, 1);
+    p = g_new0(GttGhtml, 1);
 
-	p->open_count = 0;
-	p->kvp = NULL;
-	p->prj = NULL;
-	p->query_result = NULL;
-	p->did_query = FALSE;
-	p->show_links = TRUE;
-	p->really_hide_links = FALSE;
-	p->last_ivl_time = 0;
+    p->open_count = 0;
+    p->kvp = NULL;
+    p->prj = NULL;
+    p->query_result = NULL;
+    p->did_query = FALSE;
+    p->show_links = TRUE;
+    p->really_hide_links = FALSE;
+    p->last_ivl_time = 0;
 
-	gtt_ghtml_deprecated_init (p);
+    gtt_ghtml_deprecated_init(p);
 
-	return p;
+    return p;
 }
 
-void
-gtt_ghtml_destroy (GttGhtml *p)
+void gtt_ghtml_destroy(GttGhtml *p)
 {
-	if (!p) return;
+    if (!p)
+        return;
 
-	if (p->query_result) g_list_free (p->query_result);
-	g_free (p);
+    if (p->query_result)
+        g_list_free(p->query_result);
+    g_free(p);
 }
 
-void
-gtt_ghtml_set_stream (GttGhtml *p, gpointer ud,
-                                   GttGhtmlOpenStream op,
-                                   GttGhtmlWriteStream wr,
-                                   GttGhtmlCloseStream cl,
-                                   GttGhtmlError er)
+void gtt_ghtml_set_stream(
+    GttGhtml *p, gpointer ud, GttGhtmlOpenStream op, GttGhtmlWriteStream wr,
+    GttGhtmlCloseStream cl, GttGhtmlError er
+)
 {
-	if (!p) return;
-	p->user_data = ud;
-	p->open_stream = op;
-	p->write_stream = wr;
-	p->close_stream = cl;
-	p->error = er;
+    if (!p)
+        return;
+    p->user_data = ud;
+    p->open_stream = op;
+    p->write_stream = wr;
+    p->close_stream = cl;
+    p->error = er;
 }
 
 /* This sets the over-ride flag, so that no internal links are shown,
  * really really for real, when printing out to file.
  */
-void
-gtt_ghtml_show_links (GttGhtml *p, gboolean sl)
+void gtt_ghtml_show_links(GttGhtml *p, gboolean sl)
 {
-	if (!p) return;
-	p->really_hide_links = (FALSE == sl);
-	p->show_links = sl;
+    if (!p)
+        return;
+    p->really_hide_links = (FALSE == sl);
+    p->show_links = sl;
 }
 
 /* ===================== END OF FILE ==============================  */

--- a/src/ghtml.h
+++ b/src/ghtml.h
@@ -41,82 +41,80 @@ typedef struct gtt_ghtml_s GttGhtml;
 
 struct gtt_ghtml_s
 {
-	/* stream interface for writing */
-	void (*open_stream) (GttGhtml *, gpointer);
-	void (*write_stream) (GttGhtml *, const char *, size_t len, gpointer);
-	void (*close_stream) (GttGhtml *, gpointer);
-	void (*error) (GttGhtml *, int errcode, const char * msg, gpointer);
-	gpointer user_data;
+    /* stream interface for writing */
+    void (*open_stream)(GttGhtml *, gpointer);
+    void (*write_stream)(GttGhtml *, const char *, size_t len, gpointer);
+    void (*close_stream)(GttGhtml *, gpointer);
+    void (*error)(GttGhtml *, int errcode, const char *msg, gpointer);
+    gpointer user_data;
 
-	/* open_count and ref_path used for recursive file includes */
-	int open_count;
-	const char * ref_path;
+    /* open_count and ref_path used for recursive file includes */
+    int open_count;
+    const char *ref_path;
 
-	/* Key-Value Pair data; includes HTML form GET/POST results. */
-	KvpFrame *kvp;
-	
-	/* The 'linked' project */
-	GttProject *prj;
-	
-	/* List of projects, returned as query result */
-	GList *query_result;
-	gboolean did_query; /* TRUE if query was run */
-	
-	gboolean show_links; /* Flag -- show internal <a href> links */
-	gboolean really_hide_links; /* Flag -- show internal <a href> links */
+    /* Key-Value Pair data; includes HTML form GET/POST results. */
+    KvpFrame *kvp;
 
-	time_t last_ivl_time;  /* hack for pretty-printing interval dates */
+    /* The 'linked' project */
+    GttProject *prj;
 
-	/* ------------------------------------------------------ */
-	/* Deprecated portion of this struct -- will go away someday. */
-	/* Used only by ghtml-deprecated.c */
-	/* Table layout info */
+    /* List of projects, returned as query result */
+    GList *query_result;
+    gboolean did_query; /* TRUE if query was run */
 
-	gboolean show_html;  /* Flag -- add html markup, or not */
+    gboolean show_links;        /* Flag -- show internal <a href> links */
+    gboolean really_hide_links; /* Flag -- show internal <a href> links */
 
-	/* field delimiter, for tab/comma delim */
-	char * delim;
+    time_t last_ivl_time; /* hack for pretty-printing interval dates */
+
+    /* ------------------------------------------------------ */
+    /* Deprecated portion of this struct -- will go away someday. */
+    /* Used only by ghtml-deprecated.c */
+    /* Table layout info */
+
+    gboolean show_html; /* Flag -- add html markup, or not */
+
+    /* field delimiter, for tab/comma delim */
+    char *delim;
 
 #define NCOL 30
-	int ntask_cols;
-	int task_cols[NCOL];
-	char * task_titles[NCOL];
+    int ntask_cols;
+    int task_cols[NCOL];
+    char *task_titles[NCOL];
 
-	int ninvl_cols;
-	int invl_cols[NCOL];
-	char * invl_titles[NCOL];
+    int ninvl_cols;
+    int invl_cols[NCOL];
+    char *invl_titles[NCOL];
 
-	char **tp;
+    char **tp;
 };
 
 extern GttGhtml *ghtml_guile_global_hack;
 
+GttGhtml *gtt_ghtml_new(void);
+void gtt_ghtml_destroy(GttGhtml *p);
 
-GttGhtml * gtt_ghtml_new (void);
-void gtt_ghtml_destroy (GttGhtml *p);
+typedef void (*GttGhtmlOpenStream)(GttGhtml *, gpointer);
+typedef void (*GttGhtmlWriteStream)(GttGhtml *, const char *, size_t len, gpointer);
+typedef void (*GttGhtmlCloseStream)(GttGhtml *, gpointer);
+typedef void (*GttGhtmlError)(GttGhtml *, int errcode, const char *msg, gpointer);
 
-typedef void (*GttGhtmlOpenStream) (GttGhtml *, gpointer);
-typedef void (*GttGhtmlWriteStream) (GttGhtml *, const char *, size_t len, gpointer);
-typedef void (*GttGhtmlCloseStream) (GttGhtml *, gpointer);
-typedef void (*GttGhtmlError) (GttGhtml *, int errcode, const char * msg, gpointer);
-
-void gtt_ghtml_set_stream (GttGhtml *, gpointer user_data,
-                                       GttGhtmlOpenStream,
-                                       GttGhtmlWriteStream,
-                                       GttGhtmlCloseStream,
-                                       GttGhtmlError);
+void gtt_ghtml_set_stream(
+    GttGhtml *, gpointer user_data, GttGhtmlOpenStream, GttGhtmlWriteStream,
+    GttGhtmlCloseStream, GttGhtmlError
+);
 
 /** The gtt_ghtml_display() routine will parse the indicated gtt file,
  *     and output standard HTML to the indicated stream.
  */
-void gtt_ghtml_display (GttGhtml *, const char *path_frag, GttProject *prj);
+void gtt_ghtml_display(GttGhtml *, const char *path_frag, GttProject *prj);
 
 /** The gtt_gthml_show_links() routine will set a flag indicating whether
  *     the output html should include internal <a href> links.  Normally,
  *     this should be set to TRUE when displaying in the internal browser,
  *     and FALSE when printing.
  */
-void gtt_ghtml_show_links (GttGhtml *, gboolean);
+void gtt_ghtml_show_links(GttGhtml *, gboolean);
 
 /** The gtt_ghtml_resolve_path() routine helps find the fully-qualified
  *     path name to the indicated filename, so that the file can be opened.
@@ -126,7 +124,6 @@ void gtt_ghtml_show_links (GttGhtml *, gboolean);
  *     is not found, then the standard gnotime data dirs are checked.
  *     The checked data dirs are locale-dependent.
  */
-char * gtt_ghtml_resolve_path (const char *path_frag, const char *reference_path);
+char *gtt_ghtml_resolve_path(const char *path_frag, const char *reference_path);
 
 #endif /* __GTT_GHTML_H__ */
-

--- a/src/gtt.h
+++ b/src/gtt.h
@@ -19,12 +19,11 @@
 #ifndef __GTT_H__
 #define __GTT_H__
 
-
 #include <gnome.h>
 
-#define GTT_APP_TITLE        "Gnome Time Tracker"
-#define GTT_APP_PROPER_NAME  "GnoTime"
-#define GTT_APP_NAME         "gnotime"
+#define GTT_APP_TITLE "Gnome Time Tracker"
+#define GTT_APP_PROPER_NAME "GnoTime"
+#define GTT_APP_NAME "gnotime"
 
 #define XML_DATA_FILENAME "gnotime.d/gnotime-data.xml"
 
@@ -37,27 +36,26 @@ void err_init(void);
 /* The save_all() routine will write out all state to files.
  *    If an error occurs, it returns an error message.
  */
-char * save_all (void);
+char *save_all(void);
 
 /* The save_properties() routine will write out the application
  * properties to the application file.  It will pop up a warning
  * gui window if the save fails for some reason.
  */
-void save_properties (void);
+void save_properties(void);
 
 /* The save_projects() routine will write out the project data
  * to the data file.  It will pop up a warning
  * gui window if the save fails for some reason.
  */
-void save_projects (void);
+void save_projects(void);
 
 /* The read_data() routine will load the project data file
    and setup the interface with the new data
  */
-void read_data (gboolean);
+void read_data(gboolean);
 
 void unlock_gtt(void);
 const char *gtt_gettext(const char *s);
-
 
 #endif /* __GTT_H__ */

--- a/src/idle-dialog.c
+++ b/src/idle-dialog.c
@@ -19,9 +19,9 @@
 
 #include "config.h"
 
-#include <glib.h>
-#include <glade/glade.h>
 #include <gdk/gdkx.h>
+#include <glade/glade.h>
+#include <glib.h>
 #include <gnome.h>
 #include <string.h>
 
@@ -30,151 +30,141 @@
 
 #include <qof.h>
 
+#include "app.h"
 #include "cur-proj.h"
-#include "idle-dialog.h"
 #include "dialog.h"
+#include "idle-dialog.h"
 #include "proj.h"
 #include "util.h"
-#include "app.h"
 
 int config_idle_timeout = -1;
 
 struct GttIdleDialog_s
 {
-	GladeXML    *gtxml;
-	GtkDialog   *dlg;
-	GtkButton   *yes_btn;
-	GtkButton   *no_btn;
-	GtkButton   *help_btn;
-	GtkLabel    *idle_label;
-	GtkLabel    *credit_label;
-	GtkLabel    *time_label;
-	GtkRange    *scale;
+    GladeXML *gtxml;
+    GtkDialog *dlg;
+    GtkButton *yes_btn;
+    GtkButton *no_btn;
+    GtkButton *help_btn;
+    GtkLabel *idle_label;
+    GtkLabel *credit_label;
+    GtkLabel *time_label;
+    GtkRange *scale;
 
-	Display     *display;
-	gboolean    xss_extension_supported;
-	XScreenSaverInfo *xss_info;
-	guint       timeout_event_source;
+    Display *display;
+    gboolean xss_extension_supported;
+    XScreenSaverInfo *xss_info;
+    guint timeout_event_source;
 
-	gboolean    visible;
+    gboolean visible;
 
-	GttProject  *prj;
-	time_t      last_activity;
-	time_t      previous_credit;
+    GttProject *prj;
+    time_t last_activity;
+    time_t previous_credit;
 };
 
-static gboolean idle_timeout_func (gpointer data);
+static gboolean idle_timeout_func(gpointer data);
 
-static void
-schedule_idle_timeout (gint timeout, GttIdleDialog *idle_dialog)
+static void schedule_idle_timeout(gint timeout, GttIdleDialog *idle_dialog)
 {
-	if (idle_dialog->timeout_event_source != 0)
-	{
-		g_source_remove (idle_dialog->timeout_event_source);
-	}
-	if (timeout > 0 && idle_dialog->xss_extension_supported)
-	{
-		/* If we already have an idle timeout
-		 * sceduled, cancel it.
-		 */
-		idle_dialog->timeout_event_source = g_timeout_add_seconds (timeout, idle_timeout_func, idle_dialog);
-	}
+    if (idle_dialog->timeout_event_source != 0)
+    {
+        g_source_remove(idle_dialog->timeout_event_source);
+    }
+    if (timeout > 0 && idle_dialog->xss_extension_supported)
+    {
+        /* If we already have an idle timeout
+         * sceduled, cancel it.
+         */
+        idle_dialog->timeout_event_source
+            = g_timeout_add_seconds(timeout, idle_timeout_func, idle_dialog);
+    }
 }
 
-static gboolean
-idle_timeout_func (gpointer data)
+static gboolean idle_timeout_func(gpointer data)
 {
-	GttIdleDialog *idle_dialog = (GttIdleDialog *) data;
-	GdkWindow *gdk_window = gtk_widget_get_root_window (app_window);
-	XID drawable = gdk_x11_drawable_get_xid (GDK_DRAWABLE(gdk_window));
-	Status xss_query_ok = XScreenSaverQueryInfo (idle_dialog->display,
-												 drawable,
-												 idle_dialog->xss_info);
-	if (xss_query_ok)
-	{
-		int idle_seconds = idle_dialog->xss_info->idle / 1000;
-		if (cur_proj != NULL &&
-			config_idle_timeout > 0 &&
-			idle_seconds >= config_idle_timeout)
-		{
-			time_t now = time(0);
-			idle_dialog->last_activity = now - idle_seconds;
-			show_idle_dialog (idle_dialog);
-			/* schedule a new timeout for one minute ahead to
-			   update the dialog. */
-			schedule_idle_timeout (60,  idle_dialog);
-		}
-		else
-		{
-			if (cur_proj != NULL)
-			{
-				schedule_idle_timeout (config_idle_timeout - idle_seconds, idle_dialog);
-			}
-			else if (idle_dialog->visible)
-			{
-				raise_idle_dialog (idle_dialog);
-				schedule_idle_timeout (60, idle_dialog);
-			}
-		}
-	}
-	return FALSE;
-}
-
-
-/* =========================================================== */
-
-static void
-help_cb (GObject *obj, GttIdleDialog *dlg)
-{
-	gtt_help_popup (GTK_WIDGET(dlg->dlg), "idletimer");
+    GttIdleDialog *idle_dialog = (GttIdleDialog *) data;
+    GdkWindow *gdk_window = gtk_widget_get_root_window(app_window);
+    XID drawable = gdk_x11_drawable_get_xid(GDK_DRAWABLE(gdk_window));
+    Status xss_query_ok
+        = XScreenSaverQueryInfo(idle_dialog->display, drawable, idle_dialog->xss_info);
+    if (xss_query_ok)
+    {
+        int idle_seconds = idle_dialog->xss_info->idle / 1000;
+        if (cur_proj != NULL && config_idle_timeout > 0 && idle_seconds >= config_idle_timeout)
+        {
+            time_t now = time(0);
+            idle_dialog->last_activity = now - idle_seconds;
+            show_idle_dialog(idle_dialog);
+            /* schedule a new timeout for one minute ahead to
+               update the dialog. */
+            schedule_idle_timeout(60, idle_dialog);
+        }
+        else
+        {
+            if (cur_proj != NULL)
+            {
+                schedule_idle_timeout(config_idle_timeout - idle_seconds, idle_dialog);
+            }
+            else if (idle_dialog->visible)
+            {
+                raise_idle_dialog(idle_dialog);
+                schedule_idle_timeout(60, idle_dialog);
+            }
+        }
+    }
+    return FALSE;
 }
 
 /* =========================================================== */
 
-static void
-dialog_close (GObject *obj, GttIdleDialog *dlg)
+static void help_cb(GObject *obj, GttIdleDialog *dlg)
 {
-	dlg->dlg = NULL;
-	dlg->gtxml = NULL;
-	dlg->visible = FALSE;
+    gtt_help_popup(GTK_WIDGET(dlg->dlg), "idletimer");
 }
 
 /* =========================================================== */
 
-static void
-dialog_kill (GObject *obj, GttIdleDialog *dlg)
+static void dialog_close(GObject *obj, GttIdleDialog *dlg)
 {
-	gtk_widget_destroy (GTK_WIDGET(dlg->dlg));
-	dlg->dlg = NULL;
-	dlg->gtxml = NULL;
-	dlg->visible = FALSE;
+    dlg->dlg = NULL;
+    dlg->gtxml = NULL;
+    dlg->visible = FALSE;
 }
 
 /* =========================================================== */
 
-static void
-restart_proj (GObject *obj, GttIdleDialog *dlg)
+static void dialog_kill(GObject *obj, GttIdleDialog *dlg)
 {
-	dlg->last_activity = time(0);  /* bug fix, sometimes events are lost */
-	cur_proj_set (dlg->prj);
-	dialog_kill (obj, dlg);
+    gtk_widget_destroy(GTK_WIDGET(dlg->dlg));
+    dlg->dlg = NULL;
+    dlg->gtxml = NULL;
+    dlg->visible = FALSE;
 }
 
 /* =========================================================== */
 
-static void
-adjust_timer (GttIdleDialog *dlg, time_t adjustment)
+static void restart_proj(GObject *obj, GttIdleDialog *dlg)
 {
-	GttInterval *ivl;
-	time_t stop;
-	
-	ivl = gtt_project_get_first_interval (dlg->prj);
-	stop = gtt_interval_get_stop (ivl);
-	stop -= dlg->previous_credit;
-	stop += adjustment;
-	gtt_interval_set_stop (ivl, stop);
+    dlg->last_activity = time(0); /* bug fix, sometimes events are lost */
+    cur_proj_set(dlg->prj);
+    dialog_kill(obj, dlg);
+}
 
-	dlg->previous_credit = adjustment;
+/* =========================================================== */
+
+static void adjust_timer(GttIdleDialog *dlg, time_t adjustment)
+{
+    GttInterval *ivl;
+    time_t stop;
+
+    ivl = gtt_project_get_first_interval(dlg->prj);
+    stop = gtt_interval_get_stop(ivl);
+    stop -= dlg->previous_credit;
+    stop += adjustment;
+    gtt_interval_set_stop(ivl, stop);
+
+    dlg->previous_credit = adjustment;
 }
 
 /* =========================================================== */
@@ -184,152 +174,152 @@ adjust_timer (GttIdleDialog *dlg, time_t adjustment)
  * free the returned string when done.
  */
 
-static char *
-util_escape_html_markup (const char *str)
+static char *util_escape_html_markup(const char *str)
 {
-	char * p;
-	char * ret;
+    char *p;
+    char *ret;
 
-	if (str == NULL) return g_strdup("");
+    if (str == NULL)
+        return g_strdup("");
 
-	p = strchr (str, '&');
-	if (!p) return g_strdup (str);
+    p = strchr(str, '&');
+    if (!p)
+        return g_strdup(str);
 
-	/* count number of ampersands */
-	int ampcnt = 0;
-	while (p)
-	{
-		ampcnt ++;
-		p = strchr (p+1, '&');
-	}
-	
-	/* make room for the escapes */
-	int len = strlen(str);
-	ret = g_new0 (char, len+4*ampcnt+1);
-	
-	/* replace & by &amp; unless its already &amp; */
-	p = strchr (str, '&');
-	const char *start = str;
-	while (p)
-	{
-		strncat (ret, start, p-start);
-		if (strncmp (p, "&amp;", 5))
-		{
-			strcat (ret, "&amp;");
-		}
-		else
-		{
-			strcat (ret, "&");
-		}
-		start = p+1;
-		p = strchr (start, '&');
-	}
-	strcat (ret, start);
-	return ret;
+    /* count number of ampersands */
+    int ampcnt = 0;
+    while (p)
+    {
+        ampcnt++;
+        p = strchr(p + 1, '&');
+    }
+
+    /* make room for the escapes */
+    int len = strlen(str);
+    ret = g_new0(char, len + 4 * ampcnt + 1);
+
+    /* replace & by &amp; unless its already &amp; */
+    p = strchr(str, '&');
+    const char *start = str;
+    while (p)
+    {
+        strncat(ret, start, p - start);
+        if (strncmp(p, "&amp;", 5))
+        {
+            strcat(ret, "&amp;");
+        }
+        else
+        {
+            strcat(ret, "&");
+        }
+        start = p + 1;
+        p = strchr(start, '&');
+    }
+    strcat(ret, start);
+    return ret;
 }
 
 /* =========================================================== */
 
-static void
-display_value (GttIdleDialog *dlg, time_t credit)
+static void display_value(GttIdleDialog *dlg, time_t credit)
 {
-	char tbuff [30];
-	char mbuff [130];
-	char * msg;
-	time_t now = time(0);
-	time_t idle_time;
-	
-	/* Set a value for the thingy under the slider */
-	if (3600 > credit)
-	{
-		xxxqof_print_minutes_elapsed_buff (tbuff, 30, credit, TRUE);
-		g_snprintf (mbuff, 130, _("%s minutes"), tbuff);
-	}
-	else
-	{
-		xxxqof_print_hours_elapsed_buff (tbuff, 30, credit, FALSE);
-		g_snprintf (mbuff, 130, _("%s hours"), tbuff);
-	}
-	gtk_label_set_text (dlg->time_label, mbuff);
-	
-	/* Set a value in the main message; show hours,
-	 * or minutes, as is more appropriate.
-	 */
-	if (3600 > credit)
-	{
-		msg = g_strdup_printf (
-		         _("The timer will be credited "
-		           "with %ld minutes since the last keyboard/mouse "
-		           "activity.  If you want to change the amount "
-		           "of time credited, use the slider below to "
-		           "adjust the value."),
-		           (credit+30)/60);
-	}
-	else
-	{
-		msg = g_strdup_printf (
-		         _("The timer will be credited "
-		           "with %s hours since the last keyboard/mouse "
-		           "activity.  If you want to change the amount "
-		           "of time credited, use the slider below to "
-		           "adjust the value."),
-		           tbuff);
-	}
-	gtk_label_set_text (dlg->credit_label, msg);
-	g_free (msg);
+    char tbuff[30];
+    char mbuff[130];
+    char *msg;
+    time_t now = time(0);
+    time_t idle_time;
 
-	/* Update the total elapsed time part of the message */
-	idle_time = now - dlg->last_activity;
-	
-	char *ptitle = util_escape_html_markup (
-	                            gtt_project_get_title(dlg->prj));
-	char *pdesc = util_escape_html_markup (
-	                            gtt_project_get_desc(dlg->prj));
-	if (3600 > idle_time)
-	{
-		msg = g_strdup_printf (
-			_("The keyboard and mouse have been idle "
-			  "for %ld minutes.  The currently running "
-			  "project, <b><i>%s - %s</i></b>, "
-			  "has been stopped. "
-			  "Do you want to restart it?"),
-			(idle_time+30)/60, ptitle, pdesc);
-	}
-	else
-	{
-		msg = g_strdup_printf (
-			_("The keyboard and mouse have been idle "
-			  "for %ld:%02ld hours.  The currently running "
-			  "project (%s - %s) "
-			  "has been stopped. "
-			  "Do you want to restart it?"),
-			(idle_time+30)/3600, ((idle_time+30)/60)%60,
-		   ptitle, pdesc);
-	}
-	
-	gtk_label_set_markup (dlg->idle_label, msg);
-	g_free (msg);
-	g_free (ptitle);
-	g_free (pdesc);
+    /* Set a value for the thingy under the slider */
+    if (3600 > credit)
+    {
+        xxxqof_print_minutes_elapsed_buff(tbuff, 30, credit, TRUE);
+        g_snprintf(mbuff, 130, _("%s minutes"), tbuff);
+    }
+    else
+    {
+        xxxqof_print_hours_elapsed_buff(tbuff, 30, credit, FALSE);
+        g_snprintf(mbuff, 130, _("%s hours"), tbuff);
+    }
+    gtk_label_set_text(dlg->time_label, mbuff);
+
+    /* Set a value in the main message; show hours,
+     * or minutes, as is more appropriate.
+     */
+    if (3600 > credit)
+    {
+        msg = g_strdup_printf(
+            _("The timer will be credited "
+              "with %ld minutes since the last keyboard/mouse "
+              "activity.  If you want to change the amount "
+              "of time credited, use the slider below to "
+              "adjust the value."),
+            (credit + 30) / 60
+        );
+    }
+    else
+    {
+        msg = g_strdup_printf(
+            _("The timer will be credited "
+              "with %s hours since the last keyboard/mouse "
+              "activity.  If you want to change the amount "
+              "of time credited, use the slider below to "
+              "adjust the value."),
+            tbuff
+        );
+    }
+    gtk_label_set_text(dlg->credit_label, msg);
+    g_free(msg);
+
+    /* Update the total elapsed time part of the message */
+    idle_time = now - dlg->last_activity;
+
+    char *ptitle = util_escape_html_markup(gtt_project_get_title(dlg->prj));
+    char *pdesc = util_escape_html_markup(gtt_project_get_desc(dlg->prj));
+    if (3600 > idle_time)
+    {
+        msg = g_strdup_printf(
+            _("The keyboard and mouse have been idle "
+              "for %ld minutes.  The currently running "
+              "project, <b><i>%s - %s</i></b>, "
+              "has been stopped. "
+              "Do you want to restart it?"),
+            (idle_time + 30) / 60, ptitle, pdesc
+        );
+    }
+    else
+    {
+        msg = g_strdup_printf(
+            _("The keyboard and mouse have been idle "
+              "for %ld:%02ld hours.  The currently running "
+              "project (%s - %s) "
+              "has been stopped. "
+              "Do you want to restart it?"),
+            (idle_time + 30) / 3600, ((idle_time + 30) / 60) % 60, ptitle, pdesc
+        );
+    }
+
+    gtk_label_set_markup(dlg->idle_label, msg);
+    g_free(msg);
+    g_free(ptitle);
+    g_free(pdesc);
 }
 
 /* =========================================================== */
 
-static void
-value_changed (GObject *obj, GttIdleDialog *dlg)
+static void value_changed(GObject *obj, GttIdleDialog *dlg)
 {
-	double slider_value;
-	time_t credit;
-	time_t now = time(0);
+    double slider_value;
+    time_t credit;
+    time_t now = time(0);
 
-	slider_value = gtk_range_get_value (dlg->scale);
-	slider_value /= 90.0;
-	slider_value *= (now - dlg->last_activity);
+    slider_value = gtk_range_get_value(dlg->scale);
+    slider_value /= 90.0;
+    slider_value *= (now - dlg->last_activity);
 
-	credit = (time_t) slider_value;
-	
-	display_value (dlg, credit);  /* display value in GUI */
-	adjust_timer (dlg, credit);   /* change value in data store */
+    credit = (time_t) slider_value;
+
+    display_value(dlg, credit); /* display value in GUI */
+    adjust_timer(dlg, credit);  /* change value in data store */
 }
 
 /* =========================================================== */
@@ -338,174 +328,162 @@ value_changed (GObject *obj, GttIdleDialog *dlg)
  * do a heavyweight re-initialization each time.  Urgh.
  */
 
-static void
-idle_dialog_realize (GttIdleDialog * id)
+static void idle_dialog_realize(GttIdleDialog *id)
 {
-	GladeXML *gtxml;
+    GladeXML *gtxml;
 
-	id->prj = NULL;
+    id->prj = NULL;
 
-	gtxml = gtt_glade_xml_new ("glade/idle.glade", "Idle Dialog");
-	id->gtxml = gtxml;
+    gtxml = gtt_glade_xml_new("glade/idle.glade", "Idle Dialog");
+    id->gtxml = gtxml;
 
-	id->dlg = GTK_DIALOG (glade_xml_get_widget (gtxml, "Idle Dialog"));
+    id->dlg = GTK_DIALOG(glade_xml_get_widget(gtxml, "Idle Dialog"));
 
-	id->yes_btn = GTK_BUTTON(glade_xml_get_widget (gtxml, "yes button"));
-	id->no_btn  = GTK_BUTTON(glade_xml_get_widget (gtxml, "no button"));
-	id->help_btn = GTK_BUTTON(glade_xml_get_widget (gtxml, "helpbutton1"));
-	id->idle_label = GTK_LABEL (glade_xml_get_widget (gtxml, "idle label"));
-	id->credit_label = GTK_LABEL (glade_xml_get_widget (gtxml, "credit label"));
-	id->time_label = GTK_LABEL (glade_xml_get_widget (gtxml, "time label"));
-	id->scale = GTK_RANGE (glade_xml_get_widget (gtxml, "scale"));
+    id->yes_btn = GTK_BUTTON(glade_xml_get_widget(gtxml, "yes button"));
+    id->no_btn = GTK_BUTTON(glade_xml_get_widget(gtxml, "no button"));
+    id->help_btn = GTK_BUTTON(glade_xml_get_widget(gtxml, "helpbutton1"));
+    id->idle_label = GTK_LABEL(glade_xml_get_widget(gtxml, "idle label"));
+    id->credit_label = GTK_LABEL(glade_xml_get_widget(gtxml, "credit label"));
+    id->time_label = GTK_LABEL(glade_xml_get_widget(gtxml, "time label"));
+    id->scale = GTK_RANGE(glade_xml_get_widget(gtxml, "scale"));
 
-	g_signal_connect(G_OBJECT(id->dlg), "destroy",
-	          G_CALLBACK(dialog_close), id);
+    g_signal_connect(G_OBJECT(id->dlg), "destroy", G_CALLBACK(dialog_close), id);
 
-	g_signal_connect(G_OBJECT(id->yes_btn), "clicked",
-	          G_CALLBACK(restart_proj), id);
+    g_signal_connect(G_OBJECT(id->yes_btn), "clicked", G_CALLBACK(restart_proj), id);
 
-	g_signal_connect(G_OBJECT(id->no_btn), "clicked",
-	          G_CALLBACK(dialog_kill), id);
+    g_signal_connect(G_OBJECT(id->no_btn), "clicked", G_CALLBACK(dialog_kill), id);
 
-	g_signal_connect(G_OBJECT(id->help_btn), "clicked",
-	          G_CALLBACK(help_cb), id);
+    g_signal_connect(G_OBJECT(id->help_btn), "clicked", G_CALLBACK(help_cb), id);
 
-	g_signal_connect(G_OBJECT(id->scale), "value_changed",
-	          G_CALLBACK(value_changed), id);
-
+    g_signal_connect(G_OBJECT(id->scale), "value_changed", G_CALLBACK(value_changed), id);
 }
 
 /* =========================================================== */
 
-GttIdleDialog *
-idle_dialog_new (void)
+GttIdleDialog *idle_dialog_new(void)
 {
-	GttIdleDialog *id;
+    GttIdleDialog *id;
 
-	id = g_new0 (GttIdleDialog, 1);
-	id->prj = NULL;
+    id = g_new0(GttIdleDialog, 1);
+    id->prj = NULL;
 
-	id->gtxml = NULL;
+    id->gtxml = NULL;
 
-	gchar *display_name = gdk_get_display ();
-	id->display = XOpenDisplay (display_name);
-	if (id->display == NULL)
-	{
-		g_warning ("Could not open display %s", display_name);
-	}
-	else
-	{
-		int xss_events, xss_error;
-		id->xss_extension_supported = XScreenSaverQueryExtension (id->display, &xss_events, &xss_error);
-		if (id->xss_extension_supported)
-		{
-			id->xss_info = XScreenSaverAllocInfo ();
-			if (config_idle_timeout > 0)
-			{
-				schedule_idle_timeout (config_idle_timeout, id);
-			}
-		}
-		else
-		{
-			g_warning (_("The XScreenSaver is not supported on this display.\n"
-						 "The idle timeout functionality will not be available."));
-		}
-	}
-	g_free(display_name);
-	
-	return id;
+    gchar *display_name = gdk_get_display();
+    id->display = XOpenDisplay(display_name);
+    if (id->display == NULL)
+    {
+        g_warning("Could not open display %s", display_name);
+    }
+    else
+    {
+        int xss_events, xss_error;
+        id->xss_extension_supported
+            = XScreenSaverQueryExtension(id->display, &xss_events, &xss_error);
+        if (id->xss_extension_supported)
+        {
+            id->xss_info = XScreenSaverAllocInfo();
+            if (config_idle_timeout > 0)
+            {
+                schedule_idle_timeout(config_idle_timeout, id);
+            }
+        }
+        else
+        {
+            g_warning(_("The XScreenSaver is not supported on this display.\n"
+                        "The idle timeout functionality will not be available."));
+        }
+    }
+    g_free(display_name);
+
+    return id;
 }
 
 /* =========================================================== */
 
-void
-show_idle_dialog (GttIdleDialog *id)
+void show_idle_dialog(GttIdleDialog *id)
 {
-	time_t now;
-	time_t idle_time;
-	GttProject *prj = cur_proj;
+    time_t now;
+    time_t idle_time;
+    GttProject *prj = cur_proj;
 
-	if (!id) return;
-	if (0 > config_idle_timeout) return;
-	if (!prj) return;
+    if (!id)
+        return;
+    if (0 > config_idle_timeout)
+        return;
+    if (!prj)
+        return;
 
-	now = time(0);
-	idle_time = now - id->last_activity;
+    now = time(0);
+    idle_time = now - id->last_activity;
 
-	/* Due to GtkDialog broken-ness, re-realize the GUI */
-	if (NULL == id->gtxml)
-	{
-		idle_dialog_realize (id);
-	}
+    /* Due to GtkDialog broken-ness, re-realize the GUI */
+    if (NULL == id->gtxml)
+    {
+        idle_dialog_realize(id);
+    }
 
-	/* Mark the idle dialog as visible so we don't start the no
-	 * project timeout timer when it's not needed.
-	 */
-	id->visible = TRUE;
+    /* Mark the idle dialog as visible so we don't start the no
+     * project timeout timer when it's not needed.
+     */
+    id->visible = TRUE;
 
-	/* Stop the timer on the current project */
-	cur_proj_set (NULL);
+    /* Stop the timer on the current project */
+    cur_proj_set(NULL);
 
-	id->prj = prj;
+    id->prj = prj;
 
-	/* The idle timer can trip because gtt was left running
-	 * on a laptop, which was them put in suspend mode (i.e.
-	 * by closing the cover).  When the laptop is resumed,
-	 * the poll_last_activity will return the many hours/days
-	 * that the laptop has been shut down, and merely stoping
-	 * the timer (as above) will credit hours/days to the
-	 * current active project.  We don't want this, we need
-	 * to undo this damage.
-	 */
-	id->previous_credit = idle_time;
-	adjust_timer (id, config_idle_timeout);
+    /* The idle timer can trip because gtt was left running
+     * on a laptop, which was them put in suspend mode (i.e.
+     * by closing the cover).  When the laptop is resumed,
+     * the poll_last_activity will return the many hours/days
+     * that the laptop has been shut down, and merely stoping
+     * the timer (as above) will credit hours/days to the
+     * current active project.  We don't want this, we need
+     * to undo this damage.
+     */
+    id->previous_credit = idle_time;
+    adjust_timer(id, config_idle_timeout);
 
-
-	raise_idle_dialog (id);
-
+    raise_idle_dialog(id);
 }
 
 /* =========================================================== */
 
-void
-raise_idle_dialog (GttIdleDialog *id)
+void raise_idle_dialog(GttIdleDialog *id)
 {
-	g_return_if_fail(id);
-	g_return_if_fail(id->gtxml);
+    g_return_if_fail(id);
+    g_return_if_fail(id->gtxml);
 
-	/* Now, draw the messages in the GUI popup. */
-	display_value (id, config_idle_timeout);
+    /* Now, draw the messages in the GUI popup. */
+    display_value(id, config_idle_timeout);
 
+    /* The following will raise the window, and put it on the current
+     * workspace, at least if the metacity WM is used. Haven't tried
+     * other window managers.
+     */
 
-	/* The following will raise the window, and put it on the current
-	 * workspace, at least if the metacity WM is used. Haven't tried
-	 * other window managers.
-	 */
-
-	gtk_window_present (GTK_WINDOW (id->dlg));
-	id->visible = TRUE;
+    gtk_window_present(GTK_WINDOW(id->dlg));
+    id->visible = TRUE;
 }
 
-void
-idle_dialog_activate_timer (GttIdleDialog *idle_dialog)
+void idle_dialog_activate_timer(GttIdleDialog *idle_dialog)
 {
-	schedule_idle_timeout (config_idle_timeout, idle_dialog);
+    schedule_idle_timeout(config_idle_timeout, idle_dialog);
 }
 
-void
-idle_dialog_deactivate_timer (GttIdleDialog *idle_dialog)
+void idle_dialog_deactivate_timer(GttIdleDialog *idle_dialog)
 {
-	if (idle_dialog->timeout_event_source != 0)
-	{
-		g_source_remove (idle_dialog->timeout_event_source);
-		idle_dialog->timeout_event_source = 0;
-	}
+    if (idle_dialog->timeout_event_source != 0)
+    {
+        g_source_remove(idle_dialog->timeout_event_source);
+        idle_dialog->timeout_event_source = 0;
+    }
 }
 
-gboolean
-idle_dialog_is_visible(GttIdleDialog *idle_dialog)
+gboolean idle_dialog_is_visible(GttIdleDialog *idle_dialog)
 {
-	return idle_dialog->visible;
+    return idle_dialog->visible;
 }
 
 /* =========================== END OF FILE ============================== */

--- a/src/idle-dialog.h
+++ b/src/idle-dialog.h
@@ -38,7 +38,7 @@
 
 typedef struct GttIdleDialog_s GttIdleDialog;
 
-GttIdleDialog * idle_dialog_new (void);
+GttIdleDialog *idle_dialog_new(void);
 
 /** This routine will display the idle dialog, but only
  *  if the keyboard/mouse has been idle for some amount of time.
@@ -46,7 +46,7 @@ GttIdleDialog * idle_dialog_new (void);
  *  be stopped (and the ctree display to be updated to reflect the
  *  stopped project).
  */
-void show_idle_dialog (GttIdleDialog *id);
+void show_idle_dialog(GttIdleDialog *id);
 
 /** This routine will raise the idle dialog to the top of the
  *  current screen. But it will do this only if the idle dialog
@@ -56,17 +56,16 @@ void show_idle_dialog (GttIdleDialog *id);
  *  another window, or it ends up on a different workspace than the
  *  current workspace, and so the user can't see it, can't find it.
  */
-void raise_idle_dialog (GttIdleDialog *id);
+void raise_idle_dialog(GttIdleDialog *id);
 
 /** This routine will activate the idle timer, so that the idle dialog
  *  is raised when needed.
  */
-void idle_dialog_activate_timer (GttIdleDialog *id);
-
+void idle_dialog_activate_timer(GttIdleDialog *id);
 
 /** This routine will deactivate the idle timer.
  */
-void idle_dialog_deactivate_timer (GttIdleDialog *id);
+void idle_dialog_deactivate_timer(GttIdleDialog *id);
 
 gboolean idle_dialog_is_visible(GttIdleDialog *id);
 

--- a/src/idle-timer.c
+++ b/src/idle-timer.c
@@ -46,7 +46,7 @@
 
  */
 
-# include "config.h"
+#include "config.h"
 
 /* #define DEBUG_TIMERS */
 
@@ -58,22 +58,22 @@
 #include <gdk/gdkx.h>
 #include <gtk/gtk.h>
 
+#include <X11/X.h>
+#include <X11/Xlib.h>
+#include <X11/Xos.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <X11/X.h>
-#include <X11/Xlib.h>
-#include <X11/Xos.h>
 
 #ifdef HAVE_XMU
-# ifndef VMS
-#  include <X11/Xmu/Error.h>
-# else /* VMS */
-#  include <Xmu/Error.h>
-# endif /* VMS */
-# else /* !HAVE_XMU */
+#ifndef VMS
+#include <X11/Xmu/Error.h>
+#else /* VMS */
+#include <Xmu/Error.h>
+#endif /* VMS */
+#else  /* !HAVE_XMU */
 /* # include "xmu.h" */
 #endif /* !HAVE_XMU */
 
@@ -90,40 +90,38 @@ typedef struct IdleTimeoutScreen_s IdleTimeoutScreen;
  */
 struct IdleTimeout_s
 {
-  /* pointer_timeout is how often we check for pinter
-   * movements (in seconds) */
-  int pointer_timeout;
+    /* pointer_timeout is how often we check for pinter
+     * movements (in seconds) */
+    int pointer_timeout;
 
-  /* notice_events_timeout is how long we wait before we
-   * walk the the window tree, selecting events on new windows */
-  int notice_events_timeout;
+    /* notice_events_timeout is how long we wait before we
+     * walk the the window tree, selecting events on new windows */
+    int notice_events_timeout;
 
-  int nscreens;
-  IdleTimeoutScreen *screens;
-  IdleTimeoutScreen *default_screen;        /* ...on which dialogs will appear. */
+    int nscreens;
+    IdleTimeoutScreen *screens;
+    IdleTimeoutScreen *default_screen; /* ...on which dialogs will appear. */
 
-  Display *dpy;
+    Display *dpy;
 
-  Bool using_xidle_extension;           /* which extension is being used.         */
-  Bool using_proc_interrupts;
+    Bool using_xidle_extension; /* which extension is being used.         */
+    Bool using_proc_interrupts;
 
-  Bool scanning_all_windows;
-  Bool polling_mouse_position;
+    Bool scanning_all_windows;
+    Bool polling_mouse_position;
 
-  guint check_pointer_timer_id;        /* `prefs.pointer_timeout' */
+    guint check_pointer_timer_id; /* `prefs.pointer_timeout' */
 
-  time_t dispatch_time;                   /* Time of event dispatch. */
-  time_t last_activity_time;           /* Time of last user activity. */
-  time_t last_wall_clock_time;     /* Used to detect laptop suspend. */
-  IdleTimeoutScreen *last_activity_screen;
+    time_t dispatch_time;        /* Time of event dispatch. */
+    time_t last_activity_time;   /* Time of last user activity. */
+    time_t last_wall_clock_time; /* Used to detect laptop suspend. */
+    IdleTimeoutScreen *last_activity_screen;
 
-  Bool emergency_lock_p;        /* Set when the wall clock has jumped
-                                   (presumably due to laptop suspend) and we
-                                   need to lock down right away instead of
-                                   waiting for the lock timer to go off. */
-
+    Bool emergency_lock_p; /* Set when the wall clock has jumped
+                              (presumably due to laptop suspend) and we
+                              need to lock down right away instead of
+                              waiting for the lock timer to go off. */
 };
-
 
 /* This structure holds all the data that applies to the screen-specific parts
    of the display connection; if the display has multiple screens, there will
@@ -131,25 +129,24 @@ struct IdleTimeout_s
  */
 struct IdleTimeoutScreen_s
 {
-  IdleTimeout *global;
+    IdleTimeout *global;
 
-  Screen *screen;
-  // Widget toplevel_shell;
+    Screen *screen;
+    // Widget toplevel_shell;
 
-  int poll_mouse_last_root_x;                /* Used only when no server exts. */
-  int poll_mouse_last_root_y;
-  Window poll_mouse_last_child;
-  unsigned int poll_mouse_last_mask;
+    int poll_mouse_last_root_x; /* Used only when no server exts. */
+    int poll_mouse_last_root_y;
+    Window poll_mouse_last_child;
+    unsigned int poll_mouse_last_mask;
 };
-
 
 /* ===================================================================== */
 
 #ifdef HAVE_PROC_INTERRUPTS
-static Bool proc_interrupts_activity_p (IdleTimeout *si);
+static Bool proc_interrupts_activity_p(IdleTimeout *si);
 #endif /* HAVE_PROC_INTERRUPTS */
 
-static void check_for_clock_skew (IdleTimeout *si);
+static void check_for_clock_skew(IdleTimeout *si);
 
 /* ===================================================================== */
 /* This routine will install event masks on the indicated window,
@@ -157,146 +154,140 @@ static void check_for_clock_skew (IdleTimeout *si);
  * keyboard/strcuture activity in that window.
  */
 
-static void
-notice_events (IdleTimeout *si, Window window, Bool top_p)
+static void notice_events(IdleTimeout *si, Window window, Bool top_p)
 {
-  XWindowAttributes attrs;
-  unsigned long events;
-  Window root, parent, *kids;
-  unsigned int nkids;
-  GdkWindow *gwin;
+    XWindowAttributes attrs;
+    unsigned long events;
+    Window root, parent, *kids;
+    unsigned int nkids;
+    GdkWindow *gwin;
 
-  gwin = gdk_window_lookup (window);
-  if (gwin && (window != DefaultRootWindow (si->dpy)))
-  {
-    /* If it's one of ours, don't mess up its event mask. */
-    return;
-  }
-
-  if (!XQueryTree (si->dpy, window, &root, &parent, &kids, &nkids))
-  {
-    return;
-  }
-  if (window == root) top_p = False;
-
-  XGetWindowAttributes (si->dpy, window, &attrs);
-  events = ((attrs.all_event_masks | attrs.do_not_propagate_mask)
-            & KeyPressMask );
-
-  /* Select for SubstructureNotify on all windows.
-     Select for KeyPress on all windows that already have it selected.
-
-     Note that we can't select for ButtonPress, because of X braindamage:
-     only one client at a time may select for ButtonPress on a given
-     window, though any number can select for KeyPress.  Someone explain
-     *that* to me.
-
-     So, if the user spends a while clicking the mouse without ever moving
-     the mouse or touching the keyboard, we won't know that they've been
-     active, and the screensaver will come on.  That sucks, but I don't
-     know how to get around it.
-   */
-  XSelectInput (si->dpy, window, SubstructureNotifyMask | events);
-
-  if (top_p && (events & KeyPressMask))
+    gwin = gdk_window_lookup(window);
+    if (gwin && (window != DefaultRootWindow(si->dpy)))
     {
-      /* Only mention one window per tree  */
-#ifdef DEBUG
-      /* hack alert -- why does this print statment almost never go ???? */
-      /* key-press events certainly *do* seem to get delivered, so they
-       * must have been selected for ??? */
-       printf ("duude selected KeyPress on 0x%lX\n", (unsigned long) window);
-#endif
-      top_p = False;
+        /* If it's one of ours, don't mess up its event mask. */
+        return;
     }
 
-  if (kids)
+    if (!XQueryTree(si->dpy, window, &root, &parent, &kids, &nkids))
     {
-      while (nkids)
-      {
-         notice_events (si, kids [--nkids], top_p);
-      }
-      XFree ((char *) kids);
+        return;
+    }
+    if (window == root)
+        top_p = False;
+
+    XGetWindowAttributes(si->dpy, window, &attrs);
+    events = ((attrs.all_event_masks | attrs.do_not_propagate_mask) & KeyPressMask);
+
+    /* Select for SubstructureNotify on all windows.
+       Select for KeyPress on all windows that already have it selected.
+
+       Note that we can't select for ButtonPress, because of X braindamage:
+       only one client at a time may select for ButtonPress on a given
+       window, though any number can select for KeyPress.  Someone explain
+       *that* to me.
+
+       So, if the user spends a while clicking the mouse without ever moving
+       the mouse or touching the keyboard, we won't know that they've been
+       active, and the screensaver will come on.  That sucks, but I don't
+       know how to get around it.
+     */
+    XSelectInput(si->dpy, window, SubstructureNotifyMask | events);
+
+    if (top_p && (events & KeyPressMask))
+    {
+        /* Only mention one window per tree  */
+#ifdef DEBUG
+        /* hack alert -- why does this print statment almost never go ???? */
+        /* key-press events certainly *do* seem to get delivered, so they
+         * must have been selected for ??? */
+        printf("duude selected KeyPress on 0x%lX\n", (unsigned long) window);
+#endif
+        top_p = False;
+    }
+
+    if (kids)
+    {
+        while (nkids)
+        {
+            notice_events(si, kids[--nkids], top_p);
+        }
+        XFree((char *) kids);
     }
 }
 
 /* ===================================================================== */
 /* stuff realted to the notice-events timer */
 
-static int
-saver_ehandler (Display *dpy, XErrorEvent *error)
+static int saver_ehandler(Display *dpy, XErrorEvent *error)
 {
 
-  fprintf (stderr, "\n"
-           "#######################################"
-           "#######################################\n\n"
-           "X Error!  PLEASE REPORT THIS BUG.\n");
+    fprintf(
+        stderr, "\n"
+                "#######################################"
+                "#######################################\n\n"
+                "X Error!  PLEASE REPORT THIS BUG.\n"
+    );
 
-  // if (XmuPrintDefaultErrorMessage (dpy, error, stderr))
+    // if (XmuPrintDefaultErrorMessage (dpy, error, stderr))
     {
-      fprintf (stderr, "\n");
-      exit (1);
+        fprintf(stderr, "\n");
+        exit(1);
     }
-  // else
-    fprintf (stderr, " (nonfatal.)\n");
-  return 0;
-}
-
-static int
-BadWindow_ehandler (Display *dpy, XErrorEvent *error)
-{
-  if (error->error_code == BadWindow ||
-      error->error_code == BadMatch ||
-      error->error_code == BadDrawable)
+    // else
+    fprintf(stderr, " (nonfatal.)\n");
     return 0;
-  else
-    return saver_ehandler (dpy, error);
 }
 
-struct notice_events_timer_arg {
-  IdleTimeout *si;
-  Window w;
+static int BadWindow_ehandler(Display *dpy, XErrorEvent *error)
+{
+    if (error->error_code == BadWindow || error->error_code == BadMatch
+        || error->error_code == BadDrawable)
+        return 0;
+    else
+        return saver_ehandler(dpy, error);
+}
+
+struct notice_events_timer_arg
+{
+    IdleTimeout *si;
+    Window w;
 };
 
-static gint
-notice_events_timer (gpointer closure)
+static gint notice_events_timer(gpointer closure)
 {
-  struct notice_events_timer_arg *arg =
-    (struct notice_events_timer_arg *) closure;
-  XErrorHandler old_handler;
-  IdleTimeout *si = arg->si;
-  Window window = arg->w;
+    struct notice_events_timer_arg *arg = (struct notice_events_timer_arg *) closure;
+    XErrorHandler old_handler;
+    IdleTimeout *si = arg->si;
+    Window window = arg->w;
 
-  g_free(arg);
+    g_free(arg);
 
-  /* When we notice a window being created, we spawn a timer that waits
-     30 seconds or so, and then selects events on that window.  This error
-     handler is used so that we can cope with the fact that the window
-     may have been destroyed <30 seconds after it was created.
-   */
-  old_handler = XSetErrorHandler (BadWindow_ehandler);
+    /* When we notice a window being created, we spawn a timer that waits
+       30 seconds or so, and then selects events on that window.  This error
+       handler is used so that we can cope with the fact that the window
+       may have been destroyed <30 seconds after it was created.
+     */
+    old_handler = XSetErrorHandler(BadWindow_ehandler);
 
-  notice_events (si, window, True);
-  XSync (si->dpy, False);
-  XSetErrorHandler (old_handler);
+    notice_events(si, window, True);
+    XSync(si->dpy, False);
+    XSetErrorHandler(old_handler);
 
-  /* we pop once, and we don't pop again */
-  return 0;
+    /* we pop once, and we don't pop again */
+    return 0;
 }
 
-
-static void
-start_notice_events_timer (IdleTimeout *si, Window w)
+static void start_notice_events_timer(IdleTimeout *si, Window w)
 {
-  struct notice_events_timer_arg *arg;
+    struct notice_events_timer_arg *arg;
 
-  /* we want to create a fresh one of these for every
-   * new window. */
-  arg = g_new(struct notice_events_timer_arg, 1);
-  arg->si = si;
-  arg->w = w;
-  gtk_timeout_add ( si->notice_events_timeout *1000,
-                   notice_events_timer, (gpointer) arg);
+    /* we want to create a fresh one of these for every
+     * new window. */
+    arg = g_new(struct notice_events_timer_arg, 1);
+    arg->si = si;
+    arg->w = w;
+    gtk_timeout_add(si->notice_events_timeout * 1000, notice_events_timer, (gpointer) arg);
 }
 
 /* ===================================================================== */
@@ -305,63 +296,58 @@ start_notice_events_timer (IdleTimeout *si, Window w)
    wake up and poll the mouse position, which is possibly more reliable than
    selecting motion events on every window.
  */
-static gint
-check_pointer_timer (gpointer closure)
+static gint check_pointer_timer(gpointer closure)
 {
-  int i;
-  IdleTimeout *si = (IdleTimeout *) closure;
-  Bool active_p = False;
+    int i;
+    IdleTimeout *si = (IdleTimeout *) closure;
+    Bool active_p = False;
 
-  if (!si->using_proc_interrupts &&
-      (si->using_xidle_extension))
-    /* If an extension is in use, we should not be polling the mouse.
-       Unless we're also checking /proc/interrupts, in which case, we should.
-     */
-    abort ();
+    if (!si->using_proc_interrupts && (si->using_xidle_extension))
+        /* If an extension is in use, we should not be polling the mouse.
+           Unless we're also checking /proc/interrupts, in which case, we should.
+         */
+        abort();
 
-  for (i = 0; i < si->nscreens; i++)
+    for (i = 0; i < si->nscreens; i++)
     {
-      IdleTimeoutScreen *ssi = &si->screens[i];
-      Window root, child;
-      int root_x, root_y, x, y;
-      unsigned int mask;
+        IdleTimeoutScreen *ssi = &si->screens[i];
+        Window root, child;
+        int root_x, root_y, x, y;
+        unsigned int mask;
 
-      XQueryPointer (si->dpy, RootWindowOfScreen (ssi->screen), &root, &child,
-                     &root_x, &root_y, &x, &y, &mask);
+        XQueryPointer(
+            si->dpy, RootWindowOfScreen(ssi->screen), &root, &child, &root_x, &root_y, &x, &y,
+            &mask
+        );
 
-      if (root_x == ssi->poll_mouse_last_root_x &&
-          root_y == ssi->poll_mouse_last_root_y &&
-          child  == ssi->poll_mouse_last_child &&
-          mask   == ssi->poll_mouse_last_mask)
-        continue;
+        if (root_x == ssi->poll_mouse_last_root_x && root_y == ssi->poll_mouse_last_root_y
+            && child == ssi->poll_mouse_last_child && mask == ssi->poll_mouse_last_mask)
+            continue;
 
-      active_p = True;
+        active_p = True;
 
-      si->last_activity_screen    = ssi;
-      ssi->poll_mouse_last_root_x = root_x;
-      ssi->poll_mouse_last_root_y = root_y;
-      ssi->poll_mouse_last_child  = child;
-      ssi->poll_mouse_last_mask   = mask;
+        si->last_activity_screen = ssi;
+        ssi->poll_mouse_last_root_x = root_x;
+        ssi->poll_mouse_last_root_y = root_y;
+        ssi->poll_mouse_last_child = child;
+        ssi->poll_mouse_last_mask = mask;
     }
 
 #ifdef HAVE_PROC_INTERRUPTS
-  if (!active_p &&
-      si->using_proc_interrupts &&
-      proc_interrupts_activity_p (si))
+    if (!active_p && si->using_proc_interrupts && proc_interrupts_activity_p(si))
     {
-      active_p = True;
+        active_p = True;
     }
 #endif /* HAVE_PROC_INTERRUPTS */
 
-  if (active_p)
-  {
-    si->last_activity_time = time ((time_t *) 0);
-  }
+    if (active_p)
+    {
+        si->last_activity_time = time((time_t *) 0);
+    }
 
-  check_for_clock_skew (si);
-  return 1;
+    check_for_clock_skew(si);
+    return 1;
 }
-
 
 /* ===================================================================== */
 /* An unfortunate situation is this: the
@@ -376,55 +362,51 @@ check_pointer_timer (gpointer closure)
    This amounts to an assumption that machines with APM support also
    have /proc/interrupts.
  */
-static void
-check_for_clock_skew (IdleTimeout *si)
+static void check_for_clock_skew(IdleTimeout *si)
 {
-  time_t now = time ((time_t *) 0);
+    time_t now = time((time_t *) 0);
 
 #ifdef DEBUG_TIMERS
-  long shift = now - si->last_wall_clock_time;
+    long shift = now - si->last_wall_clock_time;
 
-  fprintf (stderr, "checking wall clock (%d).\n",
-             (si->last_wall_clock_time == 0 ? 0 : shift));
+    fprintf(stderr, "checking wall clock (%d).\n", (si->last_wall_clock_time == 0 ? 0 : shift));
 
-  if (si->last_wall_clock_time != 0 &&
-      shift > (p->timeout / 1000))
+    if (si->last_wall_clock_time != 0 && shift > (p->timeout / 1000))
     {
-      fprintf (stderr, "wall clock has jumped by %ld:%02ld:%02ld!\n",
-                 (shift / (60 * 60)), ((shift / 60) % 60), (shift % 60));
+        fprintf(
+            stderr, "wall clock has jumped by %ld:%02ld:%02ld!\n", (shift / (60 * 60)),
+            ((shift / 60) % 60), (shift % 60)
+        );
     }
 #endif /* DEBUG_TIMERS */
 
-  si->last_wall_clock_time = now;
+    si->last_wall_clock_time = now;
 }
-
 
 /* ===================================================================== */
 
-time_t
-poll_last_activity (IdleTimeout *si)
+time_t poll_last_activity(IdleTimeout *si)
 {
-  if (!si) return 0;
+    if (!si)
+        return 0;
 
 #ifdef HAVE_XIDLE_EXTENSION
     if (si->using_xidle_extension)
     {
-      Time idle;
-      /* The XIDLE extension uses ...
-         ask the server how long the user has been idle. */
-      if (! XGetIdleTime (si->dpy, &idle))
-      {
-         fprintf (stderr, "XGetIdleTime() failed.\n");
-      }
-/* hack alert fixme set the last activity time */
-   }
+        Time idle;
+        /* The XIDLE extension uses ...
+           ask the server how long the user has been idle. */
+        if (!XGetIdleTime(si->dpy, &idle))
+        {
+            fprintf(stderr, "XGetIdleTime() failed.\n");
+        }
+        /* hack alert fixme set the last activity time */
+    }
 #endif /* HAVE_XIDLE_EXTENSION */
 
-  return si->last_activity_time;
+    return si->last_activity_time;
 }
 
-
-
 /* ===================================================================== */
 /* Some crap for dealing with /proc/interrupts.
 
@@ -497,236 +479,241 @@ poll_last_activity (IdleTimeout *si)
    unfortunate to have the screensaver turn off when the modem on COM1 burped.
  */
 
-
 #ifdef HAVE_PROC_INTERRUPTS
 
 #define PROC_INTERRUPTS "/proc/interrupts"
 
-static Bool
-display_is_on_console_p (IdleTimeout *si)
+static Bool display_is_on_console_p(IdleTimeout *si)
 {
-  char * dpy_name = XDisplayName (NULL);
+    char *dpy_name = XDisplayName(NULL);
 
-  if (!dpy_name) return True;
+    if (!dpy_name)
+        return True;
 
-  /* If no hostname or IP address, assume its a local server,
-   * and that polling /proc/interrupts is possible.  */
-  if (':' == dpy_name[0]) return True;
+    /* If no hostname or IP address, assume its a local server,
+     * and that polling /proc/interrupts is possible.  */
+    if (':' == dpy_name[0])
+        return True;
 
-  /* If IP address is 127.0.0.1 or 127.x.x.x then its local */
-  if (!strncmp (dpy_name, "127.", 4)) return True;
+    /* If IP address is 127.0.0.1 or 127.x.x.x then its local */
+    if (!strncmp(dpy_name, "127.", 4))
+        return True;
 
-  /* If its the Unix-standard localhost, then its local */
-  if (!strncmp (dpy_name, "localhost", 9)) return True;
+    /* If its the Unix-standard localhost, then its local */
+    if (!strncmp(dpy_name, "localhost", 9))
+        return True;
 
-  return False;
+    return False;
 }
 
 /* ===================================================================== */
 
-static Bool
-query_proc_interrupts_available (IdleTimeout *si, const char **why)
+static Bool query_proc_interrupts_available(IdleTimeout *si, const char **why)
 {
-  /* We can use /proc/interrupts if $DISPLAY points to :0, and if the
-     "/proc/interrupts" file exists and is readable.
-   */
-  FILE *f;
-  if (why) *why = 0;
-  if (!display_is_on_console_p (si))
+    /* We can use /proc/interrupts if $DISPLAY points to :0, and if the
+       "/proc/interrupts" file exists and is readable.
+     */
+    FILE *f;
+    if (why)
+        *why = 0;
+    if (!display_is_on_console_p(si))
     {
-      if (why) *why = "not on primary console";
-      return False;
+        if (why)
+            *why = "not on primary console";
+        return False;
     }
 
-  f = fopen (PROC_INTERRUPTS, "r");
-  if (!f)
-    return False;
+    f = fopen(PROC_INTERRUPTS, "r");
+    if (!f)
+        return False;
 
-  fclose (f);
-  return True;
+    fclose(f);
+    return True;
 }
-
 
 /* ===================================================================== */
 
-static Bool
-proc_interrupts_activity_p (IdleTimeout *si)
+static Bool proc_interrupts_activity_p(IdleTimeout *si)
 {
-  static FILE *f0 = 0;
-  static Bool need_dup = True;
-  static char *kbd_str = NULL;
-  static char *ptr_str = NULL;
-  FILE *f1 = 0;
-  int fd;
-  static char last_kbd_line[255] = { 0, };
-  static char last_ptr_line[255] = { 0, };
-  char new_line[sizeof(last_kbd_line)];
-  Bool got_kbd = False, kbd_diff = False;
-  Bool got_ptr = False, ptr_diff = False;
+    static FILE *f0 = 0;
+    static Bool need_dup = True;
+    static char *kbd_str = NULL;
+    static char *ptr_str = NULL;
+    FILE *f1 = 0;
+    int fd;
+    static char last_kbd_line[255] = {
+        0,
+    };
+    static char last_ptr_line[255] = {
+        0,
+    };
+    char new_line[sizeof(last_kbd_line)];
+    Bool got_kbd = False, kbd_diff = False;
+    Bool got_ptr = False, ptr_diff = False;
 
-  if (!f0)
+    if (!f0)
     {
-      /* First time -- open the file. */
-      f0 = fopen (PROC_INTERRUPTS, "r");
-      if (!f0)
+        /* First time -- open the file. */
+        f0 = fopen(PROC_INTERRUPTS, "r");
+        if (!f0)
         {
-          char buf[255];
-          sprintf(buf, "%s: error opening %s", PACKAGE, PROC_INTERRUPTS);
-          perror (buf);
-          goto FAIL;
+            char buf[255];
+            sprintf(buf, "%s: error opening %s", PACKAGE, PROC_INTERRUPTS);
+            perror(buf);
+            goto FAIL;
         }
     }
 
-  if (f0 == (FILE *) -1)      /* means we got an error initializing. */
-    return False;
+    if (f0 == (FILE *) -1) /* means we got an error initializing. */
+        return False;
 
-  if (need_dup)
+    if (need_dup)
     {
-      fd = dup (fileno (f0));
-      if (fd < 0)
+        fd = dup(fileno(f0));
+        if (fd < 0)
         {
-          char buf[255];
-          sprintf(buf, "%s: could not dup() the %s fd", PACKAGE, PROC_INTERRUPTS);
-          perror (buf);
-          goto FAIL;
+            char buf[255];
+            sprintf(buf, "%s: could not dup() the %s fd", PACKAGE, PROC_INTERRUPTS);
+            perror(buf);
+            goto FAIL;
         }
-    f1 = fdopen (fd, "r");
-    if (!f1)
-      {
+        f1 = fdopen(fd, "r");
+        if (!f1)
+        {
+            char buf[255];
+            sprintf(buf, "%s: could not fdopen() the %s fd", PACKAGE, PROC_INTERRUPTS);
+            perror(buf);
+            goto FAIL;
+        }
+    }
+    else
+    {
+        f1 = f0;
+    }
+    /* fseek() to the beginning of the file even if we did the above dup.
+       I'm unclear on why it's necessary in the dup case, but it is. */
+    if (fseek(f1, 0, SEEK_SET) != 0)
+    {
         char buf[255];
-        sprintf(buf, "%s: could not fdopen() the %s fd", PACKAGE,
-                PROC_INTERRUPTS);
-        perror (buf);
+        sprintf(buf, "%s: error rewinding %s", PACKAGE, PROC_INTERRUPTS);
+        perror(buf);
         goto FAIL;
-      }
-    }
-  else
-    {
-      f1 = f0;
-    }
-  /* fseek() to the beginning of the file even if we did the above dup.
-     I'm unclear on why it's necessary in the dup case, but it is. */
-  if (fseek (f1, 0, SEEK_SET) != 0)
-    {
-      char buf[255];
-      sprintf(buf, "%s: error rewinding %s", PACKAGE, PROC_INTERRUPTS);
-      perror (buf);
-      goto FAIL;
     }
 
-  if (kbd_str == NULL)
+    if (kbd_str == NULL)
     {
-      /* Initial run through */
-      /* Determine what our search string will be. */
-      while (fgets (new_line, sizeof(new_line)-1, f1))
+        /* Initial run through */
+        /* Determine what our search string will be. */
+        while (fgets(new_line, sizeof(new_line) - 1, f1))
         {
-          if (strchr (new_line, ','))
+            if (strchr(new_line, ','))
             {
-              /* Ignore any line that has a comma on it: this is because
-               * a setup like this:
-               *
-               *      12:      930935        XT-PIC  usb-uhci, PS/2 Mouse
-               *
-               * is really bad news.  It *looks* like we can note mouse
-               * activity from that line, but really the interrupt gets
-               * fired any time a USB device has activity!  So we have to
-               * ignore any shared IRQs.
-               */
+                /* Ignore any line that has a comma on it: this is because
+                 * a setup like this:
+                 *
+                 *      12:      930935        XT-PIC  usb-uhci, PS/2 Mouse
+                 *
+                 * is really bad news.  It *looks* like we can note mouse
+                 * activity from that line, but really the interrupt gets
+                 * fired any time a USB device has activity!  So we have to
+                 * ignore any shared IRQs.
+                 */
             }
-          else if (!got_kbd && strstr(new_line, "keyboard"))
+            else if (!got_kbd && strstr(new_line, "keyboard"))
             {
-              kbd_str = "keyboard";
-              need_dup = True;
-              got_kbd = True;
-              strcpy (last_kbd_line, new_line);
+                kbd_str = "keyboard";
+                need_dup = True;
+                got_kbd = True;
+                strcpy(last_kbd_line, new_line);
             }
-          else if (!got_kbd && strstr(new_line, "PS/2 Mouse"))
+            else if (!got_kbd && strstr(new_line, "PS/2 Mouse"))
             {
-              ptr_str = "PS/2 Mouse";
-              need_dup = True;
-              got_ptr = True;
-              strcpy (last_ptr_line, new_line);
+                ptr_str = "PS/2 Mouse";
+                need_dup = True;
+                got_ptr = True;
+                strcpy(last_ptr_line, new_line);
             }
-          else if (!got_kbd && strstr(new_line, "i8042"))
+            else if (!got_kbd && strstr(new_line, "i8042"))
             {
-              if (strstr(new_line, " 1:"))
+                if (strstr(new_line, " 1:"))
                 {
-                  kbd_str = " 1:";
-                  need_dup = False;
-                  got_kbd = True;
-                  strcpy (last_kbd_line, new_line);
+                    kbd_str = " 1:";
+                    need_dup = False;
+                    got_kbd = True;
+                    strcpy(last_kbd_line, new_line);
                 }
-              else if (strstr(new_line, " 12:"))
+                else if (strstr(new_line, " 12:"))
                 {
-                  ptr_str = " 12:";
-                  need_dup = False;
-                  got_ptr = True;
-                  strcpy (last_ptr_line, new_line);
+                    ptr_str = " 12:";
+                    need_dup = False;
+                    got_ptr = True;
+                    strcpy(last_ptr_line, new_line);
                 }
             }
-          if (got_kbd && got_ptr)
-              break;
+            if (got_kbd && got_ptr)
+                break;
         }
-      if (kbd_str == NULL && ptr_str == NULL)
+        if (kbd_str == NULL && ptr_str == NULL)
         {
-          /* If we got here, we didn't find either an entry for keyboards or
-             mice in the file at all. */
-          fprintf (stderr, "%s: no keyboard or mouse data in %s?\n",
-                   PACKAGE, PROC_INTERRUPTS);
-          goto FAIL;
+            /* If we got here, we didn't find either an entry for keyboards or
+               mice in the file at all. */
+            fprintf(stderr, "%s: no keyboard or mouse data in %s?\n", PACKAGE, PROC_INTERRUPTS);
+            goto FAIL;
         }
-      if (kbd_str == NULL) {
-          kbd_str = "NoneNoneNone";
-      }
-      if (ptr_str == NULL) {
-          ptr_str = "NoneNoneNone";
-      }
-      if (need_dup == False) {
-          fclose(f1);
-          f1 = NULL;
-      }
-    }
-  else
-    {
-      /* Regular */
-      while (fgets (new_line, sizeof(new_line)-1, f1))
+        if (kbd_str == NULL)
         {
-          if (!got_kbd && strstr (new_line, kbd_str))
+            kbd_str = "NoneNoneNone";
+        }
+        if (ptr_str == NULL)
+        {
+            ptr_str = "NoneNoneNone";
+        }
+        if (need_dup == False)
+        {
+            fclose(f1);
+            f1 = NULL;
+        }
+    }
+    else
+    {
+        /* Regular */
+        while (fgets(new_line, sizeof(new_line) - 1, f1))
+        {
+            if (!got_kbd && strstr(new_line, kbd_str))
             {
-              kbd_diff = (*last_kbd_line && !!strcmp (new_line, last_kbd_line));
-              strcpy (last_kbd_line, new_line);
-              got_kbd = True;
+                kbd_diff = (*last_kbd_line && !!strcmp(new_line, last_kbd_line));
+                strcpy(last_kbd_line, new_line);
+                got_kbd = True;
             }
-          else if (!got_ptr && strstr (new_line, ptr_str))
+            else if (!got_ptr && strstr(new_line, ptr_str))
             {
-              ptr_diff = (*last_ptr_line && !!strcmp (new_line, last_ptr_line));
-              strcpy (last_ptr_line, new_line);
-              got_ptr = True;
+                ptr_diff = (*last_ptr_line && !!strcmp(new_line, last_ptr_line));
+                strcpy(last_ptr_line, new_line);
+                got_ptr = True;
             }
 
-          if (got_kbd && got_ptr)
-            break;
+            if (got_kbd && got_ptr)
+                break;
         }
     }
 
-  if (got_kbd || got_ptr)
+    if (got_kbd || got_ptr)
     {
-      if (need_dup)
-          fclose (f1);
-      return (kbd_diff || ptr_diff);
+        if (need_dup)
+            fclose(f1);
+        return (kbd_diff || ptr_diff);
     }
 
+FAIL:
+    if (f1 && (f1 != f0))
+        fclose(f1);
+    f1 = NULL;
 
- FAIL:
-  if (f1 && (f1 != f0))
-    fclose (f1);
-  f1 = NULL;
+    if (f0 && f0 != (FILE *) -1)
+        fclose(f0);
 
-  if (f0 && f0 != (FILE *) -1)
-    fclose (f0);
-
-  f0 = (FILE *) -1;
-  return False;
+    f0 = (FILE *) -1;
+    return False;
 }
 
 #endif /* HAVE_PROC_INTERRUPTS */
@@ -738,15 +725,14 @@ proc_interrupts_activity_p (IdleTimeout *si)
  * and dangerous. So we let gdk weed hem out itself.
  */
 
-static Bool
-if_event_predicate (Display *dpy, XEvent *ev, XPointer arg)
+static Bool if_event_predicate(Display *dpy, XEvent *ev, XPointer arg)
 {
-  IdleTimeout *si = (IdleTimeout *) arg;
+    IdleTimeout *si = (IdleTimeout *) arg;
 #ifdef DEBUG
-  printf ("duude event type %d\n", ev->xany.type);
+    printf("duude event type %d\n", ev->xany.type);
 #endif
-  switch (ev->xany.type)
-  {
+    switch (ev->xany.type)
+    {
     case KeyPress:
     case KeyRelease:
     case ButtonPress:
@@ -754,30 +740,30 @@ if_event_predicate (Display *dpy, XEvent *ev, XPointer arg)
     case MotionNotify:
     case EnterNotify:
     case LeaveNotify:
-      si->last_activity_time = si->dispatch_time;
-      break;
+        si->last_activity_time = si->dispatch_time;
+        break;
 
     case CreateNotify:
-      /* A window has been created on the screen somewhere.  If we're
-         supposed to scan all windows for events, prepare this window.
-         Don't reset the timer on this event. The xscreensaver typically
-         generates one of these every 10 minutes ('phosphor' mode), so
-         we shouldn't mistake this for user activity.
-       */
-      if (si->scanning_all_windows)
-      {
-        Window w = ev->xcreatewindow.window;
-        start_notice_events_timer (si, w);
-      }
-      break;
+        /* A window has been created on the screen somewhere.  If we're
+           supposed to scan all windows for events, prepare this window.
+           Don't reset the timer on this event. The xscreensaver typically
+           generates one of these every 10 minutes ('phosphor' mode), so
+           we shouldn't mistake this for user activity.
+         */
+        if (si->scanning_all_windows)
+        {
+            Window w = ev->xcreatewindow.window;
+            start_notice_events_timer(si, w);
+        }
+        break;
 
     default:
-      /* We assume all other messages might occur 'spontaneously', without
-       * the activity of a user, and therefore, we ignore them. */
-      break;
-  }
+        /* We assume all other messages might occur 'spontaneously', without
+         * the activity of a user, and therefore, we ignore them. */
+        break;
+    }
 
-  return False;
+    return False;
 }
 
 /* ===================================================================== */
@@ -787,121 +773,118 @@ if_event_predicate (Display *dpy, XEvent *ev, XPointer arg)
  * so that other timers & etc. get properly handled.
  */
 
-static int
-idle_timeout_main_loop (gpointer data)
+static int idle_timeout_main_loop(gpointer data)
 {
-  IdleTimeout *si = data;
-  int quit_now = 0;
-  fd_set rfds;
-  struct timeval tv;
-  int fd;
-  int retval;
+    IdleTimeout *si = data;
+    int quit_now = 0;
+    fd_set rfds;
+    struct timeval tv;
+    int fd;
+    int retval;
 
-  FD_ZERO (&rfds);
-  fd = ConnectionNumber (si->dpy);
+    FD_ZERO(&rfds);
+    fd = ConnectionNumber(si->dpy);
 
-  while (!quit_now)
-  {
-     FD_SET (fd, &rfds);
+    while (!quit_now)
+    {
+        FD_SET(fd, &rfds);
 
-     /* block and wait one sec at most */
-     tv.tv_sec = 1;
-     tv.tv_usec = 0;
-     retval = select(fd+1, &rfds, NULL, NULL, &tv);
-     if ((0 > retval) && (EAGAIN != errno) && (EINTR != errno))
-     {
-        printf ("GTT: fatal error in select %d, %s\n", errno, strerror(errno));
-        gtk_main_quit();
-        return 0;
-     }
+        /* block and wait one sec at most */
+        tv.tv_sec = 1;
+        tv.tv_usec = 0;
+        retval = select(fd + 1, &rfds, NULL, NULL, &tv);
+        if ((0 > retval) && (EAGAIN != errno) && (EINTR != errno))
+        {
+            printf("GTT: fatal error in select %d, %s\n", errno, strerror(errno));
+            gtk_main_quit();
+            return 0;
+        }
 
-     /* Monitor X input queue */
-     {
-        XEvent event;
-        si->dispatch_time = time (0);
-        XCheckIfEvent (si->dpy, &event, if_event_predicate, (XPointer) si);
-     }
+        /* Monitor X input queue */
+        {
+            XEvent event;
+            si->dispatch_time = time(0);
+            XCheckIfEvent(si->dpy, &event, if_event_predicate, (XPointer) si);
+        }
 
-     /* Clear out pending gtk events before we got back to sleep */
-     while (gtk_events_pending())
-     {
-        quit_now = gtk_main_iteration_do (FALSE);
-        if (quit_now) return 0;
-     }
-  }
-  return 0;
+        /* Clear out pending gtk events before we got back to sleep */
+        while (gtk_events_pending())
+        {
+            quit_now = gtk_main_iteration_do(FALSE);
+            if (quit_now)
+                return 0;
+        }
+    }
+    return 0;
 }
-
 
 /* ===================================================================== */
 
-IdleTimeout *
-idle_timeout_new (void)
+IdleTimeout *idle_timeout_new(void)
 {
-  IdleTimeout *si;
+    IdleTimeout *si;
 
-  si = g_new0 (IdleTimeout, 1);
-  si->dpy = GDK_DISPLAY();
+    si = g_new0(IdleTimeout, 1);
+    si->dpy = GDK_DISPLAY();
 
-  /* hack alert XXXX we should grep all screens */
-  si->nscreens = 1;
-  si->screens = g_new0 (IdleTimeoutScreen, 1);
-  si->screens->global = si;
-  si->screens->screen = DefaultScreenOfDisplay (si->dpy);
+    /* hack alert XXXX we should grep all screens */
+    si->nscreens = 1;
+    si->screens = g_new0(IdleTimeoutScreen, 1);
+    si->screens->global = si;
+    si->screens->screen = DefaultScreenOfDisplay(si->dpy);
 
-  /* We use /proc/interrupts because we are not otherwise getting
-   * keyboard events for some reason.  Note that Mac OSX won't have
-   * the /proc filesystem, and so won't have this ability; they'll
-   * be screwed.  XXX Need to fix root cause of missing keybd events ...
-   */
-  si->using_proc_interrupts = query_proc_interrupts_available (si, NULL);
+    /* We use /proc/interrupts because we are not otherwise getting
+     * keyboard events for some reason.  Note that Mac OSX won't have
+     * the /proc filesystem, and so won't have this ability; they'll
+     * be screwed.  XXX Need to fix root cause of missing keybd events ...
+     */
+    si->using_proc_interrupts = query_proc_interrupts_available(si, NULL);
 
-  /* how often we observe mouse  */
-  si->pointer_timeout = 5;
+    /* how often we observe mouse  */
+    si->pointer_timeout = 5;
 
-  /* how soon we select the window tree after a new windows created */
-  si->notice_events_timeout = 30;
+    /* how soon we select the window tree after a new windows created */
+    si->notice_events_timeout = 30;
 
-  /* ------------------------------------------------------------- */
-  /* We need to select events on all windows if we're not using any extensions.
-     Otherwise, we don't need to. */
-  si->scanning_all_windows = !(si->using_xidle_extension);
+    /* ------------------------------------------------------------- */
+    /* We need to select events on all windows if we're not using any extensions.
+       Otherwise, we don't need to. */
+    si->scanning_all_windows = !(si->using_xidle_extension);
 
-  /* Whether we need to periodically wake up and check to see if the mouse has
-     moved.  We only need to do this when not using any extensions.  The reason
-     this isn't the same as `polling_for_idleness' is that the "idleness" poll
-     can happen (for example) 5 minutes from now, whereas the mouse-position
-     poll should happen with low periodicity.  We don't need to poll the mouse
-     position with the XIDLE extension, but we do need to periodically wake up
-     and query the server with that extension.  For our purposes, polling
-     /proc/interrupts is just like polling the mouse position.  It has to
-     happen on the same kind of schedule. */
-  si->polling_mouse_position = (si->using_proc_interrupts ||
-                              !(si->using_xidle_extension));
+    /* Whether we need to periodically wake up and check to see if the mouse has
+       moved.  We only need to do this when not using any extensions.  The reason
+       this isn't the same as `polling_for_idleness' is that the "idleness" poll
+       can happen (for example) 5 minutes from now, whereas the mouse-position
+       poll should happen with low periodicity.  We don't need to poll the mouse
+       position with the XIDLE extension, but we do need to periodically wake up
+       and query the server with that extension.  For our purposes, polling
+       /proc/interrupts is just like polling the mouse position.  It has to
+       happen on the same kind of schedule. */
+    si->polling_mouse_position = (si->using_proc_interrupts || !(si->using_xidle_extension));
 
-  if (si->polling_mouse_position)
-  {
-    /* Check to see if the mouse has moved, and set up a repeating timer
-       to do so periodically (typically, every 5 seconds.) */
-    si->check_pointer_timer_id = gtk_timeout_add (si->pointer_timeout *1000,
-                  check_pointer_timer, (gpointer) si);
+    if (si->polling_mouse_position)
+    {
+        /* Check to see if the mouse has moved, and set up a repeating timer
+           to do so periodically (typically, every 5 seconds.) */
+        si->check_pointer_timer_id
+            = gtk_timeout_add(si->pointer_timeout * 1000, check_pointer_timer, (gpointer) si);
 
-    /* run it once, to initialze stuff */
-    check_pointer_timer ((gpointer) si);
-  }
+        /* run it once, to initialze stuff */
+        check_pointer_timer((gpointer) si);
+    }
 
-  /* ------------------------------------------------------------- */
+    /* ------------------------------------------------------------- */
 
-  if (si->scanning_all_windows)
-  {
-    /* get events from every window */
-    notice_events (si, DefaultRootWindow(si->dpy), True);
+    if (si->scanning_all_windows)
+    {
+        /* get events from every window */
+        notice_events(si, DefaultRootWindow(si->dpy), True);
 
-    /* hijack the main loop; this is the only way to get events */
-    gtk_timeout_add (900, idle_timeout_main_loop, (gpointer)si);
-  }
+        /* hijack the main loop; this is the only way to get events */
+        gtk_timeout_add(900, idle_timeout_main_loop, (gpointer) si);
+    }
 
-  return si;
+    return si;
 }
 
 /* =================== END OF FILE ===================================== */

--- a/src/idle-timer.h
+++ b/src/idle-timer.h
@@ -20,15 +20,14 @@
 
 typedef struct IdleTimeout_s IdleTimeout;
 
-IdleTimeout * idle_timeout_new (void);
+IdleTimeout *idle_timeout_new(void);
 
 /* The poll_last_activity() routine returns the wall-clock-time of the last
  * user activity on this X server.  i.e. the number of seconds since
  * last activity is given by (time(0) - poll_last_activity())
  */
-time_t poll_last_activity (IdleTimeout *);
+time_t poll_last_activity(IdleTimeout *);
 
 /* XXX There should be an idle_timeout_destroy() func, but there isn't. */
-
 
 #endif /* __IDLE_TIMER_H__ */

--- a/src/journal.c
+++ b/src/journal.c
@@ -24,16 +24,16 @@
 #include <gnome.h>
 #include <gtkhtml/gtkhtml.h>
 #include <libgnomevfs/gnome-vfs.h>
+#include <sched.h>
 #include <stdio.h>
 #include <string.h>
-#include <sched.h>
 
 #include <qof.h>
 
 #include "app.h"
 #include "dialog.h"
-#include "journal.h"
 #include "ghtml.h"
+#include "journal.h"
 #include "menus.h"
 #include "plug-in.h"
 #include "proj.h"
@@ -41,793 +41,757 @@
 #include "props-task.h"
 #include "util.h"
 
-
 /* This struct is a mish-mash of stuff relating to the
  * HTML display window, and the various actions and etc.
  * that can be taken from it. */
 
 typedef struct wiggy_s
 {
-	GttGhtml  *gh;
-	GtkHTML   *html;
-	GtkHTMLStream  *html_stream;
-	GtkWidget *top;
-	GttProject  *prj;
-	char        *filepath;  /* file containing report template */
+    GttGhtml *gh;
+    GtkHTML *html;
+    GtkHTMLStream *html_stream;
+    GtkWidget *top;
+    GttProject *prj;
+    char *filepath; /* file containing report template */
 
-	/* Interval edit menu widgets */
-	GttInterval * interval;
-	GtkWidget *interval_popup;
-	GtkWidget *interval_paste;
-	GtkWidget *interval_merge_up;
-	GtkWidget *interval_merge_down;
-	GtkWidget *interval_move_up;
-	GtkWidget *interval_move_down;
-	EditIntervalDialog *edit_ivl;
+    /* Interval edit menu widgets */
+    GttInterval *interval;
+    GtkWidget *interval_popup;
+    GtkWidget *interval_paste;
+    GtkWidget *interval_merge_up;
+    GtkWidget *interval_merge_down;
+    GtkWidget *interval_move_up;
+    GtkWidget *interval_move_down;
+    EditIntervalDialog *edit_ivl;
 
-	/* Task edit menu widgets */
-	GttTask     *task;
-	GtkWidget *task_popup;
-	GtkWidget *task_delete_memo;
-	GtkWidget *task_paste;
+    /* Task edit menu widgets */
+    GttTask *task;
+    GtkWidget *task_popup;
+    GtkWidget *task_delete_memo;
+    GtkWidget *task_paste;
 
-	/* Mouse fly-over help */
-	GtkWidget *hover_help_window;
-	GtkLabel  *hover_label;
-	guint      hover_timeout_id;
-	guint      hover_kill_id;
+    /* Mouse fly-over help */
+    GtkWidget *hover_help_window;
+    GtkLabel *hover_label;
+    guint hover_timeout_id;
+    guint hover_kill_id;
 
-	GnomeVFSHandle   *handle;  /* file handle to save to */
-	GttPlugin   *plg;          /* file path save history */
+    GnomeVFSHandle *handle; /* file handle to save to */
+    GttPlugin *plg;         /* file path save history */
 
-	/* Publish-to-URL dialog */
-	GtkWidget *publish_popup;
-	GtkEntry  *publish_entry;
+    /* Publish-to-URL dialog */
+    GtkWidget *publish_popup;
+    GtkEntry *publish_entry;
 } Wiggy;
 
-static void do_show_report (const char *, GttPlugin *,
-                KvpFrame *, GttProject *, gboolean, GList *);
-
+static void
+do_show_report(const char *, GttPlugin *, KvpFrame *, GttProject *, gboolean, GList *);
 
 /* ============================================================== */
 /* Routines that take html and mash it into browser. */
 
-static void
-wiggy_open (GttGhtml *pl, gpointer ud)
+static void wiggy_open(GttGhtml *pl, gpointer ud)
 {
-	Wiggy *wig = (Wiggy *) ud;
+    Wiggy *wig = (Wiggy *) ud;
 
-	/* open the browser for writing */
-	wig->html_stream = gtk_html_begin (wig->html);
+    /* open the browser for writing */
+    wig->html_stream = gtk_html_begin(wig->html);
 }
 
-static void
-wiggy_close (GttGhtml *pl, gpointer ud)
+static void wiggy_close(GttGhtml *pl, gpointer ud)
 {
-	Wiggy *wig = (Wiggy *) ud;
+    Wiggy *wig = (Wiggy *) ud;
 
-	/* close the browser stream */
-	gtk_html_end (wig->html, wig->html_stream, GTK_HTML_STREAM_OK);
+    /* close the browser stream */
+    gtk_html_end(wig->html, wig->html_stream, GTK_HTML_STREAM_OK);
 }
 
-static void
-wiggy_write (GttGhtml *pl, const char *str, size_t len, gpointer ud)
+static void wiggy_write(GttGhtml *pl, const char *str, size_t len, gpointer ud)
 {
-	Wiggy *wig = (Wiggy *) ud;
+    Wiggy *wig = (Wiggy *) ud;
 
-	/* write to the browser stream */
-	gtk_html_write (wig->html, wig->html_stream, str, len);
+    /* write to the browser stream */
+    gtk_html_write(wig->html, wig->html_stream, str, len);
 }
 
-static void
-wiggy_error (GttGhtml *pl, int err, const char * msg, gpointer ud)
+static void wiggy_error(GttGhtml *pl, int err, const char *msg, gpointer ud)
 {
-	Wiggy *wig = (Wiggy *) ud;
-	GtkHTML *html = wig->html;
-	GtkHTMLStream *stream;
-	char buff[1000], *p;
+    Wiggy *wig = (Wiggy *) ud;
+    GtkHTML *html = wig->html;
+    GtkHTMLStream *stream;
+    char buff[1000], *p;
 
-	stream = gtk_html_begin (html);
+    stream = gtk_html_begin(html);
 
-	if (404 == err)
-	{
-		p = buff;
-		p = g_stpcpy (p, "<html><body><h1>");
-		p = g_stpcpy (p, _("Error 404 Not Found"));
-		p = g_stpcpy (p, "</h1>");
-		p += sprintf (p, _("The file %s was not found."),
-		             (msg? (char*) msg : _("(null)")));
+    if (404 == err)
+    {
+        p = buff;
+        p = g_stpcpy(p, "<html><body><h1>");
+        p = g_stpcpy(p, _("Error 404 Not Found"));
+        p = g_stpcpy(p, "</h1>");
+        p += sprintf(p, _("The file %s was not found."), (msg ? (char *) msg : _("(null)")));
 
-		p = g_stpcpy (p, "</body></html>");
-		gtk_html_write (html, stream, buff, p-buff);
-	}
-	else
-	{
-		p = buff;
-		p = g_stpcpy (p, "<html><body><h1>");
-		p = g_stpcpy (p, _("Unkown Error"));
-		p = g_stpcpy (p, "</h1></body></html>");
-		gtk_html_write (html, stream, buff, p-buff);
-	}
+        p = g_stpcpy(p, "</body></html>");
+        gtk_html_write(html, stream, buff, p - buff);
+    }
+    else
+    {
+        p = buff;
+        p = g_stpcpy(p, "<html><body><h1>");
+        p = g_stpcpy(p, _("Unkown Error"));
+        p = g_stpcpy(p, "</h1></body></html>");
+        gtk_html_write(html, stream, buff, p - buff);
+    }
 
-	gtk_html_end (html, stream, GTK_HTML_STREAM_OK);
-
+    gtk_html_end(html, stream, GTK_HTML_STREAM_OK);
 }
 
 /* ============================================================== */
 /* Routine that take html and mash it into a file. */
 
-static void
-file_write_helper (GttGhtml *pl, const char *str, size_t len, gpointer data)
+static void file_write_helper(GttGhtml *pl, const char *str, size_t len, gpointer data)
 {
-	Wiggy *wig = (Wiggy *) data;
-	GnomeVFSFileSize buflen = len;
-	GnomeVFSFileSize bytes_written = 0;
-	size_t off = 0;
-	while (1)
-	{
-		GnomeVFSResult result;
-		result = gnome_vfs_write (wig->handle, &str[off], buflen, &bytes_written);
-		off += bytes_written;
-		buflen -= bytes_written;
-		if (0>= buflen) break;
-		if (GNOME_VFS_OK != result) break;
-	}
+    Wiggy *wig = (Wiggy *) data;
+    GnomeVFSFileSize buflen = len;
+    GnomeVFSFileSize bytes_written = 0;
+    size_t off = 0;
+    while (1)
+    {
+        GnomeVFSResult result;
+        result = gnome_vfs_write(wig->handle, &str[off], buflen, &bytes_written);
+        off += bytes_written;
+        buflen -= bytes_written;
+        if (0 >= buflen)
+            break;
+        if (GNOME_VFS_OK != result)
+            break;
+    }
 }
 
 /* ============================================================== */
 
-static void
-remember_uri (Wiggy *wig, const char * filename)
+static void remember_uri(Wiggy *wig, const char *filename)
 {
-	/* Remember history, on a per-report basis */
-	if (wig->plg && ((NULL == wig->plg->last_url) ||
-	                 (0==wig->plg->last_url[0]) ||
-	                 (0==strncmp (wig->plg->last_url, "file:/", 6))))
-	{
-		if (wig->plg->last_url) g_free (wig->plg->last_url);
-		wig->plg->last_url = g_strdup_printf ("file:%s", filename);
-	}
+    /* Remember history, on a per-report basis */
+    if (wig->plg
+        && ((NULL == wig->plg->last_url) || (0 == wig->plg->last_url[0])
+            || (0 == strncmp(wig->plg->last_url, "file:/", 6))))
+    {
+        if (wig->plg->last_url)
+            g_free(wig->plg->last_url);
+        wig->plg->last_url = g_strdup_printf("file:%s", filename);
+    }
 }
 
-static void
-save_to_gnomevfs (Wiggy *wig, const char * filename)
+static void save_to_gnomevfs(Wiggy *wig, const char *filename)
 {
-	/* Try to open the file for writing */
-	GnomeVFSResult    result;
-	result = gnome_vfs_create (&wig->handle, filename,
-	                     GNOME_VFS_OPEN_WRITE, FALSE, 0644);
+    /* Try to open the file for writing */
+    GnomeVFSResult result;
+    result = gnome_vfs_create(&wig->handle, filename, GNOME_VFS_OPEN_WRITE, FALSE, 0644);
 
-	if (GNOME_VFS_OK != result)
-	{
-		GtkWidget *mb;
-		mb = gtk_message_dialog_new (GTK_WINDOW(wig->top),
-		               GTK_DIALOG_MODAL|GTK_DIALOG_DESTROY_WITH_PARENT,
-		               GTK_MESSAGE_ERROR,
-		               GTK_BUTTONS_CLOSE,
-		               _("Unable to open the file %s\n%s"),
-		               filename,
-		               gnome_vfs_result_to_string (result));
-		g_signal_connect (G_OBJECT(mb), "response",
-		               G_CALLBACK (gtk_widget_destroy), mb);
-		gtk_widget_show (mb);
-	}
-	else
-	{
-		/* Cause ghtml to output the html again, but this time
-		 * using raw file-io handlers instead. */
-		gtt_ghtml_set_stream (wig->gh, wig, NULL, file_write_helper,
-			NULL, wiggy_error);
-		gtt_ghtml_show_links (wig->gh, FALSE);
-		gtt_ghtml_display (wig->gh, wig->filepath, wig->prj);
-		gtt_ghtml_show_links (wig->gh, TRUE);
+    if (GNOME_VFS_OK != result)
+    {
+        GtkWidget *mb;
+        mb = gtk_message_dialog_new(
+            GTK_WINDOW(wig->top), GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
+            GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE, _("Unable to open the file %s\n%s"), filename,
+            gnome_vfs_result_to_string(result)
+        );
+        g_signal_connect(G_OBJECT(mb), "response", G_CALLBACK(gtk_widget_destroy), mb);
+        gtk_widget_show(mb);
+    }
+    else
+    {
+        /* Cause ghtml to output the html again, but this time
+         * using raw file-io handlers instead. */
+        gtt_ghtml_set_stream(wig->gh, wig, NULL, file_write_helper, NULL, wiggy_error);
+        gtt_ghtml_show_links(wig->gh, FALSE);
+        gtt_ghtml_display(wig->gh, wig->filepath, wig->prj);
+        gtt_ghtml_show_links(wig->gh, TRUE);
 
-		gnome_vfs_close (wig->handle);
-		wig->handle = NULL;
+        gnome_vfs_close(wig->handle);
+        wig->handle = NULL;
 
-		/* Reset the html out handlers back to the browser */
-		gtt_ghtml_set_stream (wig->gh, wig, wiggy_open, wiggy_write,
-		   wiggy_close, wiggy_error);
-	}
+        /* Reset the html out handlers back to the browser */
+        gtt_ghtml_set_stream(wig->gh, wig, wiggy_open, wiggy_write, wiggy_close, wiggy_error);
+    }
 }
 
-static void
-save_to_file (Wiggy *wig, const char * uri)
+static void save_to_file(Wiggy *wig, const char *uri)
 {
 
 #if BORKEN_STILL_GET_X11_TRAFFIC_WHICH_HOSES_THINGS
-	/* If its an remote system URI, we fork/exec, because
-	 * gnomevfs can take a looooong time to respond ...
-	 */
-	if (0 == strncmp (uri, "ssh://", 6))
-	{
-		pid_t pid;
-		pid = fork ();
-		if (0 == pid)
-		{
-			save_to_gnomevfs (wig, uri);
+    /* If its an remote system URI, we fork/exec, because
+     * gnomevfs can take a looooong time to respond ...
+     */
+    if (0 == strncmp(uri, "ssh://", 6))
+    {
+        pid_t pid;
+        pid = fork();
+        if (0 == pid)
+        {
+            save_to_gnomevfs(wig, uri);
 
-			/* exit the child as cleanly as we can ... do NOT
-			 * generate any socket/X11/graphics/gtk traffic.  */
-			execl ("/bin/true", "/bin/true", NULL);
-			execl ("/bin/false", "/bin/false", NULL);
-		}
-		else if (0 > pid)
-		{
-			g_warning ("unable to fork\n");
-			save_to_gnomevfs (wig, uri);
-		}
-		else
-		{
-			/* else we are parent, child will save for us */
-			sched_yield();
-		}
-	}
+            /* exit the child as cleanly as we can ... do NOT
+             * generate any socket/X11/graphics/gtk traffic.  */
+            execl("/bin/true", "/bin/true", NULL);
+            execl("/bin/false", "/bin/false", NULL);
+        }
+        else if (0 > pid)
+        {
+            g_warning("unable to fork\n");
+            save_to_gnomevfs(wig, uri);
+        }
+        else
+        {
+            /* else we are parent, child will save for us */
+            sched_yield();
+        }
+    }
 #endif
 
-	save_to_gnomevfs (wig, uri);
+    save_to_gnomevfs(wig, uri);
 }
 
 /* ============================================================== */
 /* engine callbacks */
 
-static void
-redraw (GttProject * prj, gpointer data)
+static void redraw(GttProject *prj, gpointer data)
 {
-	Wiggy *wig = (Wiggy *) data;
+    Wiggy *wig = (Wiggy *) data;
 
-	gtt_ghtml_display (wig->gh, wig->filepath, wig->prj);
+    gtt_ghtml_display(wig->gh, wig->filepath, wig->prj);
 }
 
 /* ============================================================== */
 /* Global clipboard, allows cut task to be reparented to a different
  * project.  List of cut tasks allows for infinite undo. */
 
-static GList * cutted_task_list = NULL;
+static GList *cutted_task_list = NULL;
 
 /* ============================================================== */
 /* Interval Popup Menu actions */
 
-void
-edit_interval_close_cb (GtkWidget *edit_ivl, gpointer data)
+void edit_interval_close_cb(GtkWidget *edit_ivl, gpointer data)
 {
-	Wiggy *wig = (Wiggy *) data;
-	wig->edit_ivl = NULL;
+    Wiggy *wig = (Wiggy *) data;
+    wig->edit_ivl = NULL;
 }
 
-
-static void
-interval_new_clicked_cb (GtkWidget * w, gpointer data)
+static void interval_new_clicked_cb(GtkWidget *w, gpointer data)
 {
-	Wiggy *wig = (Wiggy *) data;
+    Wiggy *wig = (Wiggy *) data;
 
-	if (NULL == wig->edit_ivl) wig->edit_ivl = edit_interval_dialog_new();
+    if (NULL == wig->edit_ivl)
+        wig->edit_ivl = edit_interval_dialog_new();
 
-	edit_interval_set_close_callback (wig->edit_ivl, G_CALLBACK (edit_interval_close_cb), wig);
+    edit_interval_set_close_callback(wig->edit_ivl, G_CALLBACK(edit_interval_close_cb), wig);
 
-	wig->interval = gtt_interval_new_insert_after(wig->interval);
-	edit_interval_set_interval (wig->edit_ivl, wig->interval);
-	edit_interval_dialog_show (wig->edit_ivl);
+    wig->interval = gtt_interval_new_insert_after(wig->interval);
+    edit_interval_set_interval(wig->edit_ivl, wig->interval);
+    edit_interval_dialog_show(wig->edit_ivl);
 }
 
-static void
-interval_edit_clicked_cb(GtkWidget * dw, gpointer data)
+static void interval_edit_clicked_cb(GtkWidget *dw, gpointer data)
 {
-	Wiggy *wig = (Wiggy *) data;
+    Wiggy *wig = (Wiggy *) data;
 
-	if (NULL == wig->edit_ivl) wig->edit_ivl = edit_interval_dialog_new();
-	edit_interval_set_close_callback (wig->edit_ivl, G_CALLBACK (edit_interval_close_cb), wig);
-	edit_interval_set_interval (wig->edit_ivl, wig->interval);
-	edit_interval_dialog_show (wig->edit_ivl);
+    if (NULL == wig->edit_ivl)
+        wig->edit_ivl = edit_interval_dialog_new();
+    edit_interval_set_close_callback(wig->edit_ivl, G_CALLBACK(edit_interval_close_cb), wig);
+    edit_interval_set_interval(wig->edit_ivl, wig->interval);
+    edit_interval_dialog_show(wig->edit_ivl);
 }
 
-static void
-interval_delete_clicked_cb(GtkWidget * w, gpointer data)
+static void interval_delete_clicked_cb(GtkWidget *w, gpointer data)
 {
-	Wiggy *wig = (Wiggy *) data;
-	gtt_interval_destroy (wig->interval);
-	wig->interval = NULL;
+    Wiggy *wig = (Wiggy *) data;
+    gtt_interval_destroy(wig->interval);
+    wig->interval = NULL;
 }
 
-static void
-interval_merge_up_clicked_cb(GtkWidget * w, gpointer data)
+static void interval_merge_up_clicked_cb(GtkWidget *w, gpointer data)
 {
-	Wiggy *wig = (Wiggy *) data;
-	gtt_interval_merge_up (wig->interval);
-	wig->interval = NULL;
+    Wiggy *wig = (Wiggy *) data;
+    gtt_interval_merge_up(wig->interval);
+    wig->interval = NULL;
 }
 
-static void
-interval_merge_down_clicked_cb(GtkWidget * w, gpointer data)
+static void interval_merge_down_clicked_cb(GtkWidget *w, gpointer data)
 {
-	Wiggy *wig = (Wiggy *) data;
-	gtt_interval_merge_down (wig->interval);
-	wig->interval = NULL;
+    Wiggy *wig = (Wiggy *) data;
+    gtt_interval_merge_down(wig->interval);
+    wig->interval = NULL;
 }
 
-static void
-interval_move_up_clicked_cb(GtkWidget * w, gpointer data)
+static void interval_move_up_clicked_cb(GtkWidget *w, gpointer data)
 {
-	Wiggy *wig = (Wiggy *) data;
-	GttTask *tsk = gtt_interval_get_parent (wig->interval);
-	GttProject *prj = gtt_task_get_parent (tsk);
-	GList *tasks = gtt_project_get_tasks (prj);
-	if (!tasks) return;
-	GList *this_task = g_list_find (tasks, tsk);
-	if (!this_task) return;
-	GList *prev_task = this_task->prev;
-	if (!prev_task) return;
-	GttTask *newtask = prev_task->data;
-	gtt_task_append_interval (newtask, wig->interval);
+    Wiggy *wig = (Wiggy *) data;
+    GttTask *tsk = gtt_interval_get_parent(wig->interval);
+    GttProject *prj = gtt_task_get_parent(tsk);
+    GList *tasks = gtt_project_get_tasks(prj);
+    if (!tasks)
+        return;
+    GList *this_task = g_list_find(tasks, tsk);
+    if (!this_task)
+        return;
+    GList *prev_task = this_task->prev;
+    if (!prev_task)
+        return;
+    GttTask *newtask = prev_task->data;
+    gtt_task_append_interval(newtask, wig->interval);
 }
 
-static void
-interval_move_down_clicked_cb(GtkWidget * w, gpointer data)
+static void interval_move_down_clicked_cb(GtkWidget *w, gpointer data)
 {
-	Wiggy *wig = (Wiggy *) data;
-	GttTask *tsk = gtt_interval_get_parent (wig->interval);
-	GttProject *prj = gtt_task_get_parent (tsk);
-	GList *tasks = gtt_project_get_tasks (prj);
-	if (!tasks) return;
-	GList *this_task = g_list_find (tasks, tsk);
-	if (!this_task) return;
-	GList *next_task = this_task->next;
-	if (!next_task) return;
-	GttTask *newtask = next_task->data;
-	gtt_task_add_interval (newtask, wig->interval);
+    Wiggy *wig = (Wiggy *) data;
+    GttTask *tsk = gtt_interval_get_parent(wig->interval);
+    GttProject *prj = gtt_task_get_parent(tsk);
+    GList *tasks = gtt_project_get_tasks(prj);
+    if (!tasks)
+        return;
+    GList *this_task = g_list_find(tasks, tsk);
+    if (!this_task)
+        return;
+    GList *next_task = this_task->next;
+    if (!next_task)
+        return;
+    GttTask *newtask = next_task->data;
+    gtt_task_add_interval(newtask, wig->interval);
 }
 
-static void
-interval_insert_memo_cb(GtkWidget * w, gpointer data)
+static void interval_insert_memo_cb(GtkWidget *w, gpointer data)
 {
-	Wiggy *wig = (Wiggy *) data;
-	GttTask *newtask;
-	if (!wig->interval) return;
+    Wiggy *wig = (Wiggy *) data;
+    GttTask *newtask;
+    if (!wig->interval)
+        return;
 
-	/* Try to get billrates consistent across gap */
-	newtask = gtt_interval_get_parent (wig->interval);
-	newtask = gtt_task_copy (newtask);
-	gtt_task_set_memo (newtask, _("New Diary Entry"));
-	gtt_task_set_notes (newtask, "");
+    /* Try to get billrates consistent across gap */
+    newtask = gtt_interval_get_parent(wig->interval);
+    newtask = gtt_task_copy(newtask);
+    gtt_task_set_memo(newtask, _("New Diary Entry"));
+    gtt_task_set_notes(newtask, "");
 
-	gtt_interval_split (wig->interval, newtask);
-	prop_task_dialog_show (newtask);
+    gtt_interval_split(wig->interval, newtask);
+    prop_task_dialog_show(newtask);
 }
 
-static void
-interval_paste_memo_cb(GtkWidget * w, gpointer data)
+static void interval_paste_memo_cb(GtkWidget *w, gpointer data)
 {
-	Wiggy *wig = (Wiggy *) data;
-	GttTask *newtask = NULL;
+    Wiggy *wig = (Wiggy *) data;
+    GttTask *newtask = NULL;
 
-	if (!cutted_task_list || !wig->interval) return;
+    if (!cutted_task_list || !wig->interval)
+        return;
 
-	/* Pop one off the stack, if stack has any depth to it */
-	if (NULL == cutted_task_list->next)
-	{
-		newtask = gtt_task_copy (cutted_task_list->data);
-	}
-	else
-	{
-		newtask = cutted_task_list->data;
-		cutted_task_list->data = NULL;
-		cutted_task_list =
-		     g_list_delete_link (cutted_task_list, cutted_task_list);
-	}
+    /* Pop one off the stack, if stack has any depth to it */
+    if (NULL == cutted_task_list->next)
+    {
+        newtask = gtt_task_copy(cutted_task_list->data);
+    }
+    else
+    {
+        newtask = cutted_task_list->data;
+        cutted_task_list->data = NULL;
+        cutted_task_list = g_list_delete_link(cutted_task_list, cutted_task_list);
+    }
 
-	gtt_interval_split (wig->interval, newtask);
+    gtt_interval_split(wig->interval, newtask);
 }
 
-static void
-interval_popup_cb (Wiggy *wig)
+static void interval_popup_cb(Wiggy *wig)
 {
-	gtk_menu_popup(GTK_MENU(wig->interval_popup),
-		NULL, NULL, NULL, wig, 1, 0);
-	if (cutted_task_list)
-	{
-		gtk_widget_set_sensitive (wig->interval_paste, TRUE);
-	}
-	else
-	{
-		gtk_widget_set_sensitive (wig->interval_paste, FALSE);
-	}
+    gtk_menu_popup(GTK_MENU(wig->interval_popup), NULL, NULL, NULL, wig, 1, 0);
+    if (cutted_task_list)
+    {
+        gtk_widget_set_sensitive(wig->interval_paste, TRUE);
+    }
+    else
+    {
+        gtk_widget_set_sensitive(wig->interval_paste, FALSE);
+    }
 
-	if (gtt_interval_is_first_interval (wig->interval))
-	{
-		gtk_widget_set_sensitive (wig->interval_merge_up, FALSE);
-		gtk_widget_set_sensitive (wig->interval_move_up, TRUE);
-	}
-	else
-	{
-		gtk_widget_set_sensitive (wig->interval_merge_up, TRUE);
-		gtk_widget_set_sensitive (wig->interval_move_up, FALSE);
-	}
+    if (gtt_interval_is_first_interval(wig->interval))
+    {
+        gtk_widget_set_sensitive(wig->interval_merge_up, FALSE);
+        gtk_widget_set_sensitive(wig->interval_move_up, TRUE);
+    }
+    else
+    {
+        gtk_widget_set_sensitive(wig->interval_merge_up, TRUE);
+        gtk_widget_set_sensitive(wig->interval_move_up, FALSE);
+    }
 
-	if (gtt_interval_is_last_interval (wig->interval))
-	{
-		gtk_widget_set_sensitive (wig->interval_merge_down, FALSE);
-		gtk_widget_set_sensitive (wig->interval_move_down, TRUE);
-	}
-	else
-	{
-		gtk_widget_set_sensitive (wig->interval_merge_down, TRUE);
-		gtk_widget_set_sensitive (wig->interval_move_down, FALSE);
-	}
+    if (gtt_interval_is_last_interval(wig->interval))
+    {
+        gtk_widget_set_sensitive(wig->interval_merge_down, FALSE);
+        gtk_widget_set_sensitive(wig->interval_move_down, TRUE);
+    }
+    else
+    {
+        gtk_widget_set_sensitive(wig->interval_merge_down, TRUE);
+        gtk_widget_set_sensitive(wig->interval_move_down, FALSE);
+    }
 
-	GttTask *tsk = gtt_interval_get_parent(wig->interval);
-	if (gtt_task_is_first_task (tsk))
-	{
-		gtk_widget_set_sensitive (wig->interval_move_up, FALSE);
-	}
-	if (gtt_task_is_last_task (tsk))
-	{
-		gtk_widget_set_sensitive (wig->interval_move_down, FALSE);
-	}
+    GttTask *tsk = gtt_interval_get_parent(wig->interval);
+    if (gtt_task_is_first_task(tsk))
+    {
+        gtk_widget_set_sensitive(wig->interval_move_up, FALSE);
+    }
+    if (gtt_task_is_last_task(tsk))
+    {
+        gtk_widget_set_sensitive(wig->interval_move_down, FALSE);
+    }
 }
 
 /* ============================================================== */
 /* Task Popup Menu Actions */
 
-void
-new_task_ui(GtkWidget *w, gpointer data)
+void new_task_ui(GtkWidget *w, gpointer data)
 {
-	GttProject *prj;
-	GttTask *newtask;
+    GttProject *prj;
+    GttTask *newtask;
 
-	prj = gtt_projects_tree_get_selected_project (projects_tree);
-	if (!prj) return;
+    prj = gtt_projects_tree_get_selected_project(projects_tree);
+    if (!prj)
+        return;
 
-	newtask = gtt_task_new ();
-	gtt_project_prepend_task (prj, newtask);
-	prop_task_dialog_show (newtask);
+    newtask = gtt_task_new();
+    gtt_project_prepend_task(prj, newtask);
+    prop_task_dialog_show(newtask);
 }
 
 /* ============================================================== */
 
-void
-edit_task_ui(GtkWidget *w, gpointer data)
+void edit_task_ui(GtkWidget *w, gpointer data)
 {
-	GttProject *prj;
-	GttTask *task;
+    GttProject *prj;
+    GttTask *task;
 
-	prj = gtt_projects_tree_get_selected_project (projects_tree);
-	if (!prj) return;
+    prj = gtt_projects_tree_get_selected_project(projects_tree);
+    if (!prj)
+        return;
 
-	task = gtt_project_get_first_task(prj);
-	prop_task_dialog_show (task);
+    task = gtt_project_get_first_task(prj);
+    prop_task_dialog_show(task);
 }
 
 /* ============================================================== */
 
-static void
-task_new_task_clicked_cb(GtkWidget * w, gpointer data)
+static void task_new_task_clicked_cb(GtkWidget *w, gpointer data)
 {
-	GttTask *newtask;
-	Wiggy *wig = (Wiggy *) data;
-	newtask = gtt_task_new_insert (wig->task);
-	prop_task_dialog_show (newtask);
+    GttTask *newtask;
+    Wiggy *wig = (Wiggy *) data;
+    newtask = gtt_task_new_insert(wig->task);
+    prop_task_dialog_show(newtask);
 }
 
-static void
-task_edit_task_clicked_cb(GtkWidget * w, gpointer data)
+static void task_edit_task_clicked_cb(GtkWidget *w, gpointer data)
 {
-	Wiggy *wig = (Wiggy *) data;
-	prop_task_dialog_show (wig->task);
+    Wiggy *wig = (Wiggy *) data;
+    prop_task_dialog_show(wig->task);
 }
 
-static void
-task_delete_memo_clicked_cb(GtkWidget * w, gpointer data)
+static void task_delete_memo_clicked_cb(GtkWidget *w, gpointer data)
 {
-	Wiggy *wig = (Wiggy *) data;
+    Wiggy *wig = (Wiggy *) data;
 
-	/* It is physically impossible to cut just the memo, without
-	 * also cutting the time entries, when its the first one. */
-	if (gtt_task_is_first_task (wig->task)) return;
+    /* It is physically impossible to cut just the memo, without
+     * also cutting the time entries, when its the first one. */
+    if (gtt_task_is_first_task(wig->task))
+        return;
 
-	gtt_task_merge_up (wig->task);
+    gtt_task_merge_up(wig->task);
 
-	GList * ctl = g_list_prepend(cutted_task_list, wig->task);
-	gtt_task_remove (wig->task);
-	cutted_task_list = ctl;
+    GList *ctl = g_list_prepend(cutted_task_list, wig->task);
+    gtt_task_remove(wig->task);
+    cutted_task_list = ctl;
 }
 
-static void
-task_delete_times_clicked_cb(GtkWidget * w, gpointer data)
+static void task_delete_times_clicked_cb(GtkWidget *w, gpointer data)
 {
-	Wiggy *wig = (Wiggy *) data;
+    Wiggy *wig = (Wiggy *) data;
 
-	GList * ctl = g_list_prepend(cutted_task_list, wig->task);
-	gtt_task_remove (wig->task);
-	cutted_task_list = ctl;
+    GList *ctl = g_list_prepend(cutted_task_list, wig->task);
+    gtt_task_remove(wig->task);
+    cutted_task_list = ctl;
 }
 
-static void
-task_copy_clicked_cb(GtkWidget * w, gpointer data)
+static void task_copy_clicked_cb(GtkWidget *w, gpointer data)
 {
-	Wiggy *wig = (Wiggy *) data;
+    Wiggy *wig = (Wiggy *) data;
 
-	GttTask * tsk = gtt_task_copy (wig->task);
-	GList * ctl = g_list_prepend(cutted_task_list, tsk);
-	cutted_task_list = ctl;
+    GttTask *tsk = gtt_task_copy(wig->task);
+    GList *ctl = g_list_prepend(cutted_task_list, tsk);
+    cutted_task_list = ctl;
 }
 
-static void
-task_paste_clicked_cb(GtkWidget * w, gpointer data)
+static void task_paste_clicked_cb(GtkWidget *w, gpointer data)
 {
-	Wiggy *wig = (Wiggy *) data;
-	GttTask *newtask = NULL;
+    Wiggy *wig = (Wiggy *) data;
+    GttTask *newtask = NULL;
 
-	if (!cutted_task_list || !wig->task) return;
+    if (!cutted_task_list || !wig->task)
+        return;
 
-	/* Pop one off the stack, if stack has any depth to it */
-	newtask = cutted_task_list->data;
-	cutted_task_list->data = NULL;
-	cutted_task_list =
-	    g_list_delete_link (cutted_task_list, cutted_task_list);
-	
-	gtt_task_insert (wig->task, newtask);
+    /* Pop one off the stack, if stack has any depth to it */
+    newtask = cutted_task_list->data;
+    cutted_task_list->data = NULL;
+    cutted_task_list = g_list_delete_link(cutted_task_list, cutted_task_list);
+
+    gtt_task_insert(wig->task, newtask);
 }
 
-static void
-task_new_interval_cb (GtkWidget * w, gpointer data)
+static void task_new_interval_cb(GtkWidget *w, gpointer data)
 {
-	Wiggy *wig = (Wiggy *) data;
+    Wiggy *wig = (Wiggy *) data;
 
-	if (NULL == wig->edit_ivl) wig->edit_ivl = edit_interval_dialog_new();
+    if (NULL == wig->edit_ivl)
+        wig->edit_ivl = edit_interval_dialog_new();
 
-	wig->interval = gtt_interval_new();
-	gtt_task_add_interval (wig->task, wig->interval);
+    wig->interval = gtt_interval_new();
+    gtt_task_add_interval(wig->task, wig->interval);
 
-	edit_interval_set_interval (wig->edit_ivl, wig->interval);
-	edit_interval_dialog_show (wig->edit_ivl);
+    edit_interval_set_interval(wig->edit_ivl, wig->interval);
+    edit_interval_dialog_show(wig->edit_ivl);
 }
 
-static void
-task_popup_cb (Wiggy *wig)
+static void task_popup_cb(Wiggy *wig)
 {
-	gtk_menu_popup(GTK_MENU(wig->task_popup),
-		NULL, NULL, NULL, wig, 1, 0);
-	if (gtt_task_is_first_task (wig->task))
-	{
-		gtk_widget_set_sensitive (wig->task_delete_memo, FALSE);
-	}
-	else
-	{
-		gtk_widget_set_sensitive (wig->task_delete_memo, TRUE);
-	}
+    gtk_menu_popup(GTK_MENU(wig->task_popup), NULL, NULL, NULL, wig, 1, 0);
+    if (gtt_task_is_first_task(wig->task))
+    {
+        gtk_widget_set_sensitive(wig->task_delete_memo, FALSE);
+    }
+    else
+    {
+        gtk_widget_set_sensitive(wig->task_delete_memo, TRUE);
+    }
 
-	if (cutted_task_list)
-	{
-		gtk_widget_set_sensitive (wig->task_paste, TRUE);
-	}
-	else
-	{
-		gtk_widget_set_sensitive (wig->task_paste, FALSE);
-	}
-
+    if (cutted_task_list)
+    {
+        gtk_widget_set_sensitive(wig->task_paste, TRUE);
+    }
+    else
+    {
+        gtk_widget_set_sensitive(wig->task_paste, FALSE);
+    }
 }
 
 /* ============================================================== */
 
 #if LATER
-static void
-on_print_clicked_cb (GtkWidget *w, gpointer data)
+static void on_print_clicked_cb(GtkWidget *w, gpointer data)
 {
-	GladeXML  *glxml;
-	glxml = gtt_glade_xml_new ("glade/not-implemented.glade", "Not Implemented");
+    GladeXML *glxml;
+    glxml = gtt_glade_xml_new("glade/not-implemented.glade", "Not Implemented");
 }
 #endif
 
 /* ============================================================== */
 /* Publish Button handlers */
 
-static void
-on_publish_clicked_cb (GtkWidget *w, gpointer data)
+static void on_publish_clicked_cb(GtkWidget *w, gpointer data)
 {
-	Wiggy *wig = data;
+    Wiggy *wig = data;
 
-	/* Remind use of the last url that they used. */
-	if (wig->plg && wig->plg->last_url)
-	{
-		gtk_entry_set_text (wig->publish_entry, wig->plg->last_url);
-	}
-	gtk_widget_show (wig->publish_popup);
+    /* Remind use of the last url that they used. */
+    if (wig->plg && wig->plg->last_url)
+    {
+        gtk_entry_set_text(wig->publish_entry, wig->plg->last_url);
+    }
+    gtk_widget_show(wig->publish_popup);
 }
 
-static void
-on_pub_cancel_clicked_cb (GtkWidget *w, gpointer data)
+static void on_pub_cancel_clicked_cb(GtkWidget *w, gpointer data)
 {
-	Wiggy *wig = data;
-	gtk_widget_hide (wig->publish_popup);
+    Wiggy *wig = data;
+    gtk_widget_hide(wig->publish_popup);
 }
 
-static void
-on_pub_ok_clicked_cb (GtkWidget *w, gpointer data)
+static void on_pub_ok_clicked_cb(GtkWidget *w, gpointer data)
 {
-	Wiggy *wig = data;
-	const char * uri = gtk_entry_get_text (wig->publish_entry);
+    Wiggy *wig = data;
+    const char *uri = gtk_entry_get_text(wig->publish_entry);
 
-	remember_uri (wig, uri);
-	if (0 == strncmp (uri, "mailto:", 7))
-	{
-		GtkWidget *mb;
-		mb = gtk_message_dialog_new (GTK_WINDOW(wig->publish_popup),
-		               // GTK_DIALOG_MODAL|GTK_DIALOG_DESTROY_WITH_PARENT,
-		               GTK_DIALOG_MODAL,
-		               GTK_MESSAGE_INFO,
-		               GTK_BUTTONS_CLOSE,
-		               _("mailto: URL is not supported at this time"));
-		g_signal_connect (G_OBJECT(mb), "response",
-		               G_CALLBACK (gtk_widget_destroy), mb);
-		gtk_widget_show (mb);
-	}
-	else
-	{
-		save_to_file (wig, uri);
-	}
-	gtk_widget_hide (wig->publish_popup);
+    remember_uri(wig, uri);
+    if (0 == strncmp(uri, "mailto:", 7))
+    {
+        GtkWidget *mb;
+        mb = gtk_message_dialog_new(
+            GTK_WINDOW(wig->publish_popup),
+            // GTK_DIALOG_MODAL|GTK_DIALOG_DESTROY_WITH_PARENT,
+            GTK_DIALOG_MODAL, GTK_MESSAGE_INFO, GTK_BUTTONS_CLOSE,
+            _("mailto: URL is not supported at this time")
+        );
+        g_signal_connect(G_OBJECT(mb), "response", G_CALLBACK(gtk_widget_destroy), mb);
+        gtk_widget_show(mb);
+    }
+    else
+    {
+        save_to_file(wig, uri);
+    }
+    gtk_widget_hide(wig->publish_popup);
 }
 
 /* ============================================================== */
 
-static void
-on_save_clicked_cb (GtkWidget *w, gpointer data)
+static void on_save_clicked_cb(GtkWidget *w, gpointer data)
 {
-	GtkWidget *dialog;
-	Wiggy *wig = (Wiggy *) data;
+    GtkWidget *dialog;
+    Wiggy *wig = (Wiggy *) data;
 
-	dialog = gtk_file_chooser_dialog_new(_("Save HTML To File"),
-	                                     GTK_WINDOW(wig->top),
-	                                     GTK_FILE_CHOOSER_ACTION_SAVE,
-	                                     GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-	                                     GTK_STOCK_SAVE, GTK_RESPONSE_ACCEPT,
-	                                     NULL);
+    dialog = gtk_file_chooser_dialog_new(
+        _("Save HTML To File"), GTK_WINDOW(wig->top), GTK_FILE_CHOOSER_ACTION_SAVE,
+        GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL, GTK_STOCK_SAVE, GTK_RESPONSE_ACCEPT, NULL
+    );
 
-	gtk_file_chooser_set_do_overwrite_confirmation (GTK_FILE_CHOOSER (dialog), TRUE);
+    gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(dialog), TRUE);
 
-	/* Manually set a per-report history thingy */
-	if (wig->plg && wig->plg->last_url && (0==strncmp("file:/", wig->plg->last_url, 6)))
-	{
-		gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(dialog), wig->plg->last_url);
-	}
-	if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
-		  char *filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
-		  remember_uri (wig, filename);
-		  save_to_file (wig, filename);
-		  g_free(filename);
-	}
-	gtk_widget_destroy(GTK_WIDGET(dialog));
+    /* Manually set a per-report history thingy */
+    if (wig->plg && wig->plg->last_url && (0 == strncmp("file:/", wig->plg->last_url, 6)))
+    {
+        gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(dialog), wig->plg->last_url);
+    }
+    if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT)
+    {
+        char *filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
+        remember_uri(wig, filename);
+        save_to_file(wig, filename);
+        g_free(filename);
+    }
+    gtk_widget_destroy(GTK_WIDGET(dialog));
 }
 
-static void
-on_close_clicked_cb (GtkWidget *w, gpointer data)
+static void on_close_clicked_cb(GtkWidget *w, gpointer data)
 {
-	Wiggy *wig = (Wiggy *) data;
+    Wiggy *wig = (Wiggy *) data;
 
-	if (NULL == wig->top) return;  /* avoid recursive double-free */
-	GtkWidget *topper = wig->top;   /* avoid recursion */
-	wig->top = NULL;
+    if (NULL == wig->top)
+        return;                   /* avoid recursive double-free */
+    GtkWidget *topper = wig->top; /* avoid recursion */
+    wig->top = NULL;
 
-	/* Unplug the timout function, so that timer doesn't
-	 * pop after the destroy has happened. */
-	if (wig->hover_timeout_id)
-	{
-		gtk_timeout_remove (wig->hover_timeout_id);
-		wig->hover_timeout_id = 0;
-		gtk_widget_hide (wig->hover_help_window);
-	}
-	if (wig->hover_kill_id)
-	{
-		gtk_timeout_remove (wig->hover_kill_id);
-		wig->hover_kill_id = 0;
-		gtk_widget_hide (wig->hover_help_window);
-	}
+    /* Unplug the timout function, so that timer doesn't
+     * pop after the destroy has happened. */
+    if (wig->hover_timeout_id)
+    {
+        gtk_timeout_remove(wig->hover_timeout_id);
+        wig->hover_timeout_id = 0;
+        gtk_widget_hide(wig->hover_help_window);
+    }
+    if (wig->hover_kill_id)
+    {
+        gtk_timeout_remove(wig->hover_kill_id);
+        wig->hover_kill_id = 0;
+        gtk_widget_hide(wig->hover_help_window);
+    }
 
-	/* kill the display widget */
-	gtk_widget_destroy (topper);
+    /* kill the display widget */
+    gtk_widget_destroy(topper);
 
-	/* close the main journal window ... everything */
-	if (wig->prj) gtt_project_remove_notifier (wig->prj, redraw, wig);
-	edit_interval_dialog_destroy (wig->edit_ivl);
-	wig->prj = NULL;
+    /* close the main journal window ... everything */
+    if (wig->prj)
+        gtt_project_remove_notifier(wig->prj, redraw, wig);
+    edit_interval_dialog_destroy(wig->edit_ivl);
+    wig->prj = NULL;
 
-	gtt_ghtml_destroy (wig->gh);
-	g_free (wig->filepath);
+    gtt_ghtml_destroy(wig->gh);
+    g_free(wig->filepath);
 
-	wig->gh = NULL;
-	wig->html = NULL;
-	g_free (wig);
+    wig->gh = NULL;
+    wig->html = NULL;
+    g_free(wig);
 }
 
-static void
-destroy_cb(GtkObject *ob, gpointer data)
+static void destroy_cb(GtkObject *ob, gpointer data)
 {
 }
 
-static void
-on_refresh_clicked_cb (GtkWidget *w, gpointer data)
+static void on_refresh_clicked_cb(GtkWidget *w, gpointer data)
 {
-	Wiggy *wig = (Wiggy *) data;
-	redraw (wig->prj, data);
+    Wiggy *wig = (Wiggy *) data;
+    redraw(wig->prj, data);
 }
 
 /* ============================================================== */
 /* html events */
 
-static void
-html_link_clicked_cb(GtkHTML *doc, const gchar * url, gpointer data)
+static void html_link_clicked_cb(GtkHTML *doc, const gchar *url, gpointer data)
 {
-	Wiggy *wig = (Wiggy *) data;
-	gpointer addr = NULL;
-	char *str;
+    Wiggy *wig = (Wiggy *) data;
+    gpointer addr = NULL;
+    char *str;
 
-	/* h4x0r al3rt -- bare-naked pointer refernces ! */
-	/* decode the address buried in the URL (if its there) */
-	str = strstr (url, "0x");
-	if (str)
-	{
-		addr = (gpointer) strtoul (str, NULL, 16);
-	}
+    /* h4x0r al3rt -- bare-naked pointer refernces ! */
+    /* decode the address buried in the URL (if its there) */
+    str = strstr(url, "0x");
+    if (str)
+    {
+        addr = (gpointer) strtoul(str, NULL, 16);
+    }
 
-	if (0 == strncmp (url, "gtt:interval", 12))
-	{
-		wig->interval = addr;
-		wig->task = NULL;
-		if (addr) interval_popup_cb (wig);
-	}
-	else
-	if (0 == strncmp (url, "gtt:task", 8))
-	{
-		wig->task = addr;
-		wig->interval = NULL;
-		if (addr) task_popup_cb (wig);
-	}
-	else
-	if (0 == strncmp (url, "gtt:proj", 8))
-	{
-		GttProject *prj = addr;
-		char * path;
+    if (0 == strncmp(url, "gtt:interval", 12))
+    {
+        wig->interval = addr;
+        wig->task = NULL;
+        if (addr)
+            interval_popup_cb(wig);
+    }
+    else if (0 == strncmp(url, "gtt:task", 8))
+    {
+        wig->task = addr;
+        wig->interval = NULL;
+        if (addr)
+            task_popup_cb(wig);
+    }
+    else if (0 == strncmp(url, "gtt:proj", 8))
+    {
+        GttProject *prj = addr;
+        char *path;
 
-		wig->task = NULL;
-		wig->interval = NULL;
+        wig->task = NULL;
+        wig->interval = NULL;
 
-		path = gtt_ghtml_resolve_path (JOURNAL_REPORT, wig->filepath);
-		do_show_report (path, NULL, NULL, prj, FALSE, NULL);
-	}
-	else
-	{
-		/* All other URL's are handed off to GnomeVFS, which will
-		 * deal with them more or less appropriately.  */
-		do_show_report (url, NULL, NULL, NULL, FALSE, NULL);
-	}
+        path = gtt_ghtml_resolve_path(JOURNAL_REPORT, wig->filepath);
+        do_show_report(path, NULL, NULL, prj, FALSE, NULL);
+    }
+    else
+    {
+        /* All other URL's are handed off to GnomeVFS, which will
+         * deal with them more or less appropriately.  */
+        do_show_report(url, NULL, NULL, NULL, FALSE, NULL);
+    }
 }
 
 /* ============================================================== */
 
 static void
-html_url_requested_cb(GtkHTML *doc, const gchar * url,
-                      GtkHTMLStream *handle, gpointer data)
+html_url_requested_cb(GtkHTML *doc, const gchar *url, GtkHTMLStream *handle, gpointer data)
 {
-	Wiggy *wig = data;
-	const char * path = gtt_ghtml_resolve_path (url, wig->filepath);
-	if (!path) return;
+    Wiggy *wig = data;
+    const char *path = gtt_ghtml_resolve_path(url, wig->filepath);
+    if (!path)
+        return;
 
-	GnomeVFSResult    result;
-	GnomeVFSHandle   *vfs;
-	result = gnome_vfs_open (&vfs, path, GNOME_VFS_OPEN_READ);
+    GnomeVFSResult result;
+    GnomeVFSHandle *vfs;
+    result = gnome_vfs_open(&vfs, path, GNOME_VFS_OPEN_READ);
 
-	if (GNOME_VFS_OK != result) return;
+    if (GNOME_VFS_OK != result)
+        return;
 
 #define BSZ 16000
-	char buff[BSZ];
-	GnomeVFSFileSize  bytes_read;
-	result = gnome_vfs_read (vfs, buff, BSZ, &bytes_read);
-	while (GNOME_VFS_OK == result)
-	{
-		gtk_html_write (doc, handle, buff, bytes_read);
-		result = gnome_vfs_read (vfs, buff, BSZ, &bytes_read);
-	}
-	gnome_vfs_close (vfs);
+    char buff[BSZ];
+    GnomeVFSFileSize bytes_read;
+    result = gnome_vfs_read(vfs, buff, BSZ, &bytes_read);
+    while (GNOME_VFS_OK == result)
+    {
+        gtk_html_write(doc, handle, buff, bytes_read);
+        result = gnome_vfs_read(vfs, buff, BSZ, &bytes_read);
+    }
+    gnome_vfs_close(vfs);
 }
 
 /* ============================================================== */
@@ -840,170 +804,169 @@ html_url_requested_cb(GtkHTML *doc, const gchar * url,
  * XXX we should display memos, etc.
  */
 
-static char *
-get_hover_msg (const gchar *url)
+static char *get_hover_msg(const gchar *url)
 {
-	char * str;
-	gpointer addr = NULL;
+    char *str;
+    gpointer addr = NULL;
 
-	/* h4x0r al3rt bare-naked pointer parsing! */
-	str = strstr (url, "0x");
-	if (str)
-	{
-		addr = (gpointer) strtoul (str, NULL, 16);
-	}
+    /* h4x0r al3rt bare-naked pointer parsing! */
+    str = strstr(url, "0x");
+    if (str)
+    {
+        addr = (gpointer) strtoul(str, NULL, 16);
+    }
 
-	/* XXX todo- -- it would be nice to make these popups
-	 * depend on the type of report tht the user is viewing.
-	 * should we pull them out of a scheme markup ??
-	 *
-	 * See http://developer.gnome.org/doc/API/2.4/pango/PangoMarkupFormat.html
-	 * for allowed markup contents.
-	 */
-	if (addr && (0 == strncmp ("gtt:task:", url, 9)))
-	{
-		GttTask *task = addr;
-		const char * memo = gtt_task_get_memo(task);
-		const char * notes = gtt_task_get_notes(task);
-		char * msg = g_strdup_printf ("<b><big>%s</big></b>\n%s\n", memo, notes);
-		return msg;
-	}
+    /* XXX todo- -- it would be nice to make these popups
+     * depend on the type of report tht the user is viewing.
+     * should we pull them out of a scheme markup ??
+     *
+     * See http://developer.gnome.org/doc/API/2.4/pango/PangoMarkupFormat.html
+     * for allowed markup contents.
+     */
+    if (addr && (0 == strncmp("gtt:task:", url, 9)))
+    {
+        GttTask *task = addr;
+        const char *memo = gtt_task_get_memo(task);
+        const char *notes = gtt_task_get_notes(task);
+        char *msg = g_strdup_printf("<b><big>%s</big></b>\n%s\n", memo, notes);
+        return msg;
+    }
 
-	if (0 == strncmp (url, "gtt:proj:", 9))
-	{
-		GttProject *prj = addr;
-		const char * title = gtt_project_get_title (prj);
-		const char * desc = gtt_project_get_desc (prj);
-		const char * notes = gtt_project_get_notes (prj);
-		char * msg = g_strdup_printf ("<b><big>%s</big></b>\n"
-		                              "<b>%s</b>\n"
-		                              "%s", title, desc, notes);
-		return msg;
-	}
+    if (0 == strncmp(url, "gtt:proj:", 9))
+    {
+        GttProject *prj = addr;
+        const char *title = gtt_project_get_title(prj);
+        const char *desc = gtt_project_get_desc(prj);
+        const char *notes = gtt_project_get_notes(prj);
+        char *msg = g_strdup_printf(
+            "<b><big>%s</big></b>\n"
+            "<b>%s</b>\n"
+            "%s",
+            title, desc, notes
+        );
+        return msg;
+    }
 
-	char * msg = _("Left-click to bring up menu");
-	return g_strdup (msg);
+    char *msg = _("Left-click to bring up menu");
+    return g_strdup(msg);
 }
 
-static gint
-hover_kill_func(gpointer data)
+static gint hover_kill_func(gpointer data)
 {
-	Wiggy *wig = data;
+    Wiggy *wig = data;
 
-	gtk_widget_hide (wig->hover_help_window);
-	return 0;
+    gtk_widget_hide(wig->hover_help_window);
+    return 0;
 }
 
-static gint
-hover_timer_func(gpointer data)
+static gint hover_timer_func(gpointer data)
 {
-	Wiggy *wig = data;
+    Wiggy *wig = data;
 
-	gint px=0, py=0, rx=0, ry=0;
-	gtk_widget_get_pointer (wig->hover_help_window, &px, &py);
-	gtk_window_get_position (GTK_WINDOW(wig->hover_help_window), &rx, &ry);
-	rx += px;
-	ry += py;
-	rx += 25; /* move it out from under the cursor shape */
-	gtk_window_move (GTK_WINDOW(wig->hover_help_window), rx, ry);
-	gtk_widget_show (wig->hover_help_window);
+    gint px = 0, py = 0, rx = 0, ry = 0;
+    gtk_widget_get_pointer(wig->hover_help_window, &px, &py);
+    gtk_window_get_position(GTK_WINDOW(wig->hover_help_window), &rx, &ry);
+    rx += px;
+    ry += py;
+    rx += 25; /* move it out from under the cursor shape */
+    gtk_window_move(GTK_WINDOW(wig->hover_help_window), rx, ry);
+    gtk_widget_show(wig->hover_help_window);
 
-	/* 8000 milisecs = 8 secs */
-	/* XXX the 'hover-loose-focus' tool below seems to be broken, and
-	 * if we don't do something, gtt will leave visual turds on the
-	 * screen indefinitely.  So, in case of turds, hide the hover help
-	 * after 8 seconds.
-	 */
-	wig->hover_kill_id = gtk_timeout_add (8000, hover_kill_func, wig);
-	return 0;
+    /* 8000 milisecs = 8 secs */
+    /* XXX the 'hover-loose-focus' tool below seems to be broken, and
+     * if we don't do something, gtt will leave visual turds on the
+     * screen indefinitely.  So, in case of turds, hide the hover help
+     * after 8 seconds.
+     */
+    wig->hover_kill_id = gtk_timeout_add(8000, hover_kill_func, wig);
+    return 0;
 }
 
 /* If the html window looses focus, we've got to hide the flyover help;
  * otherwise it will leave garbage on the screen.
  */
-static gboolean
-hover_loose_focus(GtkWidget *w, GdkEventFocus *ev, gpointer data)
+static gboolean hover_loose_focus(GtkWidget *w, GdkEventFocus *ev, gpointer data)
 {
-	Wiggy *wig = data;
+    Wiggy *wig = data;
 
-	if (wig->hover_timeout_id)
-	{
-		gtk_timeout_remove (wig->hover_timeout_id);
-		wig->hover_timeout_id = 0;
-		gtk_widget_hide (wig->hover_help_window);
-	}
-	return 0;
+    if (wig->hover_timeout_id)
+    {
+        gtk_timeout_remove(wig->hover_timeout_id);
+        wig->hover_timeout_id = 0;
+        gtk_widget_hide(wig->hover_help_window);
+    }
+    return 0;
 }
 
-static void
-html_on_url_cb(GtkHTML *doc, const gchar * url, gpointer data)
+static void html_on_url_cb(GtkHTML *doc, const gchar *url, gpointer data)
 {
-	Wiggy *wig = data;
-	if (NULL == wig->top) return;
+    Wiggy *wig = data;
+    if (NULL == wig->top)
+        return;
 
-	/* Create and initialize the hover-help window */
-	if (!wig->hover_help_window)
-	{
-		wig->hover_help_window = gtk_window_new(GTK_WINDOW_POPUP);
-		GtkWindow *wino = GTK_WINDOW (wig->hover_help_window);
-		gtk_window_set_decorated (wino, FALSE);
-		gtk_window_set_destroy_with_parent (wino, TRUE);
-		gtk_window_set_transient_for (wino, GTK_WINDOW(wig->top));
-		// gtk_window_set_type_hint (wino, GDK_WINDOW_TYPE_HINT_SPLASHSCREEN);
-		gtk_window_set_resizable (wino, FALSE);  /* FALSE to enable auto-resize */
+    /* Create and initialize the hover-help window */
+    if (!wig->hover_help_window)
+    {
+        wig->hover_help_window = gtk_window_new(GTK_WINDOW_POPUP);
+        GtkWindow *wino = GTK_WINDOW(wig->hover_help_window);
+        gtk_window_set_decorated(wino, FALSE);
+        gtk_window_set_destroy_with_parent(wino, TRUE);
+        gtk_window_set_transient_for(wino, GTK_WINDOW(wig->top));
+        // gtk_window_set_type_hint (wino, GDK_WINDOW_TYPE_HINT_SPLASHSCREEN);
+        gtk_window_set_resizable(wino, FALSE); /* FALSE to enable auto-resize */
 
-		/* There must be a better way to draw a line around the box ?? */
-		GtkWidget *frame = gtk_frame_new (NULL);
-		gtk_container_add(GTK_CONTAINER(wino), frame);
-		gtk_container_set_resize_mode (GTK_CONTAINER(frame), GTK_RESIZE_PARENT);
-		gtk_widget_show (frame);
+        /* There must be a better way to draw a line around the box ?? */
+        GtkWidget *frame = gtk_frame_new(NULL);
+        gtk_container_add(GTK_CONTAINER(wino), frame);
+        gtk_container_set_resize_mode(GTK_CONTAINER(frame), GTK_RESIZE_PARENT);
+        gtk_widget_show(frame);
 
-		/* There must be a better way to pad the text all around ?? */
-		GtkWidget *align = gtk_alignment_new (0.5, 0.5, 1.0, 1.0);
-		// gtk_alignment_set_padding (GTK_ALIGNMENT(align), 6, 6, 6, 6);
-		gtk_container_add(GTK_CONTAINER(frame), align);
-		gtk_container_set_resize_mode (GTK_CONTAINER(align), GTK_RESIZE_PARENT);
-		gtk_widget_show (align);
+        /* There must be a better way to pad the text all around ?? */
+        GtkWidget *align = gtk_alignment_new(0.5, 0.5, 1.0, 1.0);
+        // gtk_alignment_set_padding (GTK_ALIGNMENT(align), 6, 6, 6, 6);
+        gtk_container_add(GTK_CONTAINER(frame), align);
+        gtk_container_set_resize_mode(GTK_CONTAINER(align), GTK_RESIZE_PARENT);
+        gtk_widget_show(align);
 
-		GtkWidget *label = gtk_label_new ("xxx");
-		wig->hover_label = GTK_LABEL (label);
-		gtk_container_add(GTK_CONTAINER(align), label);
-		gtk_widget_show (label);
+        GtkWidget *label = gtk_label_new("xxx");
+        wig->hover_label = GTK_LABEL(label);
+        gtk_container_add(GTK_CONTAINER(align), label);
+        gtk_widget_show(label);
 
-		/* So that we can loose focus later */
-		gtk_window_set_focus (GTK_WINDOW(wig->top), GTK_WIDGET(wig->html));
+        /* So that we can loose focus later */
+        gtk_window_set_focus(GTK_WINDOW(wig->top), GTK_WIDGET(wig->html));
 
-		/* Set up in initial default, so later move works. */
-		int px=0, py=0, rx=0, ry=0;
-		gtk_widget_get_pointer (GTK_WIDGET(wig->top), &px, &py);
-		gtk_window_get_position (GTK_WINDOW(wig->top), &rx, &ry);
-		gtk_window_move (wino, rx+px, ry+py);
-	}
+        /* Set up in initial default, so later move works. */
+        int px = 0, py = 0, rx = 0, ry = 0;
+        gtk_widget_get_pointer(GTK_WIDGET(wig->top), &px, &py);
+        gtk_window_get_position(GTK_WINDOW(wig->top), &rx, &ry);
+        gtk_window_move(wino, rx + px, ry + py);
+    }
 
-	if (url)
-	{
-		char * msg = get_hover_msg (url);
-		gtk_label_set_markup (wig->hover_label, msg);
-		gtk_container_resize_children (GTK_CONTAINER(wig->hover_help_window));
-		gtk_container_check_resize (GTK_CONTAINER(wig->hover_help_window));
-		g_free (msg);
-	}
+    if (url)
+    {
+        char *msg = get_hover_msg(url);
+        gtk_label_set_markup(wig->hover_label, msg);
+        gtk_container_resize_children(GTK_CONTAINER(wig->hover_help_window));
+        gtk_container_check_resize(GTK_CONTAINER(wig->hover_help_window));
+        g_free(msg);
+    }
 
-	/* If hovering over a URL, bring up the help popup after one second. */
-	if (url)
-	{
-		/* 600 milliseconds == 0.6 second */
-		wig->hover_timeout_id = gtk_timeout_add (600, hover_timer_func, wig);
-	}
-	else
-	{
-		if (wig->hover_timeout_id)
-		{
-			gtk_timeout_remove (wig->hover_timeout_id);
-			wig->hover_timeout_id = 0;
-			gtk_widget_hide (wig->hover_help_window);
-		}
-	}
+    /* If hovering over a URL, bring up the help popup after one second. */
+    if (url)
+    {
+        /* 600 milliseconds == 0.6 second */
+        wig->hover_timeout_id = gtk_timeout_add(600, hover_timer_func, wig);
+    }
+    else
+    {
+        if (wig->hover_timeout_id)
+        {
+            gtk_timeout_remove(wig->hover_timeout_id);
+            wig->hover_timeout_id = 0;
+            gtk_widget_hide(wig->hover_help_window);
+        }
+    }
 }
 
 /* ============================================================== */
@@ -1021,94 +984,96 @@ static QofBook *book = NULL;
  * lists of qof entities, and using that to figure out the returned
  * type.  Need to change GttProject to derive from QofEntity.
  */
-static GList *
-perform_form_query (KvpFrame *kvpf)
+static GList *perform_form_query(KvpFrame *kvpf)
 {
-	GList *results, *n;
+    GList *results, *n;
 
-	if (!kvpf) return NULL;
+    if (!kvpf)
+        return NULL;
 
-	/* Allow the user to enable form debugging by adding the following html:
-	 * <input type="hidden" name="debug" value="1">
-	 */
-	char *user_debug = kvp_frame_get_string (kvpf, "debug");
-	if (user_debug)
-	{
-		printf ("Debug: HTML Form Input=%s\n", kvp_frame_to_string (kvpf));
-	}
+    /* Allow the user to enable form debugging by adding the following html:
+     * <input type="hidden" name="debug" value="1">
+     */
+    char *user_debug = kvp_frame_get_string(kvpf, "debug");
+    if (user_debug)
+    {
+        printf("Debug: HTML Form Input=%s\n", kvp_frame_to_string(kvpf));
+    }
 
-	QofSqlQuery *q = qof_sql_query_new();
+    QofSqlQuery *q = qof_sql_query_new();
 
-	if (!book) book = qof_book_new();
-	qof_sql_query_set_book (q, book);
-	qof_sql_query_set_kvp (q, kvpf);
+    if (!book)
+        book = qof_book_new();
+    qof_sql_query_set_book(q, book);
+    qof_sql_query_set_kvp(q, kvpf);
 
-	char *query_string = kvp_frame_get_string (kvpf, "query");
-	if (!query_string) return NULL;
-	if (0 == query_string[0]) return NULL;
+    char *query_string = kvp_frame_get_string(kvpf, "query");
+    if (!query_string)
+        return NULL;
+    if (0 == query_string[0])
+        return NULL;
 
-	if (user_debug)
-	{
-		printf ("earliest-end-date = %s\n", kvp_frame_get_string (kvpf, "earliest-end-date"));
-		printf ("latest-start-date = %s\n", kvp_frame_get_string (kvpf, "latest-start-date"));
-		printf ("Debug: Will run the query %s\n", query_string);
-	}
+    if (user_debug)
+    {
+        printf("earliest-end-date = %s\n", kvp_frame_get_string(kvpf, "earliest-end-date"));
+        printf("latest-start-date = %s\n", kvp_frame_get_string(kvpf, "latest-start-date"));
+        printf("Debug: Will run the query %s\n", query_string);
+    }
 
-	/* Run the query */
-	results = qof_sql_query_run (q, query_string);
+    /* Run the query */
+    results = qof_sql_query_run(q, query_string);
 
-	/* XXX free q after using it */
+    /* XXX free q after using it */
 
-	if (user_debug)
-	{
-		printf ("Debug: Query returned the following matching projects:\n");
-		/* Print out the results */
-		for (n=results; n; n=n->next)
-		{
-			GttProject *prj = n->data;
-			printf ("\t%s\n", gtt_project_get_title(prj));
-		}
-	}
+    if (user_debug)
+    {
+        printf("Debug: Query returned the following matching projects:\n");
+        /* Print out the results */
+        for (n = results; n; n = n->next)
+        {
+            GttProject *prj = n->data;
+            printf("\t%s\n", gtt_project_get_title(prj));
+        }
+    }
 
-	return results;
+    return results;
 }
 
-static void
-submit_clicked_cb(GtkHTML * doc,
-                  const gchar * method,
-                  const gchar * url,
-                  const gchar * encoding,
-                  gpointer data)
+static void submit_clicked_cb(
+    GtkHTML *doc, const gchar *method, const gchar *url, const gchar *encoding, gpointer data
+)
 {
-	Wiggy *wig = (Wiggy *) data;
-	const char *path;
-	KvpFrame *kvpf;
-	KvpValue *val;
-	GList *qresults;
+    Wiggy *wig = (Wiggy *) data;
+    const char *path;
+    KvpFrame *kvpf;
+    KvpValue *val;
+    GList *qresults;
 
-	if (!wig->prj) wig->prj = gtt_projects_tree_get_selected_project (projects_tree);
+    if (!wig->prj)
+        wig->prj = gtt_projects_tree_get_selected_project(projects_tree);
 
-	kvpf = kvp_frame_new ();
-	kvp_frame_add_url_encoding (kvpf, encoding);
+    kvpf = kvp_frame_new();
+    kvp_frame_add_url_encoding(kvpf, encoding);
 
-	/* If there is a report specified, use that, else use
-	 * the report specified in the form "action" */
-	val = kvp_frame_get_slot (kvpf, "report-path");
-	path = kvp_value_get_string (val);
-	if (!path) path = url;
-	path = gtt_ghtml_resolve_path (path, wig->filepath);
+    /* If there is a report specified, use that, else use
+     * the report specified in the form "action" */
+    val = kvp_frame_get_slot(kvpf, "report-path");
+    path = kvp_value_get_string(val);
+    if (!path)
+        path = url;
+    path = gtt_ghtml_resolve_path(path, wig->filepath);
 
-	/* Build an ad-hoc query */
-	qresults = perform_form_query (kvpf);
+    /* Build an ad-hoc query */
+    qresults = perform_form_query(kvpf);
 
-	/* Open a new window */
-	do_show_report (path, NULL, kvpf, wig->prj, TRUE, qresults);
+    /* Open a new window */
+    do_show_report(path, NULL, kvpf, wig->prj, TRUE, qresults);
 
-	/* XXX We cannnot reuse the same window from this callback, we
-	 * have to let the callback return first, else we get a nasty error.
-	 * This should be fixed: if the query and the result form is the
-	 * same, we should re-use the same window.
-	 */
+    /* XXX We cannnot reuse the same window from this callback, we
+     * have to let the callback return first, else we get a nasty error.
+     * This should be fixed: if the query and the result form is the
+     * same, we should re-use the same window.
+     */
 #if 0
 	g_free (wig->filepath);
 	wig->filepath = path;
@@ -1118,281 +1083,306 @@ submit_clicked_cb(GtkHTML * doc,
 
 /* ============================================================== */
 
-static void
-do_show_report (const char * report, GttPlugin *plg,
-                KvpFrame *kvpf, GttProject *prj,
-                gboolean did_query, GList *prjlist)
+static void do_show_report(
+    const char *report, GttPlugin *plg, KvpFrame *kvpf, GttProject *prj, gboolean did_query,
+    GList *prjlist
+)
 {
-	GtkWidget *jnl_top, *jnl_viewport;
-	GladeXML  *glxml;
-	Wiggy *wig;
+    GtkWidget *jnl_top, *jnl_viewport;
+    GladeXML *glxml;
+    Wiggy *wig;
 
-	glxml = gtt_glade_xml_new ("glade/journal.glade", "Journal Window");
+    glxml = gtt_glade_xml_new("glade/journal.glade", "Journal Window");
 
-	jnl_top = glade_xml_get_widget (glxml, "Journal Window");
-	jnl_viewport = glade_xml_get_widget (glxml, "Journal ScrollWin");
+    jnl_top = glade_xml_get_widget(glxml, "Journal Window");
+    jnl_viewport = glade_xml_get_widget(glxml, "Journal ScrollWin");
 
-	wig = g_new0 (Wiggy, 1);
-	wig->edit_ivl = NULL;
+    wig = g_new0(Wiggy, 1);
+    wig->edit_ivl = NULL;
 
-	wig->top = jnl_top;
-	wig->plg = plg;
+    wig->top = jnl_top;
+    wig->plg = plg;
 
-	if (plg) gtk_window_set_title (GTK_WINDOW(jnl_top), plg->name);
+    if (plg)
+        gtk_window_set_title(GTK_WINDOW(jnl_top), plg->name);
 
-	/* Create browser, plug it into the viewport */
-	wig->html = GTK_HTML(gtk_html_new());
-	gtk_html_set_editable (wig->html, FALSE);
-	gtk_container_add(GTK_CONTAINER(jnl_viewport), GTK_WIDGET(wig->html));
+    /* Create browser, plug it into the viewport */
+    wig->html = GTK_HTML(gtk_html_new());
+    gtk_html_set_editable(wig->html, FALSE);
+    gtk_container_add(GTK_CONTAINER(jnl_viewport), GTK_WIDGET(wig->html));
 
-	wig->gh = gtt_ghtml_new();
-	gtt_ghtml_set_stream (wig->gh, wig, wiggy_open, wiggy_write,
-		wiggy_close, wiggy_error);
+    wig->gh = gtt_ghtml_new();
+    gtt_ghtml_set_stream(wig->gh, wig, wiggy_open, wiggy_write, wiggy_close, wiggy_error);
 
-	/* ---------------------------------------------------- */
-	/* Signals for the browser, and the Journal window */
+    /* ---------------------------------------------------- */
+    /* Signals for the browser, and the Journal window */
 
-	glade_xml_signal_connect_data (glxml, "on_close_clicked",
-	        GTK_SIGNAL_FUNC (on_close_clicked_cb), wig);
+    glade_xml_signal_connect_data(
+        glxml, "on_close_clicked", GTK_SIGNAL_FUNC(on_close_clicked_cb), wig
+    );
 
-	glade_xml_signal_connect_data (glxml, "on_save_clicked",
-	        GTK_SIGNAL_FUNC (on_save_clicked_cb), wig);
+    glade_xml_signal_connect_data(
+        glxml, "on_save_clicked", GTK_SIGNAL_FUNC(on_save_clicked_cb), wig
+    );
 
 #if LATER
-	glade_xml_signal_connect_data (glxml, "on_print_clicked",
-	        GTK_SIGNAL_FUNC (on_print_clicked_cb), wig);
+    glade_xml_signal_connect_data(
+        glxml, "on_print_clicked", GTK_SIGNAL_FUNC(on_print_clicked_cb), wig
+    );
 #endif
 
-	glade_xml_signal_connect_data (glxml, "on_publish_clicked",
-	        GTK_SIGNAL_FUNC (on_publish_clicked_cb), wig);
+    glade_xml_signal_connect_data(
+        glxml, "on_publish_clicked", GTK_SIGNAL_FUNC(on_publish_clicked_cb), wig
+    );
 
-	glade_xml_signal_connect_data (glxml, "on_refresh_clicked",
-	        GTK_SIGNAL_FUNC (on_refresh_clicked_cb), wig);
+    glade_xml_signal_connect_data(
+        glxml, "on_refresh_clicked", GTK_SIGNAL_FUNC(on_refresh_clicked_cb), wig
+    );
 
-	g_signal_connect (G_OBJECT(wig->top), "destroy",
-			G_CALLBACK (destroy_cb), wig);
+    g_signal_connect(G_OBJECT(wig->top), "destroy", G_CALLBACK(destroy_cb), wig);
 
-	g_signal_connect (G_OBJECT(wig->html), "link_clicked",
-			G_CALLBACK (html_link_clicked_cb), wig);
+    g_signal_connect(
+        G_OBJECT(wig->html), "link_clicked", G_CALLBACK(html_link_clicked_cb), wig
+    );
 
-	g_signal_connect (G_OBJECT(wig->html), "submit",
-			G_CALLBACK (submit_clicked_cb), wig);
+    g_signal_connect(G_OBJECT(wig->html), "submit", G_CALLBACK(submit_clicked_cb), wig);
 
-	g_signal_connect (G_OBJECT(wig->html), "url_requested",
-			G_CALLBACK (html_url_requested_cb), wig);
+    g_signal_connect(
+        G_OBJECT(wig->html), "url_requested", G_CALLBACK(html_url_requested_cb), wig
+    );
 
-	g_signal_connect(G_OBJECT(wig->html), "on_url",
-		G_CALLBACK(html_on_url_cb), wig);
+    g_signal_connect(G_OBJECT(wig->html), "on_url", G_CALLBACK(html_on_url_cb), wig);
 
-	g_signal_connect(G_OBJECT(wig->html), "focus_out_event",
-		G_CALLBACK(hover_loose_focus), wig);
+    g_signal_connect(
+        G_OBJECT(wig->html), "focus_out_event", G_CALLBACK(hover_loose_focus), wig
+    );
 
-	gtk_widget_show (GTK_WIDGET(wig->html));
-	gtk_widget_show (jnl_top);
+    gtk_widget_show(GTK_WIDGET(wig->html));
+    gtk_widget_show(jnl_top);
 
-	/* ---------------------------------------------------- */
-	/* This is the popup for asking for the user to input an URL. */
+    /* ---------------------------------------------------- */
+    /* This is the popup for asking for the user to input an URL. */
 
-	glxml = gtt_glade_xml_new ("glade/journal.glade", "Publish Dialog");
-	wig->publish_popup = glade_xml_get_widget (glxml, "Publish Dialog");
-	wig->publish_entry = GTK_ENTRY(glade_xml_get_widget (glxml, "url entry"));
+    glxml = gtt_glade_xml_new("glade/journal.glade", "Publish Dialog");
+    wig->publish_popup = glade_xml_get_widget(glxml, "Publish Dialog");
+    wig->publish_entry = GTK_ENTRY(glade_xml_get_widget(glxml, "url entry"));
 
-	glade_xml_signal_connect_data (glxml, "on_pub_help_clicked",
-	        GTK_SIGNAL_FUNC (gtt_help_popup), NULL);
+    glade_xml_signal_connect_data(
+        glxml, "on_pub_help_clicked", GTK_SIGNAL_FUNC(gtt_help_popup), NULL
+    );
 
-	glade_xml_signal_connect_data (glxml, "on_pub_cancel_clicked",
-	        GTK_SIGNAL_FUNC (on_pub_cancel_clicked_cb), wig);
+    glade_xml_signal_connect_data(
+        glxml, "on_pub_cancel_clicked", GTK_SIGNAL_FUNC(on_pub_cancel_clicked_cb), wig
+    );
 
-	glade_xml_signal_connect_data (glxml, "on_pub_ok_clicked",
-	        GTK_SIGNAL_FUNC (on_pub_ok_clicked_cb), wig);
+    glade_xml_signal_connect_data(
+        glxml, "on_pub_ok_clicked", GTK_SIGNAL_FUNC(on_pub_ok_clicked_cb), wig
+    );
 
-	/* ---------------------------------------------------- */
-	/* This is the popup menu that says 'edit/delete/merge' */
-	/* for intervals */
+    /* ---------------------------------------------------- */
+    /* This is the popup menu that says 'edit/delete/merge' */
+    /* for intervals */
 
-	glxml = gtt_glade_xml_new ("glade/interval_popup.glade", "Interval Popup");
-	wig->interval_popup = glade_xml_get_widget (glxml, "Interval Popup");
-	wig->interval_paste = glade_xml_get_widget (glxml, "paste_memo");
-	wig->interval_merge_up = glade_xml_get_widget (glxml, "merge_up");
-	wig->interval_merge_down = glade_xml_get_widget (glxml, "merge_down");
-	wig->interval_move_up = glade_xml_get_widget (glxml, "move_up");
-	wig->interval_move_down = glade_xml_get_widget (glxml, "move_down");
-	wig->interval=NULL;
+    glxml = gtt_glade_xml_new("glade/interval_popup.glade", "Interval Popup");
+    wig->interval_popup = glade_xml_get_widget(glxml, "Interval Popup");
+    wig->interval_paste = glade_xml_get_widget(glxml, "paste_memo");
+    wig->interval_merge_up = glade_xml_get_widget(glxml, "merge_up");
+    wig->interval_merge_down = glade_xml_get_widget(glxml, "merge_down");
+    wig->interval_move_up = glade_xml_get_widget(glxml, "move_up");
+    wig->interval_move_down = glade_xml_get_widget(glxml, "move_down");
+    wig->interval = NULL;
 
-	glade_xml_signal_connect_data (glxml, "on_new_interval_activate",
-	        GTK_SIGNAL_FUNC (interval_new_clicked_cb), wig);
+    glade_xml_signal_connect_data(
+        glxml, "on_new_interval_activate", GTK_SIGNAL_FUNC(interval_new_clicked_cb), wig
+    );
 
-	glade_xml_signal_connect_data (glxml, "on_edit_activate",
-	        GTK_SIGNAL_FUNC (interval_edit_clicked_cb), wig);
+    glade_xml_signal_connect_data(
+        glxml, "on_edit_activate", GTK_SIGNAL_FUNC(interval_edit_clicked_cb), wig
+    );
 
-	glade_xml_signal_connect_data (glxml, "on_delete_activate",
-	        GTK_SIGNAL_FUNC (interval_delete_clicked_cb), wig);
+    glade_xml_signal_connect_data(
+        glxml, "on_delete_activate", GTK_SIGNAL_FUNC(interval_delete_clicked_cb), wig
+    );
 
-	glade_xml_signal_connect_data (glxml, "on_merge_up_activate",
-	        GTK_SIGNAL_FUNC (interval_merge_up_clicked_cb), wig);
+    glade_xml_signal_connect_data(
+        glxml, "on_merge_up_activate", GTK_SIGNAL_FUNC(interval_merge_up_clicked_cb), wig
+    );
 
-	glade_xml_signal_connect_data (glxml, "on_merge_down_activate",
-	        GTK_SIGNAL_FUNC (interval_merge_down_clicked_cb), wig);
+    glade_xml_signal_connect_data(
+        glxml, "on_merge_down_activate", GTK_SIGNAL_FUNC(interval_merge_down_clicked_cb), wig
+    );
 
-	glade_xml_signal_connect_data (glxml, "on_move_up_activate",
-	        GTK_SIGNAL_FUNC (interval_move_up_clicked_cb), wig);
+    glade_xml_signal_connect_data(
+        glxml, "on_move_up_activate", GTK_SIGNAL_FUNC(interval_move_up_clicked_cb), wig
+    );
 
-	glade_xml_signal_connect_data (glxml, "on_move_down_activate",
-	        GTK_SIGNAL_FUNC (interval_move_down_clicked_cb), wig);
+    glade_xml_signal_connect_data(
+        glxml, "on_move_down_activate", GTK_SIGNAL_FUNC(interval_move_down_clicked_cb), wig
+    );
 
-	glade_xml_signal_connect_data (glxml, "on_insert_memo_activate",
-	        GTK_SIGNAL_FUNC (interval_insert_memo_cb), wig);
+    glade_xml_signal_connect_data(
+        glxml, "on_insert_memo_activate", GTK_SIGNAL_FUNC(interval_insert_memo_cb), wig
+    );
 
-	glade_xml_signal_connect_data (glxml, "on_paste_memo_activate",
-	        GTK_SIGNAL_FUNC (interval_paste_memo_cb), wig);
+    glade_xml_signal_connect_data(
+        glxml, "on_paste_memo_activate", GTK_SIGNAL_FUNC(interval_paste_memo_cb), wig
+    );
 
-	/* ---------------------------------------------------- */
-	/* This is the popup menu that says 'edit/delete/merge' */
-	/* for tasks */
+    /* ---------------------------------------------------- */
+    /* This is the popup menu that says 'edit/delete/merge' */
+    /* for tasks */
 
-	glxml = gtt_glade_xml_new ("glade/task_popup.glade", "Task Popup");
-	wig->task_popup = glade_xml_get_widget (glxml, "Task Popup");
-	wig->task_delete_memo = glade_xml_get_widget (glxml, "delete_memo");
-	wig->task_paste = glade_xml_get_widget (glxml, "paste");
-	wig->task=NULL;
+    glxml = gtt_glade_xml_new("glade/task_popup.glade", "Task Popup");
+    wig->task_popup = glade_xml_get_widget(glxml, "Task Popup");
+    wig->task_delete_memo = glade_xml_get_widget(glxml, "delete_memo");
+    wig->task_paste = glade_xml_get_widget(glxml, "paste");
+    wig->task = NULL;
 
-	glade_xml_signal_connect_data (glxml, "on_new_task_activate",
-	        GTK_SIGNAL_FUNC (task_new_task_clicked_cb), wig);
+    glade_xml_signal_connect_data(
+        glxml, "on_new_task_activate", GTK_SIGNAL_FUNC(task_new_task_clicked_cb), wig
+    );
 
-	glade_xml_signal_connect_data (glxml, "on_edit_task_activate",
-	        GTK_SIGNAL_FUNC (task_edit_task_clicked_cb), wig);
+    glade_xml_signal_connect_data(
+        glxml, "on_edit_task_activate", GTK_SIGNAL_FUNC(task_edit_task_clicked_cb), wig
+    );
 
-	glade_xml_signal_connect_data (glxml, "on_delete_memo_activate",
-	        GTK_SIGNAL_FUNC (task_delete_memo_clicked_cb), wig);
+    glade_xml_signal_connect_data(
+        glxml, "on_delete_memo_activate", GTK_SIGNAL_FUNC(task_delete_memo_clicked_cb), wig
+    );
 
-	glade_xml_signal_connect_data (glxml, "on_delete_times_activate",
-	        GTK_SIGNAL_FUNC (task_delete_times_clicked_cb), wig);
+    glade_xml_signal_connect_data(
+        glxml, "on_delete_times_activate", GTK_SIGNAL_FUNC(task_delete_times_clicked_cb), wig
+    );
 
-	glade_xml_signal_connect_data (glxml, "on_copy_activate",
-	        GTK_SIGNAL_FUNC (task_copy_clicked_cb), wig);
+    glade_xml_signal_connect_data(
+        glxml, "on_copy_activate", GTK_SIGNAL_FUNC(task_copy_clicked_cb), wig
+    );
 
-	glade_xml_signal_connect_data (glxml, "on_paste_activate",
-	        GTK_SIGNAL_FUNC (task_paste_clicked_cb), wig);
+    glade_xml_signal_connect_data(
+        glxml, "on_paste_activate", GTK_SIGNAL_FUNC(task_paste_clicked_cb), wig
+    );
 
-	glade_xml_signal_connect_data (glxml, "on_new_interval_activate",
-	        GTK_SIGNAL_FUNC (task_new_interval_cb), wig);
+    glade_xml_signal_connect_data(
+        glxml, "on_new_interval_activate", GTK_SIGNAL_FUNC(task_new_interval_cb), wig
+    );
 
-	/* ---------------------------------------------------- */
-	wig->hover_help_window = NULL;
-	wig->hover_timeout_id = 0;
+    /* ---------------------------------------------------- */
+    wig->hover_help_window = NULL;
+    wig->hover_timeout_id = 0;
 
-	/* ---------------------------------------------------- */
-	/* Finally ... display the actual journal */
+    /* ---------------------------------------------------- */
+    /* Finally ... display the actual journal */
 
-	wig->prj = prj;
-	wig->filepath = g_strdup (report);
-	if (kvpf)
-	{
-		if (wig->gh->kvp) kvp_frame_delete (wig->gh->kvp);
-		wig->gh->kvp = kvpf;
-	}
-	wig->gh->did_query = did_query;
-	wig->gh->query_result = prjlist;
+    wig->prj = prj;
+    wig->filepath = g_strdup(report);
+    if (kvpf)
+    {
+        if (wig->gh->kvp)
+            kvp_frame_delete(wig->gh->kvp);
+        wig->gh->kvp = kvpf;
+    }
+    wig->gh->did_query = did_query;
+    wig->gh->query_result = prjlist;
 
-	/* XXX should add notifiers for prjlist too ?? Yes we should */
-	if (prj) gtt_project_add_notifier (prj, redraw, wig);
-	gtt_ghtml_display (wig->gh, report, prj);
+    /* XXX should add notifiers for prjlist too ?? Yes we should */
+    if (prj)
+        gtt_project_add_notifier(prj, redraw, wig);
+    gtt_ghtml_display(wig->gh, report, prj);
 
-	/* Can only set editable *after* there's content in the window */
-	// gtk_html_set_editable (wig->html, TRUE);
+    /* Can only set editable *after* there's content in the window */
+    // gtk_html_set_editable (wig->html, TRUE);
 }
 
 /* ============================================================== */
 
-char *
-gtt_ghtml_resolve_path (const char *path_frag, const char *reference_path)
+char *gtt_ghtml_resolve_path(const char *path_frag, const char *reference_path)
 {
-	const GList *list;
-	char buff[PATH_MAX], *path;
+    const GList *list;
+    char buff[PATH_MAX], *path;
 
-	if (!path_frag) return NULL;
+    if (!path_frag)
+        return NULL;
 
-	/* First, look for path_frag in the reference path. */
-	if (reference_path)
-	{
-		char * p;
-		strncpy (buff, reference_path, PATH_MAX);
-		p = strrchr (buff, '/');
-		if (p)
-		{
-			p++;
-			strncpy (p, path_frag, PATH_MAX-(p-buff));
-			if (g_file_test ((buff), G_FILE_TEST_EXISTS)) return g_strdup (buff);
-		}
-	}
+    /* First, look for path_frag in the reference path. */
+    if (reference_path)
+    {
+        char *p;
+        strncpy(buff, reference_path, PATH_MAX);
+        p = strrchr(buff, '/');
+        if (p)
+        {
+            p++;
+            strncpy(p, path_frag, PATH_MAX - (p - buff));
+            if (g_file_test((buff), G_FILE_TEST_EXISTS))
+                return g_strdup(buff);
+        }
+    }
 
-	/* Next, check each language that the user is willing to look at. */
-	list = gnome_i18n_get_language_list ("LC_MESSAGES");
-	for ( ; list; list=list->next)
-	{
-		const char *lang = list->data;
+    /* Next, check each language that the user is willing to look at. */
+    list = gnome_i18n_get_language_list("LC_MESSAGES");
+    for (; list; list = list->next)
+    {
+        const char *lang = list->data;
 
-		/* See if gnotime/ghtml/<lang>/<path_frag> exists. */
-		/* Look in the local build dir first (for testing) */
+        /* See if gnotime/ghtml/<lang>/<path_frag> exists. */
+        /* Look in the local build dir first (for testing) */
 
-		snprintf (buff, PATH_MAX, "ghtml/%s/%s", lang, path_frag);
-		path = gnome_program_locate_file (NULL, GNOME_FILE_DOMAIN_DATADIR,
-						  buff, TRUE, NULL);
-		if (path) return path;
+        snprintf(buff, PATH_MAX, "ghtml/%s/%s", lang, path_frag);
+        path = gnome_program_locate_file(NULL, GNOME_FILE_DOMAIN_DATADIR, buff, TRUE, NULL);
+        if (path)
+            return path;
 
-		snprintf (buff, PATH_MAX, "gnotime/ghtml/%s/%s", lang, path_frag);
-		path = gnome_program_locate_file (NULL, GNOME_FILE_DOMAIN_DATADIR,
-						  buff, TRUE, NULL);
-		if (path) return path;
+        snprintf(buff, PATH_MAX, "gnotime/ghtml/%s/%s", lang, path_frag);
+        path = gnome_program_locate_file(NULL, GNOME_FILE_DOMAIN_DATADIR, buff, TRUE, NULL);
+        if (path)
+            return path;
 
-		/* Backwards compat, check the gtt dir, not just the gnotime dir */
-		snprintf (buff, PATH_MAX, "gtt/ghtml/%s/%s", lang, path_frag);
-		path = gnome_program_locate_file (NULL, GNOME_FILE_DOMAIN_DATADIR,
-						  buff, TRUE, NULL);
-		if (path) return path;
+        /* Backwards compat, check the gtt dir, not just the gnotime dir */
+        snprintf(buff, PATH_MAX, "gtt/ghtml/%s/%s", lang, path_frag);
+        path = gnome_program_locate_file(NULL, GNOME_FILE_DOMAIN_DATADIR, buff, TRUE, NULL);
+        if (path)
+            return path;
 
-		/* some users compile with path settings that gnome
-		 * cannot find.  In that case we have to supply a full
-		 * path and check it's existance directly -- we CANNOT
-		 * use gnome_datadir_file() because it wont work!
-		 *
-		 * -warlord 2001-11-29
-		 */
- 		snprintf (buff, PATH_MAX, GTTDATADIR "/ghtml/%s/%s", lang, path_frag);
-		if (g_file_test ((buff), G_FILE_TEST_EXISTS)) return g_strdup (buff);
-	}
-	return g_strdup(path_frag);
+        /* some users compile with path settings that gnome
+         * cannot find.  In that case we have to supply a full
+         * path and check it's existance directly -- we CANNOT
+         * use gnome_datadir_file() because it wont work!
+         *
+         * -warlord 2001-11-29
+         */
+        snprintf(buff, PATH_MAX, GTTDATADIR "/ghtml/%s/%s", lang, path_frag);
+        if (g_file_test((buff), G_FILE_TEST_EXISTS))
+            return g_strdup(buff);
+    }
+    return g_strdup(path_frag);
 }
-
 
 /* XXX The show_report routine should probably be using data pulled from
  * GConf, in the same way that the user-defined items are obtained.
  * Currently, these are hard-coded in menus.c.
  */
 
-void
-show_report (GtkWidget *w, gpointer data)
+void show_report(GtkWidget *w, gpointer data)
 {
-	char *report_file = data;
-	GttProject *prj;
-	char * path;
+    char *report_file = data;
+    GttProject *prj;
+    char *path;
 
-	prj = gtt_projects_tree_get_selected_project (projects_tree);
+    prj = gtt_projects_tree_get_selected_project(projects_tree);
 
-	path = gtt_ghtml_resolve_path (report_file, NULL);
-	do_show_report (path, NULL, NULL, prj, FALSE, NULL);
+    path = gtt_ghtml_resolve_path(report_file, NULL);
+    do_show_report(path, NULL, NULL, prj, FALSE, NULL);
 }
 
-void
-invoke_report(GtkWidget *widget, gpointer data)
+void invoke_report(GtkWidget *widget, gpointer data)
 {
-	GttProject *prj;
-	GttPlugin *plg = data;
+    GttProject *prj;
+    GttPlugin *plg = data;
 
-	prj = gtt_projects_tree_get_selected_project (projects_tree);
+    prj = gtt_projects_tree_get_selected_project(projects_tree);
 
-	/* Do not gnome-filepath this, this is for user-defined reports */
-	do_show_report (plg->path, plg, NULL, prj, FALSE, NULL);
+    /* Do not gnome-filepath this, this is for user-defined reports */
+    do_show_report(plg->path, plg, NULL, prj, FALSE, NULL);
 }
 
 /* ===================== END OF FILE ==============================  */

--- a/src/journal.h
+++ b/src/journal.h
@@ -20,21 +20,21 @@
 #define __GTT_JOURNAL_H__
 
 /* Menu callback, will show the report passed as filename */
-void show_report   (GtkWidget *, gpointer filename);
+void show_report(GtkWidget *, gpointer filename);
 
 /* Menu callback, will show the report set up as a dynamically
  * configured menu item. */
-void invoke_report (GtkWidget *, gpointer);
+void invoke_report(GtkWidget *, gpointer);
 
 /* The new_task_ui() routine will create a new task at the head
  *    of the project, and pop up a dialog to edit it.  This
  *    routine is a callback.
  */
-void new_task_ui (GtkWidget *, gpointer);
+void new_task_ui(GtkWidget *, gpointer);
 
 /* The edit_task_ui() routine will pop up a dialog to edit the task
  *    currently at the head of the project.
  */
-void edit_task_ui (GtkWidget *, gpointer);
+void edit_task_ui(GtkWidget *, gpointer);
 
 #endif /* __GTT_JOURNAL_H__ */

--- a/src/log.c
+++ b/src/log.c
@@ -16,285 +16,288 @@
  *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <glib.h>
 #include <config.h>
+#include <glib.h>
 #include <gnome.h>
+#include <libgnomevfs/gnome-vfs.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <libgnomevfs/gnome-vfs.h>
 
 #include "cur-proj.h"
 #include "log.h"
 #include "prefs.h"
 #include "proj.h"
 
-#define CAN_LOG ((config_logfile_name!=NULL)&&(config_logfile_use))
+#define CAN_LOG ((config_logfile_name != NULL) && (config_logfile_use))
 
-
-static gboolean
-log_write(time_t t, const char *logstr)
+static gboolean log_write(time_t t, const char *logstr)
 {
-	char date[256];
-	char *filename;
-	GnomeVFSHandle   *handle;
-	GnomeVFSResult    result;
+    char date[256];
+    char *filename;
+    GnomeVFSHandle *handle;
+    GnomeVFSResult result;
 
-	g_return_val_if_fail (logstr != NULL, FALSE);
+    g_return_val_if_fail(logstr != NULL, FALSE);
 
-	if (!CAN_LOG) return TRUE;
+    if (!CAN_LOG)
+        return TRUE;
 
-	if ((config_logfile_name[0] == '~') &&
-	    (config_logfile_name[1] == '/') &&
-	    (config_logfile_name[2] != 0))
-	{
-		filename = gnome_util_prepend_user_home(&config_logfile_name[2]);
+    if ((config_logfile_name[0] == '~') && (config_logfile_name[1] == '/')
+        && (config_logfile_name[2] != 0))
+    {
+        filename = gnome_util_prepend_user_home(&config_logfile_name[2]);
 
-		result = gnome_vfs_create (&handle, filename,
-		                          GNOME_VFS_OPEN_WRITE, FALSE, 0644);
-		g_free (filename);
-	} else {
-		result = gnome_vfs_create (&handle, config_logfile_name,
-		                          GNOME_VFS_OPEN_WRITE, FALSE, 0644);
-	}
+        result = gnome_vfs_create(&handle, filename, GNOME_VFS_OPEN_WRITE, FALSE, 0644);
+        g_free(filename);
+    }
+    else
+    {
+        result
+            = gnome_vfs_create(&handle, config_logfile_name, GNOME_VFS_OPEN_WRITE, FALSE, 0644);
+    }
 
-	if (GNOME_VFS_OK != result)
-	{
-		g_warning (_("Cannot open logfile %s for append: %s"),
-			   config_logfile_name, gnome_vfs_result_to_string (result));
-		return FALSE;
-	}
+    if (GNOME_VFS_OK != result)
+    {
+        g_warning(
+            _("Cannot open logfile %s for append: %s"), config_logfile_name,
+            gnome_vfs_result_to_string(result)
+        );
+        return FALSE;
+    }
 
-	if (t < 0)
-		t = time(NULL);
+    if (t < 0)
+        t = time(NULL);
 
-	/* Translators: Format to use in the gnotime logfile */
-	int rc = strftime (date, sizeof (date), _("%b %d %H:%M:%S"), localtime(&t));
-	if (0 >= rc) strcpy (date, "???");
+    /* Translators: Format to use in the gnotime logfile */
+    int rc = strftime(date, sizeof(date), _("%b %d %H:%M:%S"), localtime(&t));
+    if (0 >= rc)
+        strcpy(date, "???");
 
-	/* Append to end of file */
-	gnome_vfs_seek (handle, GNOME_VFS_SEEK_END, 0);
-	GnomeVFSFileSize bytes_written;
-	gnome_vfs_write (handle, date, strlen(date), &bytes_written);
-	gnome_vfs_write (handle, logstr, strlen(logstr), &bytes_written);
-	gnome_vfs_write (handle, "\n", 1, &bytes_written);
-	
-	gnome_vfs_close (handle);
-	return TRUE;
+    /* Append to end of file */
+    gnome_vfs_seek(handle, GNOME_VFS_SEEK_END, 0);
+    GnomeVFSFileSize bytes_written;
+    gnome_vfs_write(handle, date, strlen(date), &bytes_written);
+    gnome_vfs_write(handle, logstr, strlen(logstr), &bytes_written);
+    gnome_vfs_write(handle, "\n", 1, &bytes_written);
+
+    gnome_vfs_close(handle);
+    return TRUE;
 }
 
-
-char *
-printf_project(const char *format, GttProject *proj)
+char *printf_project(const char *format, GttProject *proj)
 {
-	GString *str;
-	const char *p;
-	char *ret;
-	int sss;
+    GString *str;
+    const char *p;
+    char *ret;
+    int sss;
 
-	if (!format) return NULL;
+    if (!format)
+        return NULL;
 
-	str = g_string_new (NULL);
-	for (p = format; *p; p++) {
-		if (*p != '%') {
-			g_string_append_c(str, *p);
-		} else {
-			p++;
-			
-			switch (*p) {
-			case 't':
-			{
-				const char * title = gtt_project_get_title(proj);
-				if (title && title[0])
-					g_string_append(str, title);
-				else
-					g_string_append(str, _("no title"));
-				break;
-			}
-			case 'd':
-			{
-				const char * desc = gtt_project_get_desc(proj);
-				if (desc && desc[0])
-					g_string_append(str, desc);
-				else
-					g_string_append(str, _("no description"));
-				break;
-			}
-			case 'D':
-			   sss = gtt_project_get_id (proj);
-				g_string_append_printf (str, "%d", sss);
-				break;
+    str = g_string_new(NULL);
+    for (p = format; *p; p++)
+    {
+        if (*p != '%')
+        {
+            g_string_append_c(str, *p);
+        }
+        else
+        {
+            p++;
 
-			case 'e':
-				sss = gtt_project_get_sizing (proj);
-				g_string_append_printf (str,"%d", sss);
-				break;
+            switch (*p)
+            {
+            case 't':
+            {
+                const char *title = gtt_project_get_title(proj);
+                if (title && title[0])
+                    g_string_append(str, title);
+                else
+                    g_string_append(str, _("no title"));
+                break;
+            }
+            case 'd':
+            {
+                const char *desc = gtt_project_get_desc(proj);
+                if (desc && desc[0])
+                    g_string_append(str, desc);
+                else
+                    g_string_append(str, _("no description"));
+                break;
+            }
+            case 'D':
+                sss = gtt_project_get_id(proj);
+                g_string_append_printf(str, "%d", sss);
+                break;
 
-			case 'h':
-				sss = gtt_project_get_secs_ever (proj);
-				g_string_append_printf (str, "%d", sss / 3600);
-				break;
+            case 'e':
+                sss = gtt_project_get_sizing(proj);
+                g_string_append_printf(str, "%d", sss);
+                break;
 
-			case 'H':
-				sss = gtt_project_get_secs_day (proj);
-				g_string_append_printf (str, "%02d", sss / 3600);
-				break;
+            case 'h':
+                sss = gtt_project_get_secs_ever(proj);
+                g_string_append_printf(str, "%d", sss / 3600);
+                break;
 
-			case 'm':
-				sss = gtt_project_get_secs_ever (proj);
-				g_string_append_printf (str, "%d", sss / 60);
-				break;
-				
-			case 'M':
-				sss = gtt_project_get_secs_day (proj);
-				g_string_append_printf (str, "%02d", (sss / 60) % 60);
-				break;
-				
-			case 's':
-				sss = gtt_project_get_secs_ever (proj);
-				g_string_append_printf (str,"%d", sss);
-				break;
+            case 'H':
+                sss = gtt_project_get_secs_day(proj);
+                g_string_append_printf(str, "%02d", sss / 3600);
+                break;
 
-			case 'S':
-				sss = gtt_project_get_secs_day (proj);
-				g_string_append_printf (str, "%02d", sss % 60);
-				break;
+            case 'm':
+                sss = gtt_project_get_secs_ever(proj);
+                g_string_append_printf(str, "%d", sss / 60);
+                break;
 
-			case 'T':
-				sss = gtt_project_get_secs_ever(proj);
-				g_string_append_printf(str, "%d:%02d:%02d", sss / 3600,
-					   (sss / 60) % 60,
-					   sss % 60);
-				break;
+            case 'M':
+                sss = gtt_project_get_secs_day(proj);
+                g_string_append_printf(str, "%02d", (sss / 60) % 60);
+                break;
+
+            case 's':
+                sss = gtt_project_get_secs_ever(proj);
+                g_string_append_printf(str, "%d", sss);
+                break;
+
+            case 'S':
+                sss = gtt_project_get_secs_day(proj);
+                g_string_append_printf(str, "%02d", sss % 60);
+                break;
+
+            case 'T':
+                sss = gtt_project_get_secs_ever(proj);
+                g_string_append_printf(
+                    str, "%d:%02d:%02d", sss / 3600, (sss / 60) % 60, sss % 60
+                );
+                break;
             case 'r':
-			    {
-				GList *tasks = gtt_project_get_tasks(proj);
-				GttTask *tsk = tasks->data;
-				const char * memo = gtt_task_get_memo(tsk);
-				g_string_append(str, memo);
-			    }
-				break;
-			default:
-				g_string_append_c(str, *p);
-				break;
-			}
-		}
-	}
-	ret = str->str;
-	/* Uhh, I'm not sure, but I think 'FALSE' means don't free
-	 * the char * array  */
-	g_string_free (str, FALSE);
-	return ret;
+            {
+                GList *tasks = gtt_project_get_tasks(proj);
+                GttTask *tsk = tasks->data;
+                const char *memo = gtt_task_get_memo(tsk);
+                g_string_append(str, memo);
+            }
+            break;
+            default:
+                g_string_append_c(str, *p);
+                break;
+            }
+        }
+    }
+    ret = str->str;
+    /* Uhh, I'm not sure, but I think 'FALSE' means don't free
+     * the char * array  */
+    g_string_free(str, FALSE);
+    return ret;
 }
 
-
-static char *
-build_log_entry(const char *format, GttProject *proj)
+static char *build_log_entry(const char *format, GttProject *proj)
 {
-	if (!format || !format[0])
-		format = config_logfile_start;
-	if (!proj)
-		return g_strdup(_("program started"));
+    if (!format || !format[0])
+        format = config_logfile_start;
+    if (!proj)
+        return g_strdup(_("program started"));
 
-	return printf_project (format, proj);
+    return printf_project(format, proj);
 }
 
-static void
-do_log_proj (time_t t, GttProject *proj, gboolean start)
+static void do_log_proj(time_t t, GttProject *proj, gboolean start)
 {
-	char *s;
+    char *s;
 
-	if (start) {
-		s = build_log_entry (config_logfile_start, proj);
-	} else /*stop*/ {
-		s = build_log_entry (config_logfile_stop, proj);
-	}
+    if (start)
+    {
+        s = build_log_entry(config_logfile_start, proj);
+    }
+    else /*stop*/
+    {
+        s = build_log_entry(config_logfile_stop, proj);
+    }
 
-	log_write (t, s);
-	g_free (s);
+    log_write(t, s);
+    g_free(s);
 }
 
-static void
-log_proj_intern (GttProject *proj, gboolean log_if_equal)
+static void log_proj_intern(GttProject *proj, gboolean log_if_equal)
 {
-	static GttProject *last_proj = NULL;
-	static gboolean logged_last = FALSE;
-	static time_t logged_last_time = 0;
-	time_t t;
+    static GttProject *last_proj = NULL;
+    static gboolean logged_last = FALSE;
+    static time_t logged_last_time = 0;
+    time_t t;
 
-	if ( ! CAN_LOG)
-		return;
+    if (!CAN_LOG)
+        return;
 
-	/* used for flushing, forcing a start entry, used at end of day */
-	if (log_if_equal &&
-	    last_proj == proj &&
-	    logged_last)
-	{
-		do_log_proj (-1, proj, TRUE /*start*/);
-		return;
-	}
+    /* used for flushing, forcing a start entry, used at end of day */
+    if (log_if_equal && last_proj == proj && logged_last)
+    {
+        do_log_proj(-1, proj, TRUE /*start*/);
+        return;
+    }
 
-	if (proj == NULL) {
-		if (last_proj == NULL)
-			return;
-		if (logged_last)
-			do_log_proj (-1, last_proj, FALSE /*start*/);
-		last_proj = NULL;
-		return;
-	}
+    if (proj == NULL)
+    {
+        if (last_proj == NULL)
+            return;
+        if (logged_last)
+            do_log_proj(-1, last_proj, FALSE /*start*/);
+        last_proj = NULL;
+        return;
+    }
 
-	if (last_proj == NULL) {
-		last_proj = proj;
-		logged_last_time = time (NULL);
-		logged_last = FALSE;
-	} else if (last_proj != proj) {
-		if (logged_last)
-			do_log_proj (-1, last_proj, FALSE /*start*/);
-		last_proj = proj;
-		logged_last_time = time (NULL);
-		logged_last = FALSE;
-	}
+    if (last_proj == NULL)
+    {
+        last_proj = proj;
+        logged_last_time = time(NULL);
+        logged_last = FALSE;
+    }
+    else if (last_proj != proj)
+    {
+        if (logged_last)
+            do_log_proj(-1, last_proj, FALSE /*start*/);
+        last_proj = proj;
+        logged_last_time = time(NULL);
+        logged_last = FALSE;
+    }
 
-	t = time (NULL);
+    t = time(NULL);
 
-	if ( ! logged_last &&
-	    (long)(t - logged_last_time) >= config_logfile_min_secs) {
-		do_log_proj (logged_last_time, proj, TRUE /*start*/);
-		logged_last = TRUE;
-	}
+    if (!logged_last && (long) (t - logged_last_time) >= config_logfile_min_secs)
+    {
+        do_log_proj(logged_last_time, proj, TRUE /*start*/);
+        logged_last = TRUE;
+    }
 }
 
-void
-log_proj (GttProject *proj)
+void log_proj(GttProject *proj)
 {
-	if ( ! CAN_LOG)
-		return;
+    if (!CAN_LOG)
+        return;
 
-	log_proj_intern (proj, FALSE /*log_if_equal*/);
+    log_proj_intern(proj, FALSE /*log_if_equal*/);
 }
 
-void
-log_exit (void)
+void log_exit(void)
 {
-	if ( ! CAN_LOG)
-		return;
-	log_proj_intern (NULL, FALSE /*log_if_equal*/);
-	log_write (-1, _("program exited"));
+    if (!CAN_LOG)
+        return;
+    log_proj_intern(NULL, FALSE /*log_if_equal*/);
+    log_write(-1, _("program exited"));
 }
 
-void
-log_start (void)
+void log_start(void)
 {
-	if ( ! CAN_LOG)
-		return;
-	log_write (-1, _("program started"));
+    if (!CAN_LOG)
+        return;
+    log_write(-1, _("program started"));
 }
 
-void
-log_endofday (void)
+void log_endofday(void)
 {
-	if ( ! CAN_LOG)
-		return;
-	/* force a flush of the logfile */
-	if (cur_proj != NULL)
-		log_proj_intern (cur_proj, TRUE /*log_if_equal*/);
+    if (!CAN_LOG)
+        return;
+    /* force a flush of the logfile */
+    if (cur_proj != NULL)
+        log_proj_intern(cur_proj, TRUE /*log_if_equal*/);
 }

--- a/src/log.h
+++ b/src/log.h
@@ -26,6 +26,6 @@ void log_start(void);
 void log_exit(void);
 void log_endofday(void);
 
-char * printf_project (const char *format, GttProject *);
+char *printf_project(const char *format, GttProject *);
 
 #endif /* __GTT_LOG_H__ */

--- a/src/main.c
+++ b/src/main.c
@@ -22,8 +22,8 @@
 
 #include <errno.h>
 #include <gconf/gconf.h>
-#include <glade/glade.h>
 #include <gio/gio.h>
+#include <glade/glade.h>
 #include <gnome.h>
 #include <libgnomeui/gnome-window-icon.h>
 #include <libgnomevfs/gnome-vfs.h>
@@ -46,8 +46,8 @@
 #include "file-io.h"
 #include "gtt.h"
 #include "log.h"
-#include "menus.h"
 #include "menucmd.h"
+#include "menus.h"
 #include "prefs.h"
 #include "proj.h"
 #include "timer.h"
@@ -58,111 +58,104 @@
 #include "dbus.h"
 #endif
 
-char *first_proj_title = NULL;  /* command line over-ride */
+char *first_proj_title = NULL; /* command line over-ride */
 
-static gboolean first_time_ever = FALSE;  /* has gtt ever run before? */
+static gboolean first_time_ever = FALSE; /* has gtt ever run before? */
 
 GttProjectList *master_list = NULL;
 
-const char *
-gtt_gettext(const char *s)
+const char *gtt_gettext(const char *s)
 {
-	g_return_val_if_fail(s != NULL, NULL);
-	if (0 == strncmp(s, "[GTT]", 5))
-		return &s[5];
-	return s;
+    g_return_val_if_fail(s != NULL, NULL);
+    if (0 == strncmp(s, "[GTT]", 5))
+        return &s[5];
+    return s;
 }
 
 static char *build_lock_fname(void)
 {
-	GString *str;
-	static char *fname = NULL;
+    GString *str;
+    static char *fname = NULL;
 
-	if (fname != NULL) return fname;
+    if (fname != NULL)
+        return fname;
 
-	/* note it will handle unset "HOME" fairly gracefully */
-	str = g_string_new (g_getenv ("HOME"));
-	g_string_append (str, "/.gnotime");
+    /* note it will handle unset "HOME" fairly gracefully */
+    str = g_string_new(g_getenv("HOME"));
+    g_string_append(str, "/.gnotime");
 #ifdef DEBUG
-	g_string_append (str, "-" VERSION);
+    g_string_append(str, "-" VERSION);
 #endif
-	g_string_append (str, ".pid");
+    g_string_append(str, ".pid");
 
-	fname = str->str;
-	g_string_free (str, FALSE);
-	return fname;
+    fname = str->str;
+    g_string_free(str, FALSE);
+    return fname;
 }
-
-
 
 static void lock_gtt(void)
 {
-	FILE *f;
-	char *fname;
-	gboolean warn = FALSE;
+    FILE *f;
+    char *fname;
+    gboolean warn = FALSE;
 
-	fname = build_lock_fname ();
+    fname = build_lock_fname();
 
-	/* if the pid file exists and such a process exists
-	 * and this process is owned by the current user,
-	 * else this pid file is very very stale and can be
-	 * ignored */
-	if (NULL != (f = fopen(fname, "rt"))) {
-		int pid;
+    /* if the pid file exists and such a process exists
+     * and this process is owned by the current user,
+     * else this pid file is very very stale and can be
+     * ignored */
+    if (NULL != (f = fopen(fname, "rt")))
+    {
+        int pid;
 
-		if (fscanf (f, "%d", &pid) == 1 &&
-		    pid > 0 &&
-		    kill (pid, 0) == 0) {
-			warn = TRUE;
-		}
-		fclose(f);
-	}
-	
-	if (warn)
-	{
-		GtkWidget *warning;
-		warning = gnome_message_box_new(
-			_("There seems to be another GnoTime running.\n"
-			  "Press OK to start GnoTime anyway, or press Cancel to quit."),
-			GNOME_MESSAGE_BOX_WARNING,
-			GTK_STOCK_OK,
-			GTK_STOCK_CANCEL,
-			NULL);
-		if(gnome_dialog_run_and_close(GNOME_DIALOG(warning))!=0)
-		{
-			exit(0);
-		}
-	}
-	f = fopen(fname, "wt");
-	if (NULL == f)
-	{
-		g_warning(_("Cannot create pid-file!"));
-		return;
-	}
-	fprintf(f, "%d\n", getpid());
-	fclose(f);
+        if (fscanf(f, "%d", &pid) == 1 && pid > 0 && kill(pid, 0) == 0)
+        {
+            warn = TRUE;
+        }
+        fclose(f);
+    }
+
+    if (warn)
+    {
+        GtkWidget *warning;
+        warning = gnome_message_box_new(
+            _("There seems to be another GnoTime running.\n"
+              "Press OK to start GnoTime anyway, or press Cancel to quit."),
+            GNOME_MESSAGE_BOX_WARNING, GTK_STOCK_OK, GTK_STOCK_CANCEL, NULL
+        );
+        if (gnome_dialog_run_and_close(GNOME_DIALOG(warning)) != 0)
+        {
+            exit(0);
+        }
+    }
+    f = fopen(fname, "wt");
+    if (NULL == f)
+    {
+        g_warning(_("Cannot create pid-file!"));
+        return;
+    }
+    fprintf(f, "%d\n", getpid());
+    fclose(f);
 }
 
-
-
-void
-unlock_gtt(void)
+void unlock_gtt(void)
 {
-	log_exit();
-	run_shell_command (cur_proj, FALSE);
-	unlink(build_lock_fname());
+    log_exit();
+    run_shell_command(cur_proj, FALSE);
+    unlink(build_lock_fname());
 
-	/* cleanup the guts. */
+    /* cleanup the guts. */
 #if 0
 /* Don't -- its currently buggy, recursive, will hang and whack data */
 	project_list_destroy ();
 #endif
 
-	/* Perform a clean shutdown of QOF subsystem. */
-	qof_close();
-	// qof_log_shutdown();
+    /* Perform a clean shutdown of QOF subsystem. */
+    qof_close();
+    // qof_log_shutdown();
 
-	/* gnome shutdown */
+    /* gnome shutdown */
 #if 0
 	gnome_vfs_shutdown ();
 #endif
@@ -171,411 +164,393 @@ unlock_gtt(void)
 /* Return a 1 if the indicated directory did not exist, and
  * and was successfully created.  Else return 0.
  */
-static int
-create_data_dir (const char * fpath)
+static int create_data_dir(const char *fpath)
 {
-	struct stat fsb;
-	char * filepath;
-	int rc;
-	char * sep;
+    struct stat fsb;
+    char *filepath;
+    int rc;
+    char *sep;
 
-	filepath = g_strdup (fpath);
-	sep = rindex (filepath, '/');
-	sep ++;
-	*sep = 0x0;   /* null terminate */
+    filepath = g_strdup(fpath);
+    sep = rindex(filepath, '/');
+    sep++;
+    *sep = 0x0; /* null terminate */
 
-	/* See if directory exists */
-	rc = stat (filepath, &fsb);
-	if (0 > rc)
-	{
-		int norr = errno;
-		if (norr)
-		{
-			/* If we are here, directory does not exist. */
-			/* Try to create it */
-			rc = mkdir (filepath, S_IRWXU);
-			if (0 == rc)
-			{
-				/* If we are here, the create directory succeeded. */
-				g_free (filepath);
-				return 1;
-			}
-		}
-	}
-	g_free (filepath);
-	return 0;
+    /* See if directory exists */
+    rc = stat(filepath, &fsb);
+    if (0 > rc)
+    {
+        int norr = errno;
+        if (norr)
+        {
+            /* If we are here, directory does not exist. */
+            /* Try to create it */
+            rc = mkdir(filepath, S_IRWXU);
+            if (0 == rc)
+            {
+                /* If we are here, the create directory succeeded. */
+                g_free(filepath);
+                return 1;
+            }
+        }
+    }
+    g_free(filepath);
+    return 0;
 }
 
-
-static void
-post_read_data(void)
+static void post_read_data(void)
 {
-	gtt_post_data_config();
+    gtt_post_data_config();
 
-	err_init();
-//	ctree_setup(global_ptw, master_list);
-	gtt_projects_tree_populate (projects_tree,
-								gtt_project_list_get_list (master_list),
-								TRUE);
-	gtt_post_ctree_config();
-	menu_set_states();
-	toolbar_set_states();
-	init_timer();
+    err_init();
+    //	ctree_setup(global_ptw, master_list);
+    gtt_projects_tree_populate(projects_tree, gtt_project_list_get_list(master_list), TRUE);
+    gtt_post_ctree_config();
+    menu_set_states();
+    toolbar_set_states();
+    init_timer();
 
-	/* Plugins need to be added to the main menus dynamically,
-	 * after the config file has been read */
-	menus_add_plugins (GNOME_APP(app_window));
-	log_start();
-	app_show();
+    /* Plugins need to be added to the main menus dynamically,
+     * after the config file has been read */
+    menus_add_plugins(GNOME_APP(app_window));
+    log_start();
+    app_show();
 }
 
 #ifdef THIS_IS_CURRENTLY_UNUSED
-static void
-read_data_err_run_or_abort (GtkDialog *w, gint response_id)
+static void read_data_err_run_or_abort(GtkDialog *w, gint response_id)
 {
-	if ((GTK_RESPONSE_OK == response_id) ||
-	    (GTK_RESPONSE_YES == response_id))
-	{
-		gtk_widget_destroy (GTK_WIDGET(w));
-		post_read_data();
-	}
-	else
-	{
-		gtk_main_quit();
-	}
+    if ((GTK_RESPONSE_OK == response_id) || (GTK_RESPONSE_YES == response_id))
+    {
+        gtk_widget_destroy(GTK_WIDGET(w));
+        post_read_data();
+    }
+    else
+    {
+        gtk_main_quit();
+    }
 }
 #endif /* THIS_IS_CURRENTLY_UNUSED */
 
-static char *
-resolve_old_path (const char * pathfrag)
+static char *resolve_old_path(const char *pathfrag)
 {
-	char * fullpath;
-	const char * confpath;
+    char *fullpath;
+    const char *confpath;
 
-	if (('~' != pathfrag[0]) &&
-	    ('/' != pathfrag[0]))
-	{
-		/* If not an absolute filepath, look for the file in the same dir
-		 * where the gtt config file was found. */
-		confpath = gtt_get_config_filepath ();
-		if (NULL == confpath || 0 == confpath[0])
-		{
-			fullpath = gnome_config_get_real_path (pathfrag);
-		}
-		else
-		{
-			fullpath = g_strconcat ( confpath,
-			                    "/",
-			                    pathfrag,
-			                    NULL);
-		}
-	}
-	else
-	{
-		/* I suppose we should look up $HOME if ~ */
-		fullpath = g_strdup (pathfrag);
-	}
+    if (('~' != pathfrag[0]) && ('/' != pathfrag[0]))
+    {
+        /* If not an absolute filepath, look for the file in the same dir
+         * where the gtt config file was found. */
+        confpath = gtt_get_config_filepath();
+        if (NULL == confpath || 0 == confpath[0])
+        {
+            fullpath = gnome_config_get_real_path(pathfrag);
+        }
+        else
+        {
+            fullpath = g_strconcat(confpath, "/", pathfrag, NULL);
+        }
+    }
+    else
+    {
+        /* I suppose we should look up $HOME if ~ */
+        fullpath = g_strdup(pathfrag);
+    }
 
-	return fullpath;
+    return fullpath;
 }
 
-static char *
-resolve_path (const char * pathfrag)
+static char *resolve_path(const char *pathfrag)
 {
-	char * fullpath;
+    char *fullpath;
 
-	if (('~' != pathfrag[0]) &&
-	    ('/' != pathfrag[0]))
-	{
-		/* If not an absolute filepath, look for the file in the current
-		 * gnome config dir ...*/
-		fullpath = gnome_config_get_real_path (pathfrag);
-	}
-	else
-	{
-		/* I suppose we should look up $HOME if ~ */
-		fullpath = g_strdup (pathfrag);
-	}
+    if (('~' != pathfrag[0]) && ('/' != pathfrag[0]))
+    {
+        /* If not an absolute filepath, look for the file in the current
+         * gnome config dir ...*/
+        fullpath = gnome_config_get_real_path(pathfrag);
+    }
+    else
+    {
+        /* I suppose we should look up $HOME if ~ */
+        fullpath = g_strdup(pathfrag);
+    }
 
-	return fullpath;
+    return fullpath;
 }
 
-
-static GFile *
-choose_backup_file (char *data_filepath) {
-	GFile *result = NULL;
-
-	GtkWidget * dialog = gtk_file_chooser_dialog_new ("Choose a backup file",
-											NULL,
-											GTK_FILE_CHOOSER_ACTION_OPEN,
-											GTK_STOCK_OPEN,
-											GTK_RESPONSE_ACCEPT,
-											GTK_STOCK_CANCEL,
-											GTK_RESPONSE_REJECT,
-											NULL);
-
-	GFile *data_file = g_file_new_for_path (data_filepath);
-	GFile *data_directory = g_file_get_parent (data_file);
-	gtk_file_chooser_set_current_folder (GTK_FILE_CHOOSER(dialog), g_file_get_path (data_directory));
-	g_object_unref (data_file);
-	g_object_unref (data_directory);
-	gint dialog_response = gtk_dialog_run (GTK_DIALOG (dialog));
-
-	switch (dialog_response) {
-	case GTK_RESPONSE_ACCEPT:
-		result = gtk_file_chooser_get_file (GTK_FILE_CHOOSER(dialog));
-		break;
-	}
-	gtk_widget_destroy (dialog);
-	return result;
-}
-
-
-static gboolean
-backups_exist (const char *xml_filepath)
+static GFile *choose_backup_file(char *data_filepath)
 {
-	GFile *data_file = g_file_new_for_path (xml_filepath);
-	GFile *data_dir_file = g_file_get_parent (data_file);
-	char *data_dir_path = g_file_get_path (data_dir_file);
-	char *data_file_name = g_file_get_basename (data_file);
-	GDir *data_dir = g_dir_open (data_dir_path, 0, NULL);
-	gboolean result = FALSE;
+    GFile *result = NULL;
 
-	const gchar *file_name = NULL;
-	while ((file_name = g_dir_read_name (data_dir)) != NULL)
-	{
-		if (strcmp(data_file_name, file_name) != 0) {
-			result = TRUE;
-			break;
-		}
-	}
+    GtkWidget *dialog = gtk_file_chooser_dialog_new(
+        "Choose a backup file", NULL, GTK_FILE_CHOOSER_ACTION_OPEN, GTK_STOCK_OPEN,
+        GTK_RESPONSE_ACCEPT, GTK_STOCK_CANCEL, GTK_RESPONSE_REJECT, NULL
+    );
 
-	g_object_unref (data_file);
-	g_object_unref (data_dir_file);
-	g_object_unref (data_dir);
-	g_free (data_dir_path);
-	g_free (data_file_name);
-	return result;
+    GFile *data_file = g_file_new_for_path(data_filepath);
+    GFile *data_directory = g_file_get_parent(data_file);
+    gtk_file_chooser_set_current_folder(
+        GTK_FILE_CHOOSER(dialog), g_file_get_path(data_directory)
+    );
+    g_object_unref(data_file);
+    g_object_unref(data_directory);
+    gint dialog_response = gtk_dialog_run(GTK_DIALOG(dialog));
 
+    switch (dialog_response)
+    {
+    case GTK_RESPONSE_ACCEPT:
+        result = gtk_file_chooser_get_file(GTK_FILE_CHOOSER(dialog));
+        break;
+    }
+    gtk_widget_destroy(dialog);
+    return result;
 }
 
+static gboolean backups_exist(const char *xml_filepath)
+{
+    GFile *data_file = g_file_new_for_path(xml_filepath);
+    GFile *data_dir_file = g_file_get_parent(data_file);
+    char *data_dir_path = g_file_get_path(data_dir_file);
+    char *data_file_name = g_file_get_basename(data_file);
+    GDir *data_dir = g_dir_open(data_dir_path, 0, NULL);
+    gboolean result = FALSE;
 
-static gboolean
-try_restoring_backup (char *xml_filepath) {
+    const gchar *file_name = NULL;
+    while ((file_name = g_dir_read_name(data_dir)) != NULL)
+    {
+        if (strcmp(data_file_name, file_name) != 0)
+        {
+            result = TRUE;
+            break;
+        }
+    }
 
-	GtkWidget *mb;
-	gboolean have_backups = backups_exist (xml_filepath);
+    g_object_unref(data_file);
+    g_object_unref(data_dir_file);
+    g_object_unref(data_dir);
+    g_free(data_dir_path);
+    g_free(data_file_name);
+    return result;
+}
 
-	gchar * qmsg = g_strdup_printf("It was not possible to load the data file \"%s\". What do you want to do?", xml_filepath);
+static gboolean try_restoring_backup(char *xml_filepath)
+{
 
-	mb = gtk_message_dialog_new (NULL,
-								 GTK_DIALOG_MODAL,
-								 GTK_MESSAGE_ERROR,
-								 GTK_BUTTONS_NONE,
-								 "%s",
-								 qmsg);
+    GtkWidget *mb;
+    gboolean have_backups = backups_exist(xml_filepath);
 
-	gtk_dialog_add_button (GTK_DIALOG(mb),
-						   _("Create a new file"),
-						   GTK_RESPONSE_YES);
+    gchar *qmsg = g_strdup_printf(
+        "It was not possible to load the data file \"%s\". What do you want to do?",
+        xml_filepath
+    );
 
-	if (have_backups) {
-		gtk_dialog_add_button (GTK_DIALOG(mb),
-							   _("Load a backup"),
-							   GTK_RESPONSE_NO);
-	}
+    mb = gtk_message_dialog_new(
+        NULL, GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR, GTK_BUTTONS_NONE, "%s", qmsg
+    );
 
-	gtk_dialog_add_button (GTK_DIALOG(mb),
-						   _("Quit"),
-						   GTK_RESPONSE_CANCEL);
-	
-	gint response = gtk_dialog_run (GTK_DIALOG(mb));
-	gtk_widget_destroy (mb);
-	g_free (qmsg);
-	GFile *backup_file = NULL;
-	GError *error = NULL;
-	gboolean copy_success = FALSE;
-	switch (response) {
-	case GTK_RESPONSE_YES:
-		return FALSE;
+    gtk_dialog_add_button(GTK_DIALOG(mb), _("Create a new file"), GTK_RESPONSE_YES);
 
-	case GTK_RESPONSE_NO:
-		backup_file = choose_backup_file (xml_filepath);
-		if (backup_file != NULL) {
-			copy_success = g_file_copy(backup_file, g_file_new_for_path(xml_filepath), G_FILE_COPY_OVERWRITE, NULL, NULL, NULL, &error);
-			if (copy_success) {
-				return TRUE;
-			} else {
+    if (have_backups)
+    {
+        gtk_dialog_add_button(GTK_DIALOG(mb), _("Load a backup"), GTK_RESPONSE_NO);
+    }
+
+    gtk_dialog_add_button(GTK_DIALOG(mb), _("Quit"), GTK_RESPONSE_CANCEL);
+
+    gint response = gtk_dialog_run(GTK_DIALOG(mb));
+    gtk_widget_destroy(mb);
+    g_free(qmsg);
+    GFile *backup_file = NULL;
+    GError *error = NULL;
+    gboolean copy_success = FALSE;
+    switch (response)
+    {
+    case GTK_RESPONSE_YES:
+        return FALSE;
+
+    case GTK_RESPONSE_NO:
+        backup_file = choose_backup_file(xml_filepath);
+        if (backup_file != NULL)
+        {
+            copy_success = g_file_copy(
+                backup_file, g_file_new_for_path(xml_filepath), G_FILE_COPY_OVERWRITE, NULL,
+                NULL, NULL, &error
+            );
+            if (copy_success)
+            {
+                return TRUE;
+            }
+            else
+            {
                 // TODO Display error message
-				mb = gtk_message_dialog_new (NULL,
-											 GTK_DIALOG_MODAL,
-											 GTK_MESSAGE_ERROR,
-											 GTK_BUTTONS_OK,
-											 _("Could not copy backup file."));
-				gtk_dialog_run (GTK_DIALOG(mb));
-			}
-		} else {
-			exit(1);
-		}
-		return TRUE;
-		break;
-	case GTK_RESPONSE_CANCEL:
-		exit(1);
-		break;
-	}
-	return FALSE;
+                mb = gtk_message_dialog_new(
+                    NULL, GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR, GTK_BUTTONS_OK,
+                    _("Could not copy backup file.")
+                );
+                gtk_dialog_run(GTK_DIALOG(mb));
+            }
+        }
+        else
+        {
+            exit(1);
+        }
+        return TRUE;
+        break;
+    case GTK_RESPONSE_CANCEL:
+        exit(1);
+        break;
+    }
+    return FALSE;
 }
 
-static gboolean
-read_data_file(char *xml_filepath, GError **error) {
-	GttErrCode xml_errcode;
-	gboolean read_is_ok;
-
-	/* Try ... */
-	gtt_err_set_code (GTT_NO_ERR);
-	gtt_xml_read_file (xml_filepath);
-
-	/* Catch ... */
-	xml_errcode = gtt_err_get_code();
-
-	read_is_ok = (GTT_NO_ERR == xml_errcode);
-
-	/* If the xml file read bombed because the file doesn't exist,
-	 * and yet the project list isn't null, that's because we read
-	 * and old-format config file that had the projects in it.
-	 * This is not an error. This is OK.
-	 */
-	read_is_ok |= (GTT_CANT_OPEN_FILE == xml_errcode) &&
-	               gtt_project_list_get_list(master_list);
-
-	/* Its possible that the read failed because this is the
-	 * first time that gnotime is being run.  In this case,
-	 * create the data directory, and don't display any errors.
-	 */
-	if (GTT_CANT_OPEN_FILE == xml_errcode)
-	{
-		/* If the create directory succeeded, its not an error
-		 * if GTT is being run for the first time.
-		 */
-		if (create_data_dir (xml_filepath))
-		{
-			read_is_ok |= first_time_ever;
-		}
-	}
-
-	if (read_is_ok)
-	{
-		post_read_data ();
-		return TRUE;
-	} else {
-		*error = g_error_new (g_quark_from_string ("gtt"), GTT_CANT_OPEN_FILE, "Could not read data file \"%s\"", xml_filepath);
-	}
-	return FALSE;
-}
-
-void
-read_data(gboolean reloading) {
-	char * xml_filepath;
-	GError *error = NULL;
-
-  if (reloading) {
-      notes_area_set_project(global_na, NULL);
-      gtt_project_list_destroy(master_list);
-      master_list = gtt_project_list_new();
-  }
-
-	xml_filepath = resolve_old_path (config_data_url);
-
-	while (!read_data_file (xml_filepath, &error)) {
-		if (error != NULL) {
-			if (!try_restoring_backup (xml_filepath)) {
-				break;
-			}
-		}
-	}
-
-	post_read_data ();
-	g_free (xml_filepath);
-	return;
-}
-
-static void
-post_read_config(void)
+static gboolean read_data_file(char *xml_filepath, GError **error)
 {
-	read_data(FALSE);
+    GttErrCode xml_errcode;
+    gboolean read_is_ok;
+
+    /* Try ... */
+    gtt_err_set_code(GTT_NO_ERR);
+    gtt_xml_read_file(xml_filepath);
+
+    /* Catch ... */
+    xml_errcode = gtt_err_get_code();
+
+    read_is_ok = (GTT_NO_ERR == xml_errcode);
+
+    /* If the xml file read bombed because the file doesn't exist,
+     * and yet the project list isn't null, that's because we read
+     * and old-format config file that had the projects in it.
+     * This is not an error. This is OK.
+     */
+    read_is_ok |= (GTT_CANT_OPEN_FILE == xml_errcode) && gtt_project_list_get_list(master_list);
+
+    /* Its possible that the read failed because this is the
+     * first time that gnotime is being run.  In this case,
+     * create the data directory, and don't display any errors.
+     */
+    if (GTT_CANT_OPEN_FILE == xml_errcode)
+    {
+        /* If the create directory succeeded, its not an error
+         * if GTT is being run for the first time.
+         */
+        if (create_data_dir(xml_filepath))
+        {
+            read_is_ok |= first_time_ever;
+        }
+    }
+
+    if (read_is_ok)
+    {
+        post_read_data();
+        return TRUE;
+    }
+    else
+    {
+        *error = g_error_new(
+            g_quark_from_string("gtt"), GTT_CANT_OPEN_FILE, "Could not read data file \"%s\"",
+            xml_filepath
+        );
+    }
+    return FALSE;
 }
 
-static void
-read_config_err_run_or_abort (GtkDialog *w, gint response_id)
+void read_data(gboolean reloading)
 {
-	if ((GTK_RESPONSE_OK == response_id) ||
-	    (GTK_RESPONSE_YES == response_id))
-	{
-		gtk_widget_destroy (GTK_WIDGET(w));
-		first_time_ever = TRUE;
-		post_read_config();
-	}
-	else
-	{
-		gtk_main_quit();
-	}
+    char *xml_filepath;
+    GError *error = NULL;
+
+    if (reloading)
+    {
+        notes_area_set_project(global_na, NULL);
+        gtt_project_list_destroy(master_list);
+        master_list = gtt_project_list_new();
+    }
+
+    xml_filepath = resolve_old_path(config_data_url);
+
+    while (!read_data_file(xml_filepath, &error))
+    {
+        if (error != NULL)
+        {
+            if (!try_restoring_backup(xml_filepath))
+            {
+                break;
+            }
+        }
+    }
+
+    post_read_data();
+    g_free(xml_filepath);
+    return;
 }
 
-static void
-read_config(void)
+static void post_read_config(void)
 {
-	GttErrCode conf_errcode;
-
-	/* Try ... */
-	gtt_err_set_code (GTT_NO_ERR);
-	gtt_load_config ();
-
-	/* Catch ... */
-	conf_errcode = gtt_err_get_code();
-	if (GTT_NO_ERR != conf_errcode)
-	{
-		const char *fp;
-		char *errmsg, *qmsg;
-		fp = gtt_get_config_filepath();
-		errmsg = gtt_err_to_string (conf_errcode, fp);
-		qmsg = g_strconcat (errmsg,
-			_("Shall I setup a new configuration?"),
-			NULL);
-
-		GtkWidget *mb;
-		mb = gtk_message_dialog_new (NULL,
-		         GTK_DIALOG_MODAL,
-		         GTK_MESSAGE_ERROR,
-		         GTK_BUTTONS_YES_NO,
-                 "%s",
-		         qmsg);
-		g_signal_connect (G_OBJECT(mb), "response",
-		         G_CALLBACK (read_config_err_run_or_abort),
-		         NULL);
-		gtk_widget_show (mb);
-		g_free (qmsg);
-		g_free (errmsg);
-	}
-	else
-	{
-		post_read_config();
-	}
+    read_data(FALSE);
 }
 
+static void read_config_err_run_or_abort(GtkDialog *w, gint response_id)
+{
+    if ((GTK_RESPONSE_OK == response_id) || (GTK_RESPONSE_YES == response_id))
+    {
+        gtk_widget_destroy(GTK_WIDGET(w));
+        first_time_ever = TRUE;
+        post_read_config();
+    }
+    else
+    {
+        gtk_main_quit();
+    }
+}
+
+static void read_config(void)
+{
+    GttErrCode conf_errcode;
+
+    /* Try ... */
+    gtt_err_set_code(GTT_NO_ERR);
+    gtt_load_config();
+
+    /* Catch ... */
+    conf_errcode = gtt_err_get_code();
+    if (GTT_NO_ERR != conf_errcode)
+    {
+        const char *fp;
+        char *errmsg, *qmsg;
+        fp = gtt_get_config_filepath();
+        errmsg = gtt_err_to_string(conf_errcode, fp);
+        qmsg = g_strconcat(errmsg, _("Shall I setup a new configuration?"), NULL);
+
+        GtkWidget *mb;
+        mb = gtk_message_dialog_new(
+            NULL, GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR, GTK_BUTTONS_YES_NO, "%s", qmsg
+        );
+        g_signal_connect(
+            G_OBJECT(mb), "response", G_CALLBACK(read_config_err_run_or_abort), NULL
+        );
+        gtk_widget_show(mb);
+        g_free(qmsg);
+        g_free(errmsg);
+    }
+    else
+    {
+        post_read_config();
+    }
+}
 
 #if DEVEL_VERSION_WARNING
 /* used only to display development version warning messsage */
-static void
-beta_run_or_abort(GtkWidget *w, gint butnum)
+static void beta_run_or_abort(GtkWidget *w, gint butnum)
 {
-	if (butnum == 1)
-	{
-		gtk_main_quit();
-	}
-	else
-	{
-		read_config();
-	}
+    if (butnum == 1)
+    {
+        gtk_main_quit();
+    }
+    else
+    {
+        read_config();
+    }
 }
 #endif
 
@@ -592,68 +567,68 @@ beta_run_or_abort(GtkWidget *w, gint butnum)
  * the algo will result in the tail end copies being whacked incorrectly.
  * It took me some work to get this right.
  */
-static void
-make_backup (const char * filename)
+static void make_backup(const char *filename)
 {
-	extern int save_count;
-	char *old_name, *new_name;
-	size_t len;
-	struct stat old_stat;
-	struct utimbuf ub;
-	int suffix=0;
-	int lm;
-	int rc;
+    extern int save_count;
+    char *old_name, *new_name;
+    size_t len;
+    struct stat old_stat;
+    struct utimbuf ub;
+    int suffix = 0;
+    int lm;
+    int rc;
 
-	/* Figure out how far to back up.  This computes a
-	 * logarithm base BK_FREQ */
-	save_count ++;
-	lm = save_count;
-	while (lm)
-	{
+    /* Figure out how far to back up.  This computes a
+     * logarithm base BK_FREQ */
+    save_count++;
+    lm = save_count;
+    while (lm)
+    {
 #define BK_FREQ 4
-		if (0 == lm%BK_FREQ) suffix ++;
-		else break;
-		lm /= BK_FREQ;
-	}
-	lm %= BK_FREQ;
+        if (0 == lm % BK_FREQ)
+            suffix++;
+        else
+            break;
+        lm /= BK_FREQ;
+    }
+    lm %= BK_FREQ;
 
-	/* Build filenames */
-	len = strlen (filename);
-	old_name = g_new0 (char, len+20);
-	new_name = g_new0 (char, len+20);
-	strcpy (old_name, filename);
-	strcpy (new_name, filename);
-	
+    /* Build filenames */
+    len = strlen(filename);
+    old_name = g_new0(char, len + 20);
+    new_name = g_new0(char, len + 20);
+    strcpy(old_name, filename);
+    strcpy(new_name, filename);
 
-	if ((0 < suffix) && (0<lm))
-	{
-		/* Shuffle files, but preserve datestamps */
-		/* Don't report errors, as user may have erased
-		 * some of these older files by hand */
-		sprintf (new_name+len, ".%d.%d", suffix, lm);
-		sprintf (old_name+len, ".%d.2", suffix-1);
-		rc = stat (old_name, &old_stat);
-		rc += rename (old_name, new_name);
-		if (0 == rc)
-		{
-			ub.actime = old_stat.st_atime;
-			ub.modtime = old_stat.st_mtime;
-			utime (new_name, &ub);
-		}
-	}
+    if ((0 < suffix) && (0 < lm))
+    {
+        /* Shuffle files, but preserve datestamps */
+        /* Don't report errors, as user may have erased
+         * some of these older files by hand */
+        sprintf(new_name + len, ".%d.%d", suffix, lm);
+        sprintf(old_name + len, ".%d.2", suffix - 1);
+        rc = stat(old_name, &old_stat);
+        rc += rename(old_name, new_name);
+        if (0 == rc)
+        {
+            ub.actime = old_stat.st_atime;
+            ub.modtime = old_stat.st_mtime;
+            utime(new_name, &ub);
+        }
+    }
 
-	sprintf (new_name+len, ".0.%d",lm);
-	rc = stat (filename, &old_stat);
-	rc += rename (filename, new_name);
-	if (0 == rc)
-	{
-		ub.actime = old_stat.st_atime;
-		ub.modtime = old_stat.st_mtime;
-		utime (new_name, &ub);
-	}
+    sprintf(new_name + len, ".0.%d", lm);
+    rc = stat(filename, &old_stat);
+    rc += rename(filename, new_name);
+    if (0 == rc)
+    {
+        ub.actime = old_stat.st_atime;
+        ub.modtime = old_stat.st_mtime;
+        utime(new_name, &ub);
+    }
 
-	g_free (old_name);
-	g_free (new_name);
+    g_free(old_name);
+    g_free(new_name);
 }
 
 /* save_all() saves both data and config file, and does this
@@ -662,293 +637,280 @@ make_backup (const char * filename)
  * we'll miss the second one ... but what the hey, who cares.
  */
 
-char *
-save_all (void)
+char *save_all(void)
 {
-	GttErrCode errcode;
-	char *errmsg = NULL;
-	char * xml_filepath;
+    GttErrCode errcode;
+    char *errmsg = NULL;
+    char *xml_filepath;
 
-	xml_filepath = resolve_path (config_data_url);
+    xml_filepath = resolve_path(config_data_url);
 
-	make_backup (xml_filepath);
+    make_backup(xml_filepath);
 
-	/* Try ... */
-	gtt_err_set_code (GTT_NO_ERR);
-	gtt_xml_write_file (xml_filepath);
+    /* Try ... */
+    gtt_err_set_code(GTT_NO_ERR);
+    gtt_xml_write_file(xml_filepath);
 
-	/* Catch */
-	errcode = gtt_err_get_code();
-	if (GTT_NO_ERR != errcode)
-	{
-		errmsg = gtt_err_to_string (errcode, xml_filepath);
-	}
-	g_free (xml_filepath);
+    /* Catch */
+    errcode = gtt_err_get_code();
+    if (GTT_NO_ERR != errcode)
+    {
+        errmsg = gtt_err_to_string(errcode, xml_filepath);
+    }
+    g_free(xml_filepath);
 
-	/* Try ... */
-	gtt_err_set_code (GTT_NO_ERR);
-	gtt_save_config ();
+    /* Try ... */
+    gtt_err_set_code(GTT_NO_ERR);
+    gtt_save_config();
 
-	/* Catch */
-	errcode = gtt_err_get_code();
-	if (GTT_NO_ERR != errcode)
-	{
-		errmsg = gtt_err_to_string (errcode, NULL);
-	}
+    /* Catch */
+    errcode = gtt_err_get_code();
+    if (GTT_NO_ERR != errcode)
+    {
+        errmsg = gtt_err_to_string(errcode, NULL);
+    }
 
-	return errmsg;
+    return errmsg;
 }
 
 /* Save application properties, use GUI to indicate problem */
 
-void
-save_properties (void)
+void save_properties(void)
 {
-	GttErrCode errcode;
+    GttErrCode errcode;
 
-	/* Try ... */
-	gtt_err_set_code (GTT_NO_ERR);
-	gtt_save_config ();
+    /* Try ... */
+    gtt_err_set_code(GTT_NO_ERR);
+    gtt_save_config();
 
-	/* Catch */
-	errcode = gtt_err_get_code();
-	if (GTT_NO_ERR != errcode)
-	{
-		char *errmsg = gtt_err_to_string (errcode, NULL);
+    /* Catch */
+    errcode = gtt_err_get_code();
+    if (GTT_NO_ERR != errcode)
+    {
+        char *errmsg = gtt_err_to_string(errcode, NULL);
 
-		GtkWidget *mb;
-		mb = gtk_message_dialog_new (NULL,
-		         GTK_DIALOG_MODAL,
-		         GTK_MESSAGE_WARNING,
-		         GTK_BUTTONS_CLOSE,
-                 "%s",
-		         errmsg);
-		g_signal_connect (G_OBJECT(mb), "response",
-		         G_CALLBACK (gtk_widget_destroy), mb);
-		gtk_widget_show (mb);
-		g_free (errmsg);
-	}
+        GtkWidget *mb;
+        mb = gtk_message_dialog_new(
+            NULL, GTK_DIALOG_MODAL, GTK_MESSAGE_WARNING, GTK_BUTTONS_CLOSE, "%s", errmsg
+        );
+        g_signal_connect(G_OBJECT(mb), "response", G_CALLBACK(gtk_widget_destroy), mb);
+        gtk_widget_show(mb);
+        g_free(errmsg);
+    }
 }
 
 /* Save project data, use GUI to indicate problem */
 
-void
-save_projects (void)
+void save_projects(void)
 {
-	GttErrCode errcode;
-	char * xml_filepath;
+    GttErrCode errcode;
+    char *xml_filepath;
 
-	/* Try ... */
-	xml_filepath = resolve_path (config_data_url);
-	make_backup (xml_filepath);
+    /* Try ... */
+    xml_filepath = resolve_path(config_data_url);
+    make_backup(xml_filepath);
 
-	gtt_err_set_code (GTT_NO_ERR);
-	gtt_xml_write_file (xml_filepath);
+    gtt_err_set_code(GTT_NO_ERR);
+    gtt_xml_write_file(xml_filepath);
 
-	/* Try to handle a bizzare missing-directory error
-	 * by creating the directory, and trying again. */
-	errcode = gtt_err_get_code();
-	if (GTT_CANT_OPEN_FILE == errcode)
-	{
-		create_data_dir (xml_filepath);
-		gtt_err_set_code (GTT_NO_ERR);
-		gtt_xml_write_file (xml_filepath);
-	}
+    /* Try to handle a bizzare missing-directory error
+     * by creating the directory, and trying again. */
+    errcode = gtt_err_get_code();
+    if (GTT_CANT_OPEN_FILE == errcode)
+    {
+        create_data_dir(xml_filepath);
+        gtt_err_set_code(GTT_NO_ERR);
+        gtt_xml_write_file(xml_filepath);
+    }
 
-	/* Catch */
-	errcode = gtt_err_get_code();
-	if (GTT_NO_ERR != errcode)
-	{
-		char *errmsg = gtt_err_to_string (errcode, xml_filepath);
+    /* Catch */
+    errcode = gtt_err_get_code();
+    if (GTT_NO_ERR != errcode)
+    {
+        char *errmsg = gtt_err_to_string(errcode, xml_filepath);
 
-		GtkWidget *mb;
-		mb = gtk_message_dialog_new (NULL,
-		         GTK_DIALOG_MODAL,
-		         GTK_MESSAGE_WARNING,
-		         GTK_BUTTONS_CLOSE,
-                 "%s",
-		         errmsg);
-		g_signal_connect (G_OBJECT(mb), "response",
-		         G_CALLBACK (gtk_widget_destroy), mb);
-		gtk_widget_show (mb);
-		g_free (errmsg);
-	}
+        GtkWidget *mb;
+        mb = gtk_message_dialog_new(
+            NULL, GTK_DIALOG_MODAL, GTK_MESSAGE_WARNING, GTK_BUTTONS_CLOSE, "%s", errmsg
+        );
+        g_signal_connect(G_OBJECT(mb), "response", G_CALLBACK(gtk_widget_destroy), mb);
+        gtk_widget_show(mb);
+        g_free(errmsg);
+    }
 
-	g_free (xml_filepath);
+    g_free(xml_filepath);
 }
 
 /*
  * session management
  */
 
-static int
-save_state(GnomeClient *client, gint phase, GnomeRestartStyle save_style,
-	   gint shutdown, GnomeInteractStyle interact_styyle, gint fast,
-	   gpointer data)
+static int save_state(
+    GnomeClient *client, gint phase, GnomeRestartStyle save_style, gint shutdown,
+    GnomeInteractStyle interact_styyle, gint fast, gpointer data
+)
 {
-	char *errmsg;
-	// const char *sess_id;
-	char *argv[5];
-	int argc;
-	int x, y, w, h;
-	int rc;
+    char *errmsg;
+    // const char *sess_id;
+    char *argv[5];
+    int argc;
+    int x, y, w, h;
+    int rc;
 
-	// sess_id  = gnome_client_get_id(client);
-	if (!app_window) return FALSE;
+    // sess_id  = gnome_client_get_id(client);
+    if (!app_window)
+        return FALSE;
 
-	gdk_window_get_origin (app_window->window, &x, &y);
-	gdk_window_get_size (app_window->window, &w, &h);
-	argv[0] = (char *)data;
-	argv[1] = "--geometry";
-	argv[2] = g_strdup_printf("%dx%d+%d+%d", w, h, x, y);
-	if ((cur_proj) && (gtt_project_get_title(cur_proj))) {
-		argc = 5;
-		argv[3] = "--select-project";
-		argv[4] = (char *) gtt_project_get_title(cur_proj);
-	} else {
-		argc = 3;
-	}
-	gnome_client_set_clone_command(client, argc, argv);
-	gnome_client_set_restart_command(client, argc, argv);
-	g_free(argv[2]);
+    gdk_window_get_origin(app_window->window, &x, &y);
+    gdk_window_get_size(app_window->window, &w, &h);
+    argv[0] = (char *) data;
+    argv[1] = "--geometry";
+    argv[2] = g_strdup_printf("%dx%d+%d+%d", w, h, x, y);
+    if ((cur_proj) && (gtt_project_get_title(cur_proj)))
+    {
+        argc = 5;
+        argv[3] = "--select-project";
+        argv[4] = (char *) gtt_project_get_title(cur_proj);
+    }
+    else
+    {
+        argc = 3;
+    }
+    gnome_client_set_clone_command(client, argc, argv);
+    gnome_client_set_restart_command(client, argc, argv);
+    g_free(argv[2]);
 
-	/* save both the user preferences/config and the project lists */
-	errmsg = save_all();
-	rc = 0;
-	if (NULL == errmsg) rc = 1;
-	g_free (errmsg);
+    /* save both the user preferences/config and the project lists */
+    errmsg = save_all();
+    rc = 0;
+    if (NULL == errmsg)
+        rc = 1;
+    g_free(errmsg);
 
-	return rc;
+    return rc;
 }
 
-
-static void
-session_die(GnomeClient *client)
+static void session_die(GnomeClient *client)
 {
-	app_quit(NULL, NULL);
+    app_quit(NULL, NULL);
 }
 
-
-static void
-got_signal (int sig)
+static void got_signal(int sig)
 {
-	unlock_gtt ();
+    unlock_gtt();
 
-	/* whack thyself */
-	signal (sig, SIG_DFL);
-	kill (getpid (), sig);
+    /* whack thyself */
+    signal(sig, SIG_DFL);
+    kill(getpid(), sig);
 }
 
-
-static void
-guile_inner_main(void *closure, int argc, char **argv)
+static void guile_inner_main(void *closure, int argc, char **argv)
 {
-	gtk_main();
-	unlock_gtt();
+    gtk_main();
+    unlock_gtt();
 }
 
-#if defined (HAVE_DECL_WNOHANG) && defined (HAVE_WAITPID)
+#if defined(HAVE_DECL_WNOHANG) && defined(HAVE_WAITPID)
 inline RETSIGTYPE sigchld_handler(int unused)
 {
-	while(waitpid(-1, NULL, WNOHANG) > 0) {}
+    while (waitpid(-1, NULL, WNOHANG) > 0)
+    {
+    }
 }
 #endif
 
-int
-main(int argc, char *argv[])
+int main(int argc, char *argv[])
 {
-#if defined (HAVE_DECL_WNOHANG) || defined (HAVE_DECL_SA_NOCLDWAIT)
-	struct sigaction reapchildren;
-	memset(&reapchildren, 0, sizeof reapchildren);
+#if defined(HAVE_DECL_WNOHANG) || defined(HAVE_DECL_SA_NOCLDWAIT)
+    struct sigaction reapchildren;
+    memset(&reapchildren, 0, sizeof reapchildren);
 #endif /*  WNOHANG/SA_NOCLDWAIT */
 
-	static char *geometry_string = NULL;
-	static const struct poptOption geo_options[] =
-	{
-		{"geometry", 'g', POPT_ARG_STRING, &geometry_string, 0,
-			N_("Specify geometry"), N_("GEOMETRY")},
-		{"select-project", 's', POPT_ARG_STRING, &first_proj_title, 0,
-			N_("Select a project on startup"), N_("PROJECT")},
-		{NULL, '\0', 0, NULL, 0}
-	};
+    static char *geometry_string = NULL;
+    static const struct poptOption geo_options[]
+        = { { "geometry", 'g', POPT_ARG_STRING, &geometry_string, 0, N_("Specify geometry"),
+              N_("GEOMETRY") },
+            { "select-project", 's', POPT_ARG_STRING, &first_proj_title, 0,
+              N_("Select a project on startup"), N_("PROJECT") },
+            { NULL, '\0', 0, NULL, 0 } };
 
-	gnome_program_init(PACKAGE, VERSION, LIBGNOMEUI_MODULE, argc, argv,
-		                   GNOME_PARAM_POPT_TABLE, geo_options,
-		                   GNOME_PROGRAM_STANDARD_PROPERTIES, NULL);
-	gnome_window_icon_set_default_from_file (GNOME_ICONDIR"/gnome-cromagnon.png");
+    gnome_program_init(
+        PACKAGE, VERSION, LIBGNOMEUI_MODULE, argc, argv, GNOME_PARAM_POPT_TABLE, geo_options,
+        GNOME_PROGRAM_STANDARD_PROPERTIES, NULL
+    );
+    gnome_window_icon_set_default_from_file(GNOME_ICONDIR "/gnome-cromagnon.png");
 
-	gnome_vfs_init ();
+    gnome_vfs_init();
 
-	bindtextdomain(GETTEXT_PACKAGE, GNOMELOCALEDIR);
-	bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8");
-	textdomain(GETTEXT_PACKAGE);
+    bindtextdomain(GETTEXT_PACKAGE, GNOMELOCALEDIR);
+    bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8");
+    textdomain(GETTEXT_PACKAGE);
 
-	GnomeClient *client = gnome_master_client();
-	g_signal_connect(G_OBJECT(client), "save_yourself",
-			   G_CALLBACK(save_state), (gpointer) argv[0]);
-	g_signal_connect(G_OBJECT(client), "die",
-			   G_CALLBACK(session_die), NULL);
+    GnomeClient *client = gnome_master_client();
+    g_signal_connect(
+        G_OBJECT(client), "save_yourself", G_CALLBACK(save_state), (gpointer) argv[0]
+    );
+    g_signal_connect(G_OBJECT(client), "die", G_CALLBACK(session_die), NULL);
 
-	glade_init();
+    glade_init();
 
-	/* gconf init is needed by gtkhtml */
-	gconf_init (argc, argv, NULL);
+    /* gconf init is needed by gtkhtml */
+    gconf_init(argc, argv, NULL);
 
 #ifdef HAVE_DECL_WNOHANG
-	/* Create a signal handler to reap zombie processes.  Most portable */
-	reapchildren.sa_flags=SA_NOCLDSTOP;
-	reapchildren.sa_handler=sigchld_handler;
-	sigaction(SIGCHLD, &reapchildren, NULL);
-#elif defined (HAVE_DECL_SA_NOCLDWAIT)
-	/* Specify autoreaping using sigaction flag.  Next most portable */
-	memset(&reapchildren, 0, sizeof reapchildren);
-	reapchildren.sa_flags = SA_NOCLDWAIT;
-	sigaction(SIGCHLD, &reapchildren, NULL);
+    /* Create a signal handler to reap zombie processes.  Most portable */
+    reapchildren.sa_flags = SA_NOCLDSTOP;
+    reapchildren.sa_handler = sigchld_handler;
+    sigaction(SIGCHLD, &reapchildren, NULL);
+#elif defined(HAVE_DECL_SA_NOCLDWAIT)
+    /* Specify autoreaping using sigaction flag.  Next most portable */
+    memset(&reapchildren, 0, sizeof reapchildren);
+    reapchildren.sa_flags = SA_NOCLDWAIT;
+    sigaction(SIGCHLD, &reapchildren, NULL);
 #else
-	/* Old SysVr3 way of specifying auto reaping.  Inconsistently supported */
-	signal (SIGCHLD, SIG_IGN);
+    /* Old SysVr3 way of specifying auto reaping.  Inconsistently supported */
+    signal(SIGCHLD, SIG_IGN);
 #endif /* Signal handler to auto-reap zombies */
 
-	signal (SIGINT, got_signal);
-	signal (SIGTERM, got_signal);
-	lock_gtt();
-	app_new(argc, argv, geometry_string);
+    signal(SIGINT, got_signal);
+    signal(SIGTERM, got_signal);
+    lock_gtt();
+    app_new(argc, argv, geometry_string);
 
-	g_signal_connect(G_OBJECT(app_window), "delete_event",
-			   G_CALLBACK(app_quit), NULL);
+    g_signal_connect(G_OBJECT(app_window), "delete_event", G_CALLBACK(app_quit), NULL);
 
 #if WITH_DBUS
-	gnotime_dbus_setup();
+    gnotime_dbus_setup();
 #endif
 
-	/* Perform QOF-specific initialization, including dates, objects, query, etc. */
-	qof_init();
-	// Debugging/trace info for the qof query is written to /tmp/qof.trace
-	// qof_log_init();
-	// qof_log_set_level(QOF_MOD_QUERY, QOF_LOG_TRACE);
-	gtt_project_obj_register();
-	master_list = gtt_project_list_new();
+    /* Perform QOF-specific initialization, including dates, objects, query, etc. */
+    qof_init();
+    // Debugging/trace info for the qof query is written to /tmp/qof.trace
+    // qof_log_init();
+    // qof_log_set_level(QOF_MOD_QUERY, QOF_LOG_TRACE);
+    gtt_project_obj_register();
+    master_list = gtt_project_list_new();
 
 #if DEVEL_VERSION_WARNING
-	msgbox_ok_cancel(_("Warning"),
-		"WARNING !!! Achtung !!! Avertisment !!!\n"
-		"\n"
-		"This is a development version of GTT.  "
-		"It probably crashes. Use at own risk!\n"
-		"\n"
-		"The last stable, working version can be obtained from\n"
-		"the www.gnome.org gnome-utils cvs with\n"
-		"cvs -z3 -d :pserver:anonymous@anoncvs.gnome.org:/cvs/gnome "
-		"checkout -r gnome-utils-1-4 gnome-utils\n",
-	     "Continue", "Exit",
-		G_CALLBACK(beta_run_or_abort));
+    msgbox_ok_cancel(
+        _("Warning"),
+        "WARNING !!! Achtung !!! Avertisment !!!\n"
+        "\n"
+        "This is a development version of GTT.  "
+        "It probably crashes. Use at own risk!\n"
+        "\n"
+        "The last stable, working version can be obtained from\n"
+        "the www.gnome.org gnome-utils cvs with\n"
+        "cvs -z3 -d :pserver:anonymous@anoncvs.gnome.org:/cvs/gnome "
+        "checkout -r gnome-utils-1-4 gnome-utils\n",
+        "Continue", "Exit", G_CALLBACK(beta_run_or_abort)
+    );
 #else
-	read_config();
+    read_config();
 #endif
 
-	scm_boot_guile (argc, argv, guile_inner_main, NULL);
-	return 0; /* not reached !? */
+    scm_boot_guile(argc, argv, guile_inner_main, NULL);
+    return 0; /* not reached !? */
 }
-
 
 /* ======================= END OF FILE =================== */

--- a/src/menucmd.c
+++ b/src/menucmd.c
@@ -36,90 +36,76 @@
 #include "toolbar.h"
 #include "xml-gtt.h"
 
-
-void
-about_box(GtkWindow *w, gpointer data)
+void about_box(GtkWindow *w, gpointer data)
 {
-	const gchar *authors[] = {
-		"Goedson Teixeira Paixão <goedson@debian.org>",
-		"Linas Vepstas <linas@linas.org>",
-		"Eckehard Berns <eb@berns.i-s-o.net>",
-		"George Lebl <jirka@5z.com>",
-		"Kip Warner <kip@thevertigo.com>",
-		" ",
-		_("Bug-fixes from:"),
-		"Eric Anderson <eric.anderson@cordata.net>",
-		"Derek Atkins <warlord@mit.edu>",
-		"Jonathan Blandford  <jrb@redhat.com>",
-		"Miguel de Icaza  <miguel@nuclecu.unam.mx>",
-		"John Fleck <jfleck@inkstain.net>",
-		"Nat Friedman  <nat@nat.org>",
-		"Mark Galassi  <rosalia@cygnus.com>",
-		"Jeff Garzik  <jgarzik@pobox.com>",
-		"Sven M. Hallberg <pesco@gmx.de>",
-		"Raja R Harinath  <harinath@cs.umn.edu>",
-		"Peter Hawkins <peterhawkins@ozemail.com.au>",
-		"Toshio Kuratomi <toshio@tiki-lounge.com>",
-		"Egil Kvaleberg <egil@kvaleberg.no>",
-		"Chris Lahey  <clahey@umich.edu>",
-		"Gregory McLean <gregm@comstar.net>",
-		"Kjartan Maraas  <kmaraas@gnome.org>",
-		"Federico Mena Quintero  <federico@nuclecu.unam.mx>",
-		"Tomas Ogren  <stric@ing.umu.se>",
-		"Gediminas Paulauskas <menesis@delfi.lt>",
-		"Havoc Pennington  <hp@pobox.com>",
-		"Ettore Perazzoli  <ettore@comm2000.it>",
-		"Changwoo Ryu  <cwryu@adam.kaist.ac.kr>",
-		"Pablo Saratxaga <srtxg@chanae.alphanet.ch>",
-		"Carsten Schaar  <nhadcasc@fs-maphy.uni-hannover.de>",
-		"Mark Stosberg <mark@summersault.com>",
-		"Tom Tromey  <tromey@cygnus.com>",
-		"Sebastian Wilhelmi  <wilhelmi@ira.uka.de>",
-		NULL
-	};
+    const gchar *authors[] = { "Goedson Teixeira Paixão <goedson@debian.org>",
+                               "Linas Vepstas <linas@linas.org>",
+                               "Eckehard Berns <eb@berns.i-s-o.net>",
+                               "George Lebl <jirka@5z.com>",
+                               "Kip Warner <kip@thevertigo.com>",
+                               " ",
+                               _("Bug-fixes from:"),
+                               "Eric Anderson <eric.anderson@cordata.net>",
+                               "Derek Atkins <warlord@mit.edu>",
+                               "Jonathan Blandford  <jrb@redhat.com>",
+                               "Miguel de Icaza  <miguel@nuclecu.unam.mx>",
+                               "John Fleck <jfleck@inkstain.net>",
+                               "Nat Friedman  <nat@nat.org>",
+                               "Mark Galassi  <rosalia@cygnus.com>",
+                               "Jeff Garzik  <jgarzik@pobox.com>",
+                               "Sven M. Hallberg <pesco@gmx.de>",
+                               "Raja R Harinath  <harinath@cs.umn.edu>",
+                               "Peter Hawkins <peterhawkins@ozemail.com.au>",
+                               "Toshio Kuratomi <toshio@tiki-lounge.com>",
+                               "Egil Kvaleberg <egil@kvaleberg.no>",
+                               "Chris Lahey  <clahey@umich.edu>",
+                               "Gregory McLean <gregm@comstar.net>",
+                               "Kjartan Maraas  <kmaraas@gnome.org>",
+                               "Federico Mena Quintero  <federico@nuclecu.unam.mx>",
+                               "Tomas Ogren  <stric@ing.umu.se>",
+                               "Gediminas Paulauskas <menesis@delfi.lt>",
+                               "Havoc Pennington  <hp@pobox.com>",
+                               "Ettore Perazzoli  <ettore@comm2000.it>",
+                               "Changwoo Ryu  <cwryu@adam.kaist.ac.kr>",
+                               "Pablo Saratxaga <srtxg@chanae.alphanet.ch>",
+                               "Carsten Schaar  <nhadcasc@fs-maphy.uni-hannover.de>",
+                               "Mark Stosberg <mark@summersault.com>",
+                               "Tom Tromey  <tromey@cygnus.com>",
+                               "Sebastian Wilhelmi  <wilhelmi@ira.uka.de>",
+                               NULL };
 
+    const gchar *documenters[]
+        = { "Eckehard Berns <eb@berns.i-s-o.net>", "Linas Vepstas <linas@linas.org>",
+            "Goedson Teixeira Paixão <goedson@debian.org>", NULL };
 
-	const gchar *documenters[] = {
-		  "Eckehard Berns <eb@berns.i-s-o.net>",
-		  "Linas Vepstas <linas@linas.org>",
-		  "Goedson Teixeira Paixão <goedson@debian.org>",
-		  NULL
-	};
+    const gchar *copyright = "Copyright (C) 1997,98 Eckehard Berns\n"
+                             "Copyright (C) 2001-2004 Linas Vepstas\n"
+                             "Copyright (C) 2007-2008 Goedson Teixeira Paixão";
 
-	const gchar *copyright =
-		"Copyright (C) 1997,98 Eckehard Berns\n"
-		"Copyright (C) 2001-2004 Linas Vepstas\n"
-		"Copyright (C) 2007-2008 Goedson Teixeira Paixão";
+    const gchar *comments = _("GnoTime is a combination of stop-watch, diary, "
+                              " consultant billing system and todo-list manager.");
 
-	const gchar *comments =  _("GnoTime is a combination of stop-watch, diary, "
-							   " consultant billing system and todo-list manager.") ;
+    const gchar *license = "This program is free software; you can redistribute it and/or\n"
+                           "modify it under the terms of the GNU General Public License\n"
+                           "as published by the Free Software Foundation; either version 3\n"
+                           "of the License, or (at your option) any later version.\n"
+                           "\n"
+                           "This program is distributed in the hope that it will be useful,\n"
+                           "but WITHOUT ANY WARRANTY; without even the implied warranty of\n"
+                           "MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n"
+                           "GNU General Public License for more details.\n"
+                           "\n"
+                           "You should have received a copy of the GNU General Public License\n"
+                           "along with this program; if not, write to the Free Software\n"
+                           "Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA\n"
+                           "02110-1301, USA.\n";
 
-	const gchar *license = "This program is free software; you can redistribute it and/or\n"
-		"modify it under the terms of the GNU General Public License\n"
-		"as published by the Free Software Foundation; either version 3\n"
-		"of the License, or (at your option) any later version.\n"
-		"\n"
-		"This program is distributed in the hope that it will be useful,\n"
-		"but WITHOUT ANY WARRANTY; without even the implied warranty of\n"
-		"MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n"
-		"GNU General Public License for more details.\n"
-		"\n"
-		"You should have received a copy of the GNU General Public License\n"
-		"along with this program; if not, write to the Free Software\n"
-		"Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA\n"
-		"02110-1301, USA.\n";
-
-	gtk_show_about_dialog (w,
-						   "version", VERSION,
-						   "program-name", GTT_APP_TITLE,
-						   "authors", authors,
-						   "documenters", documenters,
-						   "website", "http://gnotime.sourceforge.net/",
-						   "translator-credits", _("translator-credits"),
-						   "copyright", copyright,
-						   "comments", comments,
-						   "license", license,
-						   NULL);
+    gtk_show_about_dialog(
+        w, "version", VERSION, "program-name", GTT_APP_TITLE, "authors", authors, "documenters",
+        documenters, "website", "http://gnotime.sourceforge.net/", "translator-credits",
+        _("translator-credits"), "copyright", copyright, "comments", comments, "license",
+        license, NULL
+    );
 }
 
 /* =============================================================================== */
@@ -129,106 +115,106 @@ about_box(GtkWindow *w, gpointer data)
  * XXX FIXME remove this code ASAP ...
  */
 
-static void
-project_name_desc(GtkDialog *w, gint response_id, GtkEntry **entries)
+static void project_name_desc(GtkDialog *w, gint response_id, GtkEntry **entries)
 {
-	const char *name, *desc;
-	GttProject *proj;
-	GttProject *sib_prj;
+    const char *name, *desc;
+    GttProject *proj;
+    GttProject *sib_prj;
 
-	if (GTK_RESPONSE_OK != response_id)
-	{
-		gtk_widget_destroy (GTK_WIDGET (w));
-		return;
-	}
+    if (GTK_RESPONSE_OK != response_id)
+    {
+        gtk_widget_destroy(GTK_WIDGET(w));
+        return;
+    }
 
-	sib_prj = gtt_projects_tree_get_selected_project (projects_tree);
+    sib_prj = gtt_projects_tree_get_selected_project(projects_tree);
 
-	if (!(name = gtk_entry_get_text(entries[0]))) return;
-	if (!(desc = gtk_entry_get_text(entries[1]))) return;
-	if (!name[0]) return;
+    if (!(name = gtk_entry_get_text(entries[0])))
+        return;
+    if (!(desc = gtk_entry_get_text(entries[1])))
+        return;
+    if (!name[0])
+        return;
 
-	/* New project will have the same parent as the currently
-	 * running project.  This seems like the sanest choice.
-	 */
-	proj = gtt_project_new_title_desc(name, desc);
-	gtt_project_insert_after (proj, sib_prj);
-	gtt_projects_tree_append_project (projects_tree, proj, gtt_project_get_parent (sib_prj));
+    /* New project will have the same parent as the currently
+     * running project.  This seems like the sanest choice.
+     */
+    proj = gtt_project_new_title_desc(name, desc);
+    gtt_project_insert_after(proj, sib_prj);
+    gtt_projects_tree_append_project(projects_tree, proj, gtt_project_get_parent(sib_prj));
 
-	gtk_widget_destroy (GTK_WIDGET (w));
+    gtk_widget_destroy(GTK_WIDGET(w));
 }
 
-static void
-free_data(GtkWidget *dlg, gpointer data)
+static void free_data(GtkWidget *dlg, gpointer data)
 {
-	g_free(data);
+    g_free(data);
 }
 
-
-void
-new_project(GtkWidget *widget, gpointer data)
+void new_project(GtkWidget *widget, gpointer data)
 {
-	GtkWidget *w, *t, *title, *d, *desc;
-	GtkDialog *dlg;
-	GtkBox *vbox;
-	GtkWidget **entries = g_new0(GtkWidget *, 2);
-	GtkWidget *table;
+    GtkWidget *w, *t, *title, *d, *desc;
+    GtkDialog *dlg;
+    GtkBox *vbox;
+    GtkWidget **entries = g_new0(GtkWidget *, 2);
+    GtkWidget *table;
 
-	title = gnome_entry_new("project_title");
-	desc = gnome_entry_new("project_description");
-	entries[0] = gnome_entry_gtk_entry(GNOME_ENTRY(title));
-	entries[1] = gnome_entry_gtk_entry(GNOME_ENTRY(desc));
+    title = gnome_entry_new("project_title");
+    desc = gnome_entry_new("project_description");
+    entries[0] = gnome_entry_gtk_entry(GNOME_ENTRY(title));
+    entries[1] = gnome_entry_gtk_entry(GNOME_ENTRY(desc));
 
-	/* Create new dialog box */
-	w = gtk_dialog_new_with_buttons (
-	             _("New Project..."),
-	            // GTK_WINDOW (widget),
-	            NULL,
-		         GTK_DIALOG_MODAL,
-		         NULL);
-	g_signal_connect (G_OBJECT(w), "response",
-	         G_CALLBACK (project_name_desc), entries);
-	dlg = GTK_DIALOG(w);
-	gtk_dialog_add_button (dlg, GTK_STOCK_OK, GTK_RESPONSE_OK);
-	gtk_dialog_add_button (dlg, GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL);
+    /* Create new dialog box */
+    w = gtk_dialog_new_with_buttons(
+        _("New Project..."),
+        // GTK_WINDOW (widget),
+        NULL, GTK_DIALOG_MODAL, NULL
+    );
+    g_signal_connect(G_OBJECT(w), "response", G_CALLBACK(project_name_desc), entries);
+    dlg = GTK_DIALOG(w);
+    gtk_dialog_add_button(dlg, GTK_STOCK_OK, GTK_RESPONSE_OK);
+    gtk_dialog_add_button(dlg, GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL);
 
-	vbox = GTK_BOX(dlg->vbox);
+    vbox = GTK_BOX(dlg->vbox);
 
-	/* Put stuff into the dialog box */
-	t = gtk_label_new(_("Project Title"));
-	d = gtk_label_new(_("Description"));
+    /* Put stuff into the dialog box */
+    t = gtk_label_new(_("Project Title"));
+    d = gtk_label_new(_("Description"));
 
-	table = gtk_table_new(2,2, FALSE);
-	gtk_table_attach(GTK_TABLE(table), t,     0,1, 0,1,
-			    GTK_FILL|GTK_EXPAND, GTK_FILL|GTK_EXPAND, 2, 1);
-	gtk_table_attach(GTK_TABLE(table), title, 1,2, 0,1,
-			    GTK_FILL|GTK_EXPAND, GTK_FILL|GTK_EXPAND, 2, 1);
-	gtk_table_attach(GTK_TABLE(table), d,     0,1, 1,2,
-			    GTK_FILL|GTK_EXPAND, GTK_FILL|GTK_EXPAND, 2, 1);
-	gtk_table_attach(GTK_TABLE(table), desc,  1,2, 1,2,
-			    GTK_FILL|GTK_EXPAND, GTK_FILL|GTK_EXPAND, 2, 1);
+    table = gtk_table_new(2, 2, FALSE);
+    gtk_table_attach(
+        GTK_TABLE(table), t, 0, 1, 0, 1, GTK_FILL | GTK_EXPAND, GTK_FILL | GTK_EXPAND, 2, 1
+    );
+    gtk_table_attach(
+        GTK_TABLE(table), title, 1, 2, 0, 1, GTK_FILL | GTK_EXPAND, GTK_FILL | GTK_EXPAND, 2, 1
+    );
+    gtk_table_attach(
+        GTK_TABLE(table), d, 0, 1, 1, 2, GTK_FILL | GTK_EXPAND, GTK_FILL | GTK_EXPAND, 2, 1
+    );
+    gtk_table_attach(
+        GTK_TABLE(table), desc, 1, 2, 1, 2, GTK_FILL | GTK_EXPAND, GTK_FILL | GTK_EXPAND, 2, 1
+    );
 
-	gtk_box_pack_start(vbox, table, FALSE, FALSE, 2);
-	gtk_widget_show(t);
-	gtk_widget_show(title);
-	gtk_widget_show(d);
-	gtk_widget_show(desc);
-	gtk_widget_show(table);
+    gtk_box_pack_start(vbox, table, FALSE, FALSE, 2);
+    gtk_widget_show(t);
+    gtk_widget_show(title);
+    gtk_widget_show(d);
+    gtk_widget_show(desc);
+    gtk_widget_show(table);
 
-	gtk_widget_grab_focus(entries[0]);
+    gtk_widget_grab_focus(entries[0]);
 
-	/* enter in first entry goes to next */
-	g_signal_connect_object (G_OBJECT (entries[0]), "activate",
-				   G_CALLBACK (gtk_widget_grab_focus),
-				   GTK_OBJECT (entries[1]), 0);
-	// gnome_dialog_editable_enters(GNOME_DIALOG(dlg),
-	// 			     GTK_EDITABLE(entries[1]));
+    /* enter in first entry goes to next */
+    g_signal_connect_object(
+        G_OBJECT(entries[0]), "activate", G_CALLBACK(gtk_widget_grab_focus),
+        GTK_OBJECT(entries[1]), 0
+    );
+    // gnome_dialog_editable_enters(GNOME_DIALOG(dlg),
+    // 			     GTK_EDITABLE(entries[1]));
 
-	g_signal_connect(G_OBJECT(dlg), "destroy",
-			   G_CALLBACK(free_data),
-			   entries);
+    g_signal_connect(G_OBJECT(dlg), "destroy", G_CALLBACK(free_data), entries);
 
-	gtk_widget_show(GTK_WIDGET(dlg));
+    gtk_widget_show(GTK_WIDGET(dlg));
 }
 
 /* ======================================================= */
@@ -238,220 +224,197 @@ new_project(GtkWidget *widget, gpointer data)
 /* XXX hack alert -- we should delete this list during shutdown. */
 static GList *cutted_project_list = NULL;
 
-gboolean
-have_cutted_project (void)
+gboolean have_cutted_project(void)
 {
-	return (NULL==cutted_project_list) ? FALSE : TRUE;
+    return (NULL == cutted_project_list) ? FALSE : TRUE;
 }
 
-static inline void
-debug_print_cutted_proj_list (char * str)
+static inline void debug_print_cutted_proj_list(char *str)
 {
 #ifdef DEBUG
-	GList *n;
-	printf ("proj list --- \n");
-	if (NULL == cutted_project_list)
-	{
-		printf ("%s: project list is empty\n", str);
-	}
-	for (n=cutted_project_list; n; n=n->next)
-	{
-		GttProject *p = n->data;
-		printf ("%s: n=%p prj=%p title=%s\n", str,n,p,gtt_project_get_title(p));
-	}
-	printf ("\n");
+    GList *n;
+    printf("proj list --- \n");
+    if (NULL == cutted_project_list)
+    {
+        printf("%s: project list is empty\n", str);
+    }
+    for (n = cutted_project_list; n; n = n->next)
+    {
+        GttProject *p = n->data;
+        printf("%s: n=%p prj=%p title=%s\n", str, n, p, gtt_project_get_title(p));
+    }
+    printf("\n");
 #endif
 }
 
-void
-cut_project(GtkWidget *w, gpointer data)
+void cut_project(GtkWidget *w, gpointer data)
 {
-	GttProject *cut_prj;
+    GttProject *cut_prj;
 
-	cut_prj = gtt_projects_tree_get_selected_project (projects_tree);
-	if (!cut_prj) return;
+    cut_prj = gtt_projects_tree_get_selected_project(projects_tree);
+    if (!cut_prj)
+        return;
 
-	cutted_project_list = g_list_prepend (cutted_project_list, cut_prj);
-	debug_print_cutted_proj_list ("cut");
+    cutted_project_list = g_list_prepend(cutted_project_list, cut_prj);
+    debug_print_cutted_proj_list("cut");
 
-	/* Clear out relevent GUI elements. */
-	prop_dialog_set_project(NULL);
+    /* Clear out relevent GUI elements. */
+    prop_dialog_set_project(NULL);
 
-	if (cut_prj == cur_proj) gen_stop_timer ();
-	gtt_project_remove(cut_prj);
-	gtt_projects_tree_remove_project (projects_tree, cut_prj);
+    if (cut_prj == cur_proj)
+        gen_stop_timer();
+    gtt_project_remove(cut_prj);
+    gtt_projects_tree_remove_project(projects_tree, cut_prj);
 
-	menu_set_states();      /* To enable paste menu item */
-	toolbar_set_states();
+    menu_set_states(); /* To enable paste menu item */
+    toolbar_set_states();
 }
 
-
-
-void
-paste_project(GtkWidget *w, gpointer data)
+void paste_project(GtkWidget *w, gpointer data)
 {
-	GttProject *sib_prj;
-	GttProject *p;
+    GttProject *sib_prj;
+    GttProject *p;
 
-	sib_prj = gtt_projects_tree_get_selected_project (projects_tree);
+    sib_prj = gtt_projects_tree_get_selected_project(projects_tree);
 
-	debug_print_cutted_proj_list ("pre paste");
+    debug_print_cutted_proj_list("pre paste");
 
-	if (!cutted_project_list) return;
-	p = cutted_project_list->data;
+    if (!cutted_project_list)
+        return;
+    p = cutted_project_list->data;
 
-	if (NULL == cutted_project_list->next)
-	{
-		/* If we paste a second time, we better paste a copy ... */
-		cutted_project_list->data = gtt_project_dup(p);
-	}
-	else
-	{
-		/* Pop element off the top. */
-		cutted_project_list->data = NULL;
-		cutted_project_list =
-		     g_list_delete_link(cutted_project_list, cutted_project_list);
-	}
-	debug_print_cutted_proj_list ("post paste");
+    if (NULL == cutted_project_list->next)
+    {
+        /* If we paste a second time, we better paste a copy ... */
+        cutted_project_list->data = gtt_project_dup(p);
+    }
+    else
+    {
+        /* Pop element off the top. */
+        cutted_project_list->data = NULL;
+        cutted_project_list = g_list_delete_link(cutted_project_list, cutted_project_list);
+    }
+    debug_print_cutted_proj_list("post paste");
 
-	/* Insert before the focus proj */
-	gtt_project_insert_before (p, sib_prj);
-	gtt_projects_tree_insert_project_before (projects_tree, p, sib_prj);
+    /* Insert before the focus proj */
+    gtt_project_insert_before(p, sib_prj);
+    gtt_projects_tree_insert_project_before(projects_tree, p, sib_prj);
 }
 
-
-
-void
-copy_project(GtkWidget *w, gpointer data)
+void copy_project(GtkWidget *w, gpointer data)
 {
-	GttProject *prj;
-	prj = gtt_projects_tree_get_selected_project (projects_tree);
+    GttProject *prj;
+    prj = gtt_projects_tree_get_selected_project(projects_tree);
 
-	if (!prj) return;
+    if (!prj)
+        return;
 
-	prj = gtt_project_dup(prj);
+    prj = gtt_project_dup(prj);
 
-	/* Hitting copy has effect of completely trashing
-	 * the list of earlier cut projects.  We do this in order
-	 * to allow the most recently copied project to be pasted
-	 * multiple times.  */
-	GList *n = cutted_project_list;
-	for (n=cutted_project_list; n; n=n->next)
-	{
-		GttProject *p = n->data;
-		gtt_project_destroy (p);
-	}
-	g_list_free (cutted_project_list);
+    /* Hitting copy has effect of completely trashing
+     * the list of earlier cut projects.  We do this in order
+     * to allow the most recently copied project to be pasted
+     * multiple times.  */
+    GList *n = cutted_project_list;
+    for (n = cutted_project_list; n; n = n->next)
+    {
+        GttProject *p = n->data;
+        gtt_project_destroy(p);
+    }
+    g_list_free(cutted_project_list);
 
-	cutted_project_list = g_list_prepend (NULL, prj);
-	debug_print_cutted_proj_list ("copy");
+    cutted_project_list = g_list_prepend(NULL, prj);
+    debug_print_cutted_proj_list("copy");
 
-	/* Update various subsystems */
-	menu_set_states();      /* to enable paste menu item */
-	toolbar_set_states();
+    /* Update various subsystems */
+    menu_set_states(); /* to enable paste menu item */
+    toolbar_set_states();
 }
-
 
 /* ======================================================= */
 /* Timer related menu functions */
 
-void
-gen_start_timer(void)
+void gen_start_timer(void)
 {
-	GttProject *prj;
-	prj = gtt_projects_tree_get_selected_project (projects_tree);
-	cur_proj_set (prj);
+    GttProject *prj;
+    prj = gtt_projects_tree_get_selected_project(projects_tree);
+    cur_proj_set(prj);
 }
 
-
-void
-gen_stop_timer(void)
+void gen_stop_timer(void)
 {
-	cur_proj_set (NULL);
+    cur_proj_set(NULL);
 }
 
-void
-menu_start_timer(GtkWidget *w, gpointer data)
+void menu_start_timer(GtkWidget *w, gpointer data)
 {
-	gen_start_timer();
+    gen_start_timer();
 }
 
-
-void
-menu_stop_timer(GtkWidget *w, gpointer data)
+void menu_stop_timer(GtkWidget *w, gpointer data)
 {
-	gen_stop_timer();
+    gen_stop_timer();
 }
 
-
-void
-menu_toggle_timer(GtkWidget *w, gpointer data)
+void menu_toggle_timer(GtkWidget *w, gpointer data)
 {
-	GttProject *prj;
-	prj = gtt_projects_tree_get_selected_project (projects_tree);
+    GttProject *prj;
+    prj = gtt_projects_tree_get_selected_project(projects_tree);
 
-	if (timer_is_running()) {
-		cur_proj_set (NULL);
-	} else {
-		cur_proj_set (prj);
-	}
+    if (timer_is_running())
+    {
+        cur_proj_set(NULL);
+    }
+    else
+    {
+        cur_proj_set(prj);
+    }
 }
 
-
-void
-menu_options(GtkWidget *w, gpointer data)
+void menu_options(GtkWidget *w, gpointer data)
 {
-	prefs_dialog_show();
+    prefs_dialog_show();
 }
 
-
-
-void
-menu_properties(GtkWidget *w, gpointer data)
+void menu_properties(GtkWidget *w, gpointer data)
 {
-	GttProject *prj;
-	prj = gtt_projects_tree_get_selected_project (projects_tree);
+    GttProject *prj;
+    prj = gtt_projects_tree_get_selected_project(projects_tree);
 
-	if (prj) {
-		prop_dialog_show(prj);
-	}
-	else
-	{
-		GtkWidget *dlg = gtk_message_dialog_new (GTK_WINDOW (app_window),
-												 GTK_DIALOG_MODAL,
-												 GTK_MESSAGE_INFO,
-												 GTK_BUTTONS_OK,
-												 _("You must select the project of which you want to edit the properties"));
-		gtk_dialog_run (GTK_DIALOG (dlg));
-		gtk_widget_destroy (dlg);
-	}
+    if (prj)
+    {
+        prop_dialog_show(prj);
+    }
+    else
+    {
+        GtkWidget *dlg = gtk_message_dialog_new(
+            GTK_WINDOW(app_window), GTK_DIALOG_MODAL, GTK_MESSAGE_INFO, GTK_BUTTONS_OK,
+            _("You must select the project of which you want to edit the properties")
+        );
+        gtk_dialog_run(GTK_DIALOG(dlg));
+        gtk_widget_destroy(dlg);
+    }
 }
-
 
 /* Cheesey usability hack to tell the user how to edit the timer
  * intervals.  Replace with something intuitive at earliest convenience.
  */
 
-void
-menu_howto_edit_times (GtkWidget *w,gpointer data)
+void menu_howto_edit_times(GtkWidget *w, gpointer data)
 {
-	char * msg;
+    char *msg;
 
-	msg = _("To edit the timer interval for this project,\n"
-	        "open the Activity window and click on a link.\n"
-	        "This will bring up a menu of time editing options.\n");
+    msg = _("To edit the timer interval for this project,\n"
+            "open the Activity window and click on a link.\n"
+            "This will bring up a menu of time editing options.\n");
 
-	GtkWidget *mb;
-	mb = gtk_message_dialog_new (NULL,
-	         GTK_DIALOG_MODAL,
-	         GTK_MESSAGE_INFO,
-	         GTK_BUTTONS_OK,
-             "%s",
-		      msg);
-	gtk_dialog_run (GTK_DIALOG (mb));
-	gtk_widget_destroy (mb);
-	show_report (NULL, ACTIVITY_REPORT);
+    GtkWidget *mb;
+    mb = gtk_message_dialog_new(
+        NULL, GTK_DIALOG_MODAL, GTK_MESSAGE_INFO, GTK_BUTTONS_OK, "%s", msg
+    );
+    gtk_dialog_run(GTK_DIALOG(mb));
+    gtk_widget_destroy(mb);
+    show_report(NULL, ACTIVITY_REPORT);
 }
-
 
 /* ============================ END OF FILE ======================= */

--- a/src/menucmd.h
+++ b/src/menucmd.h
@@ -30,7 +30,7 @@ void export_current_state(GtkWidget *, gpointer);
 void cut_project(GtkWidget *w, gpointer data);
 void paste_project(GtkWidget *w, gpointer data);
 void copy_project(GtkWidget *w, gpointer data);
-gboolean have_cutted_project (void);
+gboolean have_cutted_project(void);
 
 void menu_start_timer(GtkWidget *w, gpointer data);
 void menu_stop_timer(GtkWidget *w, gpointer data);
@@ -44,7 +44,7 @@ void menu_properties(GtkWidget *w, gpointer data);
 
 void menu_clear_daily_counter(GtkWidget *w, gpointer data);
 
-void menu_howto_edit_times (GtkWidget *w,gpointer data);
+void menu_howto_edit_times(GtkWidget *w, gpointer data);
 
 #ifdef DEBUG
 void menu_test(GtkWidget *w, gpointer data);

--- a/src/menus.c
+++ b/src/menus.c
@@ -30,374 +30,283 @@
 #include "plug-in.h"
 #include "timer.h"
 
-
-static GnomeUIInfo menu_main_file[] = {
-	{GNOME_APP_UI_ITEM, N_("_Export Tasks"), NULL,
-		export_file_picker,  TAB_DELIM_EXPORT, NULL,
-		GNOME_APP_PIXMAP_STOCK, GTK_STOCK_SAVE,
-		'E', GDK_CONTROL_MASK, NULL},
-	{GNOME_APP_UI_ITEM, N_("Export _Projects"), NULL,
-		export_file_picker, TODO_EXPORT, NULL,
-		GNOME_APP_PIXMAP_STOCK, GTK_STOCK_SAVE,
-		'P', GDK_CONTROL_MASK, NULL},
-	GNOMEUIINFO_SEPARATOR,
-	GNOMEUIINFO_MENU_EXIT_ITEM(app_quit,NULL),
-	GNOMEUIINFO_END
-};
+static GnomeUIInfo menu_main_file[]
+    = { { GNOME_APP_UI_ITEM, N_("_Export Tasks"), NULL, export_file_picker, TAB_DELIM_EXPORT,
+          NULL, GNOME_APP_PIXMAP_STOCK, GTK_STOCK_SAVE, 'E', GDK_CONTROL_MASK, NULL },
+        { GNOME_APP_UI_ITEM, N_("Export _Projects"), NULL, export_file_picker, TODO_EXPORT,
+          NULL, GNOME_APP_PIXMAP_STOCK, GTK_STOCK_SAVE, 'P', GDK_CONTROL_MASK, NULL },
+        GNOMEUIINFO_SEPARATOR,
+        GNOMEUIINFO_MENU_EXIT_ITEM(app_quit, NULL),
+        GNOMEUIINFO_END };
 
 /* Insert an item with a stock icon and a user data pointer */
 #define GNOMEUIINFO_ITEM_STOCK_DATA(label, tooltip, callback, user_data, stock_id) \
-   { GNOME_APP_UI_ITEM, label, tooltip, (gpointer)callback, user_data, NULL, \
-     GNOME_APP_PIXMAP_STOCK, stock_id, 0, (GdkModifierType) 0, NULL }
+    {                                                                              \
+        GNOME_APP_UI_ITEM, label, tooltip, (gpointer) callback, user_data, NULL,   \
+            GNOME_APP_PIXMAP_STOCK, stock_id, 0, (GdkModifierType) 0, NULL         \
+    }
 
-static GnomeUIInfo menu_main_projects[] = {
-  GNOMEUIINFO_MENU_NEW_ITEM(N_("_New ..."), NULL,
-				  new_project, NULL),
-	GNOMEUIINFO_SEPARATOR,
+static GnomeUIInfo menu_main_projects[]
+    = { GNOMEUIINFO_MENU_NEW_ITEM(N_("_New ..."), NULL, new_project, NULL),
+        GNOMEUIINFO_SEPARATOR,
 #define MENU_PROJECTS_CUT_POS 2
-  {
-    GNOME_APP_UI_ITEM,
-    N_("Cu_t"),
-    N_("Delete the selected project"),
-    cut_project,
-    NULL,
-    NULL,
-    GNOME_APP_PIXMAP_STOCK,
-    GNOME_STOCK_PIXMAP_CUT,
-    'D',
-    GDK_CONTROL_MASK,
-    NULL
-  },
+        { GNOME_APP_UI_ITEM, N_("Cu_t"), N_("Delete the selected project"), cut_project, NULL,
+          NULL, GNOME_APP_PIXMAP_STOCK, GNOME_STOCK_PIXMAP_CUT, 'D', GDK_CONTROL_MASK, NULL },
 #define MENU_PROJECTS_COPY_POS 3
-  {
-    GNOME_APP_UI_ITEM,
-    N_("_Copy"),
-    N_("Copy the selected project"),
-    copy_project,
-    NULL,
-    NULL,
-    GNOME_APP_PIXMAP_STOCK,
-    GNOME_STOCK_PIXMAP_COPY,
-    'F',
-    GDK_CONTROL_MASK,
-    NULL
-  },
+        { GNOME_APP_UI_ITEM, N_("_Copy"), N_("Copy the selected project"), copy_project, NULL,
+          NULL, GNOME_APP_PIXMAP_STOCK, GNOME_STOCK_PIXMAP_COPY, 'F', GDK_CONTROL_MASK, NULL },
 #define MENU_PROJECTS_PASTE_POS 4
-  {
-    GNOME_APP_UI_ITEM,
-    N_("_Paste"),
-    N_("Paste the previously copied project"),
-    paste_project,
-    NULL,
-    NULL,
-    GNOME_APP_PIXMAP_STOCK,
-    GNOME_STOCK_PIXMAP_PASTE,
-    'G',
-    GDK_CONTROL_MASK,
-    NULL
-  },
-	GNOMEUIINFO_SEPARATOR,
-	GNOMEUIINFO_ITEM_STOCK(N_("Edit _Times"),
-		N_("Edit the time interval associated with this project"),
-			       menu_howto_edit_times,
-			       GNOME_STOCK_BLANK),
+        { GNOME_APP_UI_ITEM, N_("_Paste"), N_("Paste the previously copied project"),
+          paste_project, NULL, NULL, GNOME_APP_PIXMAP_STOCK, GNOME_STOCK_PIXMAP_PASTE, 'G',
+          GDK_CONTROL_MASK, NULL },
+        GNOMEUIINFO_SEPARATOR,
+        GNOMEUIINFO_ITEM_STOCK(
+            N_("Edit _Times"), N_("Edit the time interval associated with this project"),
+            menu_howto_edit_times, GNOME_STOCK_BLANK
+        ),
 #define MENU_PROJECTS_PROP_POS 7
-	GNOMEUIINFO_MENU_PROPERTIES_ITEM(menu_properties,NULL),
-	GNOMEUIINFO_END
-};
+        GNOMEUIINFO_MENU_PROPERTIES_ITEM(menu_properties, NULL),
+        GNOMEUIINFO_END };
 
-static GnomeUIInfo menu_main_settings[] = {
-	GNOMEUIINFO_MENU_PREFERENCES_ITEM(menu_options,NULL),
-	GNOMEUIINFO_END
-};
-
+static GnomeUIInfo menu_main_settings[]
+    = { GNOMEUIINFO_MENU_PREFERENCES_ITEM(menu_options, NULL), GNOMEUIINFO_END };
 
 static GnomeUIInfo menu_main_reports[] = {
-	GNOMEUIINFO_ITEM_STOCK_DATA(N_("_Journal..."),
-		N_("Show the journal for this project"),
-			       show_report, JOURNAL_REPORT,
-			       GNOME_STOCK_BLANK),
-	GNOMEUIINFO_ITEM_STOCK_DATA(N_("_Activity..."),
-		N_("Show the journal together with the timestamps for this project"),
-			       show_report, ACTIVITY_REPORT,
-			       GNOME_STOCK_BLANK),
-	GNOMEUIINFO_ITEM_STOCK_DATA(N_("_Daily..."),
-		N_("Show the total time spent on a project, day by day"),
-			       show_report, DAILY_REPORT,
-			       GNOME_STOCK_BLANK),
-	GNOMEUIINFO_ITEM_STOCK_DATA(N_("_Status..."),
-		N_("Show the project descriptions and notes."),
-			       show_report, STATUS_REPORT,
-			       GNOME_STOCK_BLANK),
-	GNOMEUIINFO_ITEM_STOCK_DATA(N_("_To Do..."),
-		N_("Show a sample to-do list"),
-			       show_report, TODO_REPORT,
-			       GNOME_STOCK_BLANK),
-	GNOMEUIINFO_ITEM_STOCK_DATA(N_("_Invoice..."),
-		N_("Show a sample invoice for this project"),
-			       show_report, INVOICE_REPORT,
-			       GNOME_STOCK_BLANK),
-	GNOMEUIINFO_ITEM_STOCK_DATA(N_("_Query..."),
-		N_("Run a sample Query Generator"),
-			       show_report, QUERY_REPORT,
-			       GNOME_STOCK_BLANK),
-	GNOMEUIINFO_ITEM_STOCK_DATA(N_("_Primer..."),
-		N_("Show a sample introductory primer for designing custom reports"),
-			       show_report, PRIMER_REPORT,
-			       GNOME_STOCK_BLANK),
-	GNOMEUIINFO_ITEM_STOCK(N_("_New Report..."),
-		N_("Define a path to a new GnoTime ghtml report file"),
-			       new_report,
-			       GNOME_STOCK_BLANK),
-	GNOMEUIINFO_ITEM_STOCK(N_("_Edit Reports..."),
-		N_("Edit the entries in the Reports pulldown menu (this menu)"),
-			       report_menu_edit,
-			       GNOME_STOCK_BLANK),
-	GNOMEUIINFO_SEPARATOR,
-	GNOMEUIINFO_END
+    GNOMEUIINFO_ITEM_STOCK_DATA(
+        N_("_Journal..."), N_("Show the journal for this project"), show_report, JOURNAL_REPORT,
+        GNOME_STOCK_BLANK
+    ),
+    GNOMEUIINFO_ITEM_STOCK_DATA(
+        N_("_Activity..."),
+        N_("Show the journal together with the timestamps for this project"), show_report,
+        ACTIVITY_REPORT, GNOME_STOCK_BLANK
+    ),
+    GNOMEUIINFO_ITEM_STOCK_DATA(
+        N_("_Daily..."), N_("Show the total time spent on a project, day by day"), show_report,
+        DAILY_REPORT, GNOME_STOCK_BLANK
+    ),
+    GNOMEUIINFO_ITEM_STOCK_DATA(
+        N_("_Status..."), N_("Show the project descriptions and notes."), show_report,
+        STATUS_REPORT, GNOME_STOCK_BLANK
+    ),
+    GNOMEUIINFO_ITEM_STOCK_DATA(
+        N_("_To Do..."), N_("Show a sample to-do list"), show_report, TODO_REPORT,
+        GNOME_STOCK_BLANK
+    ),
+    GNOMEUIINFO_ITEM_STOCK_DATA(
+        N_("_Invoice..."), N_("Show a sample invoice for this project"), show_report,
+        INVOICE_REPORT, GNOME_STOCK_BLANK
+    ),
+    GNOMEUIINFO_ITEM_STOCK_DATA(
+        N_("_Query..."), N_("Run a sample Query Generator"), show_report, QUERY_REPORT,
+        GNOME_STOCK_BLANK
+    ),
+    GNOMEUIINFO_ITEM_STOCK_DATA(
+        N_("_Primer..."), N_("Show a sample introductory primer for designing custom reports"),
+        show_report, PRIMER_REPORT, GNOME_STOCK_BLANK
+    ),
+    GNOMEUIINFO_ITEM_STOCK(
+        N_("_New Report..."), N_("Define a path to a new GnoTime ghtml report file"),
+        new_report, GNOME_STOCK_BLANK
+    ),
+    GNOMEUIINFO_ITEM_STOCK(
+        N_("_Edit Reports..."), N_("Edit the entries in the Reports pulldown menu (this menu)"),
+        report_menu_edit, GNOME_STOCK_BLANK
+    ),
+    GNOMEUIINFO_SEPARATOR,
+    GNOMEUIINFO_END
 };
-
-
 
 static GnomeUIInfo menu_main_timer[] = {
 #define MENU_TIMER_START_POS 0
-	{
-    GNOME_APP_UI_ITEM,
-    N_("St_art"),
-    N_("Start the timer running"),
-    menu_start_timer,
-    NULL,
-    NULL,
-    GNOME_APP_PIXMAP_STOCK,
-    GNOME_STOCK_TIMER,
-    'S',
-    GDK_CONTROL_MASK,
-    NULL
-  },
+    { GNOME_APP_UI_ITEM, N_("St_art"), N_("Start the timer running"), menu_start_timer, NULL,
+      NULL, GNOME_APP_PIXMAP_STOCK, GNOME_STOCK_TIMER, 'S', GDK_CONTROL_MASK, NULL },
 #define MENU_TIMER_STOP_POS 1
-  {
-    GNOME_APP_UI_ITEM,
-    N_("Sto_p"),
-    N_("Stop the timer"),
-    menu_stop_timer,
-    NULL,
-    NULL,
-    GNOME_APP_PIXMAP_STOCK,
-    GNOME_STOCK_TIMER_STOP,
-    'W',
-    GDK_CONTROL_MASK,
-    NULL
-  },
+    { GNOME_APP_UI_ITEM, N_("Sto_p"), N_("Stop the timer"), menu_stop_timer, NULL, NULL,
+      GNOME_APP_PIXMAP_STOCK, GNOME_STOCK_TIMER_STOP, 'W', GDK_CONTROL_MASK, NULL },
 #define MENU_TIMER_TOGGLE_POS 2
-  {
-    GNOME_APP_UI_TOGGLEITEM,
-    N_("_Timer Running"),
-    NULL,
-    menu_toggle_timer,
-    NULL,
-    NULL,
-    GNOME_APP_PIXMAP_NONE,
-    NULL,
-    'T',
-    GDK_CONTROL_MASK,
-    NULL
-  },
-  GNOMEUIINFO_END
+    { GNOME_APP_UI_TOGGLEITEM, N_("_Timer Running"), NULL, menu_toggle_timer, NULL, NULL,
+      GNOME_APP_PIXMAP_NONE, NULL, 'T', GDK_CONTROL_MASK, NULL },
+    GNOMEUIINFO_END
 };
 
+static GnomeUIInfo menu_main_help[]
+    = { GNOMEUIINFO_HELP("gnotime"), GNOMEUIINFO_MENU_ABOUT_ITEM(about_box, NULL),
+        GNOMEUIINFO_END };
 
-static GnomeUIInfo menu_main_help[] = {
-	GNOMEUIINFO_HELP("gnotime"),
-	GNOMEUIINFO_MENU_ABOUT_ITEM(about_box,NULL),
-	GNOMEUIINFO_END
-};
-
-
-static GnomeUIInfo menu_main[] = {
-	GNOMEUIINFO_MENU_FILE_TREE(menu_main_file),
-	GNOMEUIINFO_SUBTREE(N_("_Projects"), menu_main_projects),
-	GNOMEUIINFO_MENU_SETTINGS_TREE(menu_main_settings),
-	GNOMEUIINFO_SUBTREE(N_("_Reports"), menu_main_reports),
-	GNOMEUIINFO_SUBTREE(N_("_Timer"), menu_main_timer),
-	GNOMEUIINFO_MENU_HELP_TREE(menu_main_help),
-	GNOMEUIINFO_END
-};
-
-
+static GnomeUIInfo menu_main[] = { GNOMEUIINFO_MENU_FILE_TREE(menu_main_file),
+                                   GNOMEUIINFO_SUBTREE(N_("_Projects"), menu_main_projects),
+                                   GNOMEUIINFO_MENU_SETTINGS_TREE(menu_main_settings),
+                                   GNOMEUIINFO_SUBTREE(N_("_Reports"), menu_main_reports),
+                                   GNOMEUIINFO_SUBTREE(N_("_Timer"), menu_main_timer),
+                                   GNOMEUIINFO_MENU_HELP_TREE(menu_main_help),
+                                   GNOMEUIINFO_END };
 
 static GnomeUIInfo menu_popup[] = {
 #define MENU_POPUP_JNL_POS 0
-	GNOMEUIINFO_ITEM_STOCK_DATA(N_("_Activity..."),
-		N_("Show the timesheet journal for this project"),
-			       show_report, ACTIVITY_REPORT,
-			       GNOME_STOCK_BLANK),
-	GNOMEUIINFO_ITEM_STOCK(N_("Edit _Times"),
-		N_("Edit the time interval associated with this project"),
-			       menu_howto_edit_times,
-			       GNOME_STOCK_BLANK),
-	GNOMEUIINFO_ITEM_STOCK(N_("_New Diary Entry"),
-		N_("Change the current task for this project"),
-			       new_task_ui,
-			       GNOME_STOCK_BLANK),
-	GNOMEUIINFO_ITEM_STOCK(N_("_Edit Diary Entry"),
-		N_("Edit task header for this project"),
-			       edit_task_ui,
-			       GNOME_STOCK_BLANK),
-	GNOMEUIINFO_SEPARATOR,
+    GNOMEUIINFO_ITEM_STOCK_DATA(
+        N_("_Activity..."), N_("Show the timesheet journal for this project"), show_report,
+        ACTIVITY_REPORT, GNOME_STOCK_BLANK
+    ),
+    GNOMEUIINFO_ITEM_STOCK(
+        N_("Edit _Times"), N_("Edit the time interval associated with this project"),
+        menu_howto_edit_times, GNOME_STOCK_BLANK
+    ),
+    GNOMEUIINFO_ITEM_STOCK(
+        N_("_New Diary Entry"), N_("Change the current task for this project"), new_task_ui,
+        GNOME_STOCK_BLANK
+    ),
+    GNOMEUIINFO_ITEM_STOCK(
+        N_("_Edit Diary Entry"), N_("Edit task header for this project"), edit_task_ui,
+        GNOME_STOCK_BLANK
+    ),
+    GNOMEUIINFO_SEPARATOR,
 #define MENU_POPUP_CUT_POS 5
-	GNOMEUIINFO_MENU_CUT_ITEM(cut_project,NULL),
+    GNOMEUIINFO_MENU_CUT_ITEM(cut_project, NULL),
 #define MENU_POPUP_COPY_POS 6
-	GNOMEUIINFO_MENU_COPY_ITEM(copy_project,NULL),
+    GNOMEUIINFO_MENU_COPY_ITEM(copy_project, NULL),
 #define MENU_POPUP_PASTE_POS 7
-	GNOMEUIINFO_MENU_PASTE_ITEM(paste_project,NULL),
-	GNOMEUIINFO_SEPARATOR,
+    GNOMEUIINFO_MENU_PASTE_ITEM(paste_project, NULL),
+    GNOMEUIINFO_SEPARATOR,
 #define MENU_POPUP_PROP_POS 9
-	GNOMEUIINFO_MENU_PROPERTIES_ITEM(menu_properties,NULL),
-	GNOMEUIINFO_END
+    GNOMEUIINFO_MENU_PROPERTIES_ITEM(menu_properties, NULL),
+    GNOMEUIINFO_END
 };
 
-
-
-
-GtkMenuShell *
-menus_get_popup(void)
+GtkMenuShell *menus_get_popup(void)
 {
-	static GtkMenuShell *menu = NULL;
+    static GtkMenuShell *menu = NULL;
 
-	if (menu) return menu;
+    if (menu)
+        return menu;
 
-	menu = (GtkMenuShell *)gtk_menu_new();
-	gnome_app_fill_menu(menu, menu_popup, NULL, TRUE, 0);
-	return menu;
+    menu = (GtkMenuShell *) gtk_menu_new();
+    gnome_app_fill_menu(menu, menu_popup, NULL, TRUE, 0);
+    return menu;
 }
 
-
-
-void
-menus_create(GnomeApp *app)
+void menus_create(GnomeApp *app)
 {
-	menus_get_popup(); /* initialize it */
-	gnome_app_create_menus(app, menu_main);
-
+    menus_get_popup(); /* initialize it */
+    gnome_app_create_menus(app, menu_main);
 }
 
 /* Global: the user-defined reports pull-down menu */
 static GnomeUIInfo *reports_menu = NULL;
 
-GnomeUIInfo *
-gtt_get_reports_menu (void)
+GnomeUIInfo *gtt_get_reports_menu(void)
 {
-	return (reports_menu);
+    return (reports_menu);
 }
 
-void
-gtt_set_reports_menu (GnomeApp *app, GnomeUIInfo *new_menus)
+void gtt_set_reports_menu(GnomeApp *app, GnomeUIInfo *new_menus)
 {
-	int i;
-	char * path;
+    int i;
+    char *path;
 
-	/* Build the i18n menu path ... */
-	/* (is this right ??? or is this pre-i18n ???) */
-	path = g_strdup_printf ("%s/<Separator>", _("Reports"));
+    /* Build the i18n menu path ... */
+    /* (is this right ??? or is this pre-i18n ???) */
+    path = g_strdup_printf("%s/<Separator>", _("Reports"));
 
-	/* If there are old menu items, remove them and free them. */
-	if (reports_menu)
-	{
-		int nreports;
-		for (i=0; GNOME_APP_UI_ENDOFINFO != reports_menu[i].type; i++) {}
-		nreports = i;
-		gnome_app_remove_menu_range (app, path, 1, nreports);
+    /* If there are old menu items, remove them and free them. */
+    if (reports_menu)
+    {
+        int nreports;
+        for (i = 0; GNOME_APP_UI_ENDOFINFO != reports_menu[i].type; i++)
+        {
+        }
+        nreports = i;
+        gnome_app_remove_menu_range(app, path, 1, nreports);
 
-		if (new_menus != reports_menu)
-		{
-			for (i=0; i<nreports; i++)
-			{
-				// XXX can't free this, since 'append' recycles old pointers !!
-				// there's probably a minor memory leak here ...
-				// gtt_plugin_free(reports_menu[i].user_data);
-			}
-			g_free (reports_menu);
-		}
-	}
+        if (new_menus != reports_menu)
+        {
+            for (i = 0; i < nreports; i++)
+            {
+                // XXX can't free this, since 'append' recycles old pointers !!
+                // there's probably a minor memory leak here ...
+                // gtt_plugin_free(reports_menu[i].user_data);
+            }
+            g_free(reports_menu);
+        }
+    }
 
-	/* Now install the new menu items. */
-	reports_menu = new_menus;
-	if (!reports_menu)
-	{
-		reports_menu = g_new0 (GnomeUIInfo, 1);
-		reports_menu[0].type = GNOME_APP_UI_ENDOFINFO;
-	}
+    /* Now install the new menu items. */
+    reports_menu = new_menus;
+    if (!reports_menu)
+    {
+        reports_menu = g_new0(GnomeUIInfo, 1);
+        reports_menu[0].type = GNOME_APP_UI_ENDOFINFO;
+    }
 
-	/* fixup */
-	for (i=0; GNOME_APP_UI_ENDOFINFO != reports_menu[i].type; i++)
-	{
-		reports_menu[i].moreinfo = invoke_report;
-	}
-	gnome_app_insert_menus (app, path, reports_menu);
+    /* fixup */
+    for (i = 0; GNOME_APP_UI_ENDOFINFO != reports_menu[i].type; i++)
+    {
+        reports_menu[i].moreinfo = invoke_report;
+    }
+    gnome_app_insert_menus(app, path, reports_menu);
 }
 
 /* ============================================================ */
 /* Slide a new menu entry into first place */
 
-void
-gtt_reports_menu_prepend_entry (GnomeApp *app, GnomeUIInfo *new_entry)
+void gtt_reports_menu_prepend_entry(GnomeApp *app, GnomeUIInfo *new_entry)
 {
-	int i, nitems;
-	GnomeUIInfo * current_sysmenu, *new_sysmenu;
+    int i, nitems;
+    GnomeUIInfo *current_sysmenu, *new_sysmenu;
 
-	current_sysmenu = gtt_get_reports_menu ();
-	for (i=0; GNOME_APP_UI_ENDOFINFO != current_sysmenu[i].type; i++) {}
-	nitems = i+1;
+    current_sysmenu = gtt_get_reports_menu();
+    for (i = 0; GNOME_APP_UI_ENDOFINFO != current_sysmenu[i].type; i++)
+    {
+    }
+    nitems = i + 1;
 
-	new_sysmenu = g_new0 (GnomeUIInfo, nitems+1);
-	new_sysmenu[0] = *new_entry;
+    new_sysmenu = g_new0(GnomeUIInfo, nitems + 1);
+    new_sysmenu[0] = *new_entry;
 
-	memcpy (&new_sysmenu[1], current_sysmenu, nitems*sizeof(GnomeUIInfo));
-	gtt_set_reports_menu (app, new_sysmenu);
+    memcpy(&new_sysmenu[1], current_sysmenu, nitems * sizeof(GnomeUIInfo));
+    gtt_set_reports_menu(app, new_sysmenu);
 }
 
 /* ============================================================ */
 
-void
-menus_add_plugins (GnomeApp *app)
+void menus_add_plugins(GnomeApp *app)
 {
-	gtt_set_reports_menu (app, reports_menu);
+    gtt_set_reports_menu(app, reports_menu);
 }
 
-
-void
-menu_set_states(void)
+void menu_set_states(void)
 {
-	GtkCheckMenuItem *mi;
+    GtkCheckMenuItem *mi;
 
-	if (!menu_main_timer[MENU_TIMER_START_POS].widget) return;
-	gtk_widget_set_sensitive(menu_main_timer[MENU_TIMER_TOGGLE_POS].widget,
-				 1);
-	mi = GTK_CHECK_MENU_ITEM(menu_main_timer[MENU_TIMER_TOGGLE_POS].widget);
-	/* Can't call the 'set_active' directly, as that issues an
-	 * event which puts us in an infinite loop.  Instead,
-	 * just set the value.
-	 * gtk_check_menu_item_set_active (mi, timer_is_running());
-	 */
-	mi->active = timer_is_running();
+    if (!menu_main_timer[MENU_TIMER_START_POS].widget)
+        return;
+    gtk_widget_set_sensitive(menu_main_timer[MENU_TIMER_TOGGLE_POS].widget, 1);
+    mi = GTK_CHECK_MENU_ITEM(menu_main_timer[MENU_TIMER_TOGGLE_POS].widget);
+    /* Can't call the 'set_active' directly, as that issues an
+     * event which puts us in an infinite loop.  Instead,
+     * just set the value.
+     * gtk_check_menu_item_set_active (mi, timer_is_running());
+     */
+    mi->active = timer_is_running();
 
-	/* XXX would be nice to change this menu entry to say
-	 * 'timer stopped' when the timer is stopped.  But don't
-	 * know how to change the menu label in gtk */
+    /* XXX would be nice to change this menu entry to say
+     * 'timer stopped' when the timer is stopped.  But don't
+     * know how to change the menu label in gtk */
 
-	gtk_widget_set_sensitive(menu_main_timer[MENU_TIMER_START_POS].widget,
-				 (FALSE == timer_is_running()) );
-	gtk_widget_set_sensitive(menu_main_timer[MENU_TIMER_STOP_POS].widget,
-				 (timer_is_running()) );
-	gtk_widget_set_sensitive(menu_main_projects[MENU_PROJECTS_PASTE_POS].widget,
-				 (have_cutted_project()) );
+    gtk_widget_set_sensitive(
+        menu_main_timer[MENU_TIMER_START_POS].widget, (FALSE == timer_is_running())
+    );
+    gtk_widget_set_sensitive(menu_main_timer[MENU_TIMER_STOP_POS].widget, (timer_is_running()));
+    gtk_widget_set_sensitive(
+        menu_main_projects[MENU_PROJECTS_PASTE_POS].widget, (have_cutted_project())
+    );
 
-	if (menu_popup[MENU_POPUP_CUT_POS].widget)
-	{
-		gtk_widget_set_sensitive(menu_popup[MENU_POPUP_PASTE_POS].widget,
-				 (have_cutted_project()) );
-	}
+    if (menu_popup[MENU_POPUP_CUT_POS].widget)
+    {
+        gtk_widget_set_sensitive(
+            menu_popup[MENU_POPUP_PASTE_POS].widget, (have_cutted_project())
+        );
+    }
 }
 
 /* ======================= END OF FILE ===================== */
-

--- a/src/menus.h
+++ b/src/menus.h
@@ -23,16 +23,16 @@
 
 /* names of reports */
 #define ACTIVITY_REPORT "activity.ghtml"
-#define DAILY_REPORT    "daily.ghtml"
-#define INVOICE_REPORT  "invoice.ghtml"
-#define JOURNAL_REPORT  "journal.ghtml"
-#define PRIMER_REPORT   "primer.ghtml"
-#define QUERY_REPORT    "query.ghtml"
-#define STATUS_REPORT   "status.ghtml"
-#define TODO_REPORT     "todo.ghtml"
+#define DAILY_REPORT "daily.ghtml"
+#define INVOICE_REPORT "invoice.ghtml"
+#define JOURNAL_REPORT "journal.ghtml"
+#define PRIMER_REPORT "primer.ghtml"
+#define QUERY_REPORT "query.ghtml"
+#define STATUS_REPORT "status.ghtml"
+#define TODO_REPORT "todo.ghtml"
 
 #define TAB_DELIM_EXPORT "tab-delim.ghtml"
-#define TODO_EXPORT      "todo-export.ghtml"
+#define TODO_EXPORT "todo-export.ghtml"
 
 GtkMenuShell *menus_get_popup(void);
 void menus_create(GnomeApp *app);
@@ -41,14 +41,14 @@ void menus_set_states(void);
 void menus_add_plugins(GnomeApp *app);
 
 /** Return pointer to user-defined reports menu */
-GnomeUIInfo * gtt_get_reports_menu (void);
+GnomeUIInfo *gtt_get_reports_menu(void);
 
 /** Install the indicate user reports menu */
-void gtt_set_reports_menu (GnomeApp *app, GnomeUIInfo *new_menus);
+void gtt_set_reports_menu(GnomeApp *app, GnomeUIInfo *new_menus);
 
 /** Prepend the indicated user-defined report entry into the
  *   user-defined reports menu.
  */
-void gtt_reports_menu_prepend_entry (GnomeApp *app, GnomeUIInfo *new_entry);
+void gtt_reports_menu_prepend_entry(GnomeApp *app, GnomeUIInfo *new_entry);
 
 #endif /* __GTT_MENUS_H__ */

--- a/src/myoaf.c
+++ b/src/myoaf.c
@@ -5,9 +5,6 @@
    eliminated.
 */
 
-
-
-
 #include <gtk/gtk.h>
 #if 0
 #include <liboaf/liboaf.h>
@@ -16,10 +13,7 @@
 
 #include "myoaf.h"
 
-
-
-void
-edit_calendar(GtkWidget *w, gpointer data)
+void edit_calendar(GtkWidget *w, gpointer data)
 {
 
 #if 0
@@ -94,5 +88,3 @@ srv->location_info, srv->hostname);
 printf ("duude query = %p item=%p\n", sl, cal);
 #endif
 }
-
-

--- a/src/myoaf.h
+++ b/src/myoaf.h
@@ -2,6 +2,4 @@
 
 #include <gtk/gtk.h>
 
-
-void edit_calendar (GtkWidget *, gpointer);
-
+void edit_calendar(GtkWidget *, gpointer);

--- a/src/notes-area.c
+++ b/src/notes-area.c
@@ -22,173 +22,168 @@
 #include <glade/glade.h>
 #include <gnome.h>
 
+#include "menus.h"
+#include "notes-area.h"
 #include "proj.h"
 #include "props-task.h"
-#include "notes-area.h"
 #include "util.h"
-#include "menus.h"
 
 struct NotesArea_s
 {
-	GladeXML *gtxml;
-	GtkPaned *vpane;   /* top level pane */
-	GtkContainer *projects_tree_holder;   /* scrolled widget that holds the projects tree */
+    GladeXML *gtxml;
+    GtkPaned *vpane;                    /* top level pane */
+    GtkContainer *projects_tree_holder; /* scrolled widget that holds the projects tree */
 
-	GtkPaned *hpane;   /* left-right divider */
+    GtkPaned *hpane; /* left-right divider */
 
-	GtkEntry *proj_title;
-	GtkEntry *proj_desc;
-	GtkTextView *proj_notes;
+    GtkEntry *proj_title;
+    GtkEntry *proj_desc;
+    GtkTextView *proj_notes;
 
-	GtkComboBox *task_combo;
-	GtkTextView *task_notes;
+    GtkComboBox *task_combo;
+    GtkTextView *task_notes;
 
-	GtkButton *close_proj;
-	GtkButton *close_task;
-	GtkButton *new_task;
-	GtkButton *edit_task;
+    GtkButton *close_proj;
+    GtkButton *close_task;
+    GtkButton *new_task;
+    GtkButton *edit_task;
 
-	GttProject *proj;
+    GttProject *proj;
 
-	/* The goal of 'ignore events' is to prevent an inifinite
-	 * loop of cascading events as we modify the project and the GUI.
-	 */
-	gboolean ignore_events;
+    /* The goal of 'ignore events' is to prevent an inifinite
+     * loop of cascading events as we modify the project and the GUI.
+     */
+    gboolean ignore_events;
 
-	/* The goal of the freezes is to prevent more than one update
-	 * of windows per second.  The problem is that without this,
-	 * there would be one event per keystroke, which could cause
-	 * a redraw of e.g. the journal window.  In such a case, even
-	 * moderate typists on a slow CPU could saturate the CPU entirely.
-	 */
-	gboolean proj_freeze;
-	GttTask * task_freeze;
+    /* The goal of the freezes is to prevent more than one update
+     * of windows per second.  The problem is that without this,
+     * there would be one event per keystroke, which could cause
+     * a redraw of e.g. the journal window.  In such a case, even
+     * moderate typists on a slow CPU could saturate the CPU entirely.
+     */
+    gboolean proj_freeze;
+    GttTask *task_freeze;
 };
-
 
 /* ============================================================== */
 
-#define TSK_SETUP                               \
-	GttTask *tsk;                                \
-	const char * str;                            \
-	if (NULL == na->proj) return;                \
-	if (na->ignore_events) return;               \
-	                                             \
-	na->ignore_events = TRUE;                    \
-	tsk = gtt_project_get_current_task (na->proj); \
-	if (NULL == tsk)                             \
-	{                                            \
-		tsk = gtt_task_new();                     \
-		gtt_project_prepend_task (na->proj, tsk); \
-	}                                            \
-	if (tsk != na->task_freeze)                  \
-	{                                            \
-		/* Try to avoid race condition if another task */  \
-		/* is created while this task is frozen. */        \
-		if (NULL != na->task_freeze) gtt_task_thaw (na->task_freeze); \
-		na->task_freeze = tsk;                    \
-	}                                            \
-
+#define TSK_SETUP                                         \
+    GttTask *tsk;                                         \
+    const char *str;                                      \
+    if (NULL == na->proj)                                 \
+        return;                                           \
+    if (na->ignore_events)                                \
+        return;                                           \
+                                                          \
+    na->ignore_events = TRUE;                             \
+    tsk = gtt_project_get_current_task(na->proj);         \
+    if (NULL == tsk)                                      \
+    {                                                     \
+        tsk = gtt_task_new();                             \
+        gtt_project_prepend_task(na->proj, tsk);          \
+    }                                                     \
+    if (tsk != na->task_freeze)                           \
+    {                                                     \
+        /* Try to avoid race condition if another task */ \
+        /* is created while this task is frozen. */       \
+        if (NULL != na->task_freeze)                      \
+            gtt_task_thaw(na->task_freeze);               \
+        na->task_freeze = tsk;                            \
+    }
 
 #ifdef UNUSED_CODE_RIGHT_NOW
-static void
-task_memo_changed (GtkEntry *entry, NotesArea *na)
+static void task_memo_changed(GtkEntry *entry, NotesArea *na)
 {
-	TSK_SETUP;
-	str = gtk_entry_get_text (entry);
-	gtt_task_set_memo (tsk, str);
-	na->ignore_events = FALSE;
+    TSK_SETUP;
+    str = gtk_entry_get_text(entry);
+    gtt_task_set_memo(tsk, str);
+    na->ignore_events = FALSE;
 }
 #endif /* UNUSED_CODE_RIGHT_NOW */
 
 /* ============================================================== */
 
-static void
-task_notes_changed (GtkTextBuffer *entry, NotesArea *na)
+static void task_notes_changed(GtkTextBuffer *entry, NotesArea *na)
 {
-	TSK_SETUP;
-	str = xxxgtk_textview_get_text (na->task_notes);
-	gtt_task_set_notes (tsk, str);
-	na->ignore_events = FALSE;
+    TSK_SETUP;
+    str = xxxgtk_textview_get_text(na->task_notes);
+    gtt_task_set_notes(tsk, str);
+    na->ignore_events = FALSE;
 }
 
 /* ============================================================== */
 
-#define PRJ_SETUP                        \
-	const char * str;                     \
-	if (NULL == na->proj) return;         \
-	if (na->ignore_events) return;        \
-	                                      \
-	if (FALSE == na->proj_freeze)         \
-	{                                     \
-		na->proj_freeze = TRUE;            \
-	}                                     \
-	na->ignore_events = TRUE;             \
+#define PRJ_SETUP                 \
+    const char *str;              \
+    if (NULL == na->proj)         \
+        return;                   \
+    if (na->ignore_events)        \
+        return;                   \
+                                  \
+    if (FALSE == na->proj_freeze) \
+    {                             \
+        na->proj_freeze = TRUE;   \
+    }                             \
+    na->ignore_events = TRUE;
 
-
-static void
-proj_title_changed (GtkEntry *entry, NotesArea *na)
+static void proj_title_changed(GtkEntry *entry, NotesArea *na)
 {
-	PRJ_SETUP
-	str = gtk_entry_get_text (entry);
-	gtt_project_set_title (na->proj, str);
-	na->ignore_events = FALSE;
-}
-
-
-/* ============================================================== */
-
-static void
-proj_desc_changed (GtkEntry *entry, NotesArea *na)
-{
-	PRJ_SETUP
-	str = gtk_entry_get_text (entry);
-	gtt_project_set_desc (na->proj, str);
-	na->ignore_events = FALSE;
-}
-
-/* ============================================================== */
-static GttTask *
-tasks_model_get_task (GtkTreeModel *model, GtkTreeIter *iter)
-{
-
-	GValue v = {G_TYPE_INVALID};
-	gtk_tree_model_get_value (model, iter, 1, &v);
-	GttTask *task = (GttTask *) g_value_get_pointer (&v);
-	g_value_unset (&v);
-	return task;
+    PRJ_SETUP
+    str = gtk_entry_get_text(entry);
+    gtt_project_set_title(na->proj, str);
+    na->ignore_events = FALSE;
 }
 
 /* ============================================================== */
 
-static void
-proj_notes_changed (GtkTextBuffer *entry, NotesArea *na)
+static void proj_desc_changed(GtkEntry *entry, NotesArea *na)
 {
-	PRJ_SETUP
-	str = xxxgtk_textview_get_text (na->proj_notes);
-	gtt_project_set_notes (na->proj, str);
-	na->ignore_events = FALSE;
+    PRJ_SETUP
+    str = gtk_entry_get_text(entry);
+    gtt_project_set_desc(na->proj, str);
+    na->ignore_events = FALSE;
+}
+
+/* ============================================================== */
+static GttTask *tasks_model_get_task(GtkTreeModel *model, GtkTreeIter *iter)
+{
+
+    GValue v = { G_TYPE_INVALID };
+    gtk_tree_model_get_value(model, iter, 1, &v);
+    GttTask *task = (GttTask *) g_value_get_pointer(&v);
+    g_value_unset(&v);
+    return task;
+}
+
+/* ============================================================== */
+
+static void proj_notes_changed(GtkTextBuffer *entry, NotesArea *na)
+{
+    PRJ_SETUP
+    str = xxxgtk_textview_get_text(na->proj_notes);
+    gtt_project_set_notes(na->proj, str);
+    na->ignore_events = FALSE;
 }
 
 /* ============================================================== */
 /* This routine will cause pending events to get delivered. */
 
-void
-gtt_notes_timer_callback (NotesArea *na)
+void gtt_notes_timer_callback(NotesArea *na)
 {
-	if (!na) return;
-	na->ignore_events = TRUE;
-	if (na->task_freeze)
-	{
-		gtt_task_thaw (na->task_freeze);
-		na->task_freeze = NULL;
-	}
-	if (na->proj_freeze)
-	{
-		na->proj_freeze = FALSE;
-		gtt_project_thaw (na->proj);
-	}
-	na->ignore_events = FALSE;
+    if (!na)
+        return;
+    na->ignore_events = TRUE;
+    if (na->task_freeze)
+    {
+        gtt_task_thaw(na->task_freeze);
+        na->task_freeze = NULL;
+    }
+    if (na->proj_freeze)
+    {
+        na->proj_freeze = FALSE;
+        gtt_project_thaw(na->proj);
+    }
+    na->ignore_events = FALSE;
 }
 
 /* ============================================================== */
@@ -199,250 +194,234 @@ gtt_notes_timer_callback (NotesArea *na)
 
 #define CLOSED_MARGIN 10
 
-static void
-close_proj_area (GtkButton *but, NotesArea *na)
+static void close_proj_area(GtkButton *but, NotesArea *na)
 {
-	int hpane_width;
-	int hpane_div;
+    int hpane_width;
+    int hpane_div;
 
-	hpane_width = GTK_WIDGET(na->hpane)->allocation.width;
-	hpane_div = gtk_paned_get_position (na->hpane);
+    hpane_width = GTK_WIDGET(na->hpane)->allocation.width;
+    hpane_div = gtk_paned_get_position(na->hpane);
 
-	if (hpane_div > hpane_width -CLOSED_MARGIN)
-	{
-		int vpane_height;
-		vpane_height = GTK_WIDGET(na->vpane)->allocation.height;
-		gtk_paned_set_position (na->vpane, vpane_height);
-	}
-	else
-	{
-		gtk_paned_set_position (na->hpane, 0);
-	}
+    if (hpane_div > hpane_width - CLOSED_MARGIN)
+    {
+        int vpane_height;
+        vpane_height = GTK_WIDGET(na->vpane)->allocation.height;
+        gtk_paned_set_position(na->vpane, vpane_height);
+    }
+    else
+    {
+        gtk_paned_set_position(na->hpane, 0);
+    }
 }
 
-static void
-close_task_area (GtkButton *but, NotesArea *na)
+static void close_task_area(GtkButton *but, NotesArea *na)
 {
-	int hpane_width;
-	int hpane_div;
+    int hpane_width;
+    int hpane_div;
 
-	hpane_width = GTK_WIDGET(na->hpane)->allocation.width;
-	hpane_div = gtk_paned_get_position (na->hpane);
+    hpane_width = GTK_WIDGET(na->hpane)->allocation.width;
+    hpane_div = gtk_paned_get_position(na->hpane);
 
-	/* XXX we really need only the first test, but the second
-	 * one deals iwth a freaky gtk vpaned bug that makes this
-	 * hidden button active.  Whatever.
-	 */
-	if ((hpane_div < CLOSED_MARGIN) ||
-	    (hpane_div > hpane_width -CLOSED_MARGIN))
-	{
-		int vpane_height;
-		vpane_height = GTK_WIDGET(na->vpane)->allocation.height;
-		gtk_paned_set_position (na->vpane, vpane_height);
-	}
-	else
-	{
-		gtk_paned_set_position (na->hpane, hpane_width);
-	}
+    /* XXX we really need only the first test, but the second
+     * one deals iwth a freaky gtk vpaned bug that makes this
+     * hidden button active.  Whatever.
+     */
+    if ((hpane_div < CLOSED_MARGIN) || (hpane_div > hpane_width - CLOSED_MARGIN))
+    {
+        int vpane_height;
+        vpane_height = GTK_WIDGET(na->vpane)->allocation.height;
+        gtk_paned_set_position(na->vpane, vpane_height);
+    }
+    else
+    {
+        gtk_paned_set_position(na->hpane, hpane_width);
+    }
 }
 
 /* ============================================================== */
 
-static void
-new_task_cb (GtkButton *but, NotesArea *na)
+static void new_task_cb(GtkButton *but, NotesArea *na)
 {
-	GttTask *tsk;
-	if (NULL == na->proj) return;
-	// if (na->ignore_events) return;
+    GttTask *tsk;
+    if (NULL == na->proj)
+        return;
+    // if (na->ignore_events) return;
 
-	// na->ignore_events = TRUE;
-	tsk = gtt_task_new();
-	gtt_project_prepend_task (na->proj, tsk);
-	prop_task_dialog_show (tsk);
-	if (NULL != na->task_freeze) gtt_task_thaw (na->task_freeze);
-	gtt_task_freeze (tsk);
-	na->task_freeze = tsk;
+    // na->ignore_events = TRUE;
+    tsk = gtt_task_new();
+    gtt_project_prepend_task(na->proj, tsk);
+    prop_task_dialog_show(tsk);
+    if (NULL != na->task_freeze)
+        gtt_task_thaw(na->task_freeze);
+    gtt_task_freeze(tsk);
+    na->task_freeze = tsk;
 
-	// na->ignore_events = FALSE;
+    // na->ignore_events = FALSE;
 }
 
 /* ============================================================== */
-static void
-edit_task_cb (GtkButton *but, NotesArea *na)
+static void edit_task_cb(GtkButton *but, NotesArea *na)
 {
-	if (NULL == na->proj) return;
-	GttTask *tsk = gtt_project_get_current_task (na->proj);
-	prop_task_dialog_show (tsk);
-	if (NULL != na->task_freeze) gtt_task_thaw (na->task_freeze);
-	gtt_task_freeze (tsk);
-	na->task_freeze = tsk;
+    if (NULL == na->proj)
+        return;
+    GttTask *tsk = gtt_project_get_current_task(na->proj);
+    prop_task_dialog_show(tsk);
+    if (NULL != na->task_freeze)
+        gtt_task_thaw(na->task_freeze);
+    gtt_task_freeze(tsk);
+    na->task_freeze = tsk;
 }
 
 /* ============================================================== */
-static void
-task_selected_cb (GtkComboBox *combo, gpointer dialog)
+static void task_selected_cb(GtkComboBox *combo, gpointer dialog)
 {
-	GtkTreeIter iter;
-	GtkTreeModel *model = gtk_combo_box_get_model (combo);
-	NotesArea *na = (NotesArea *) dialog;
+    GtkTreeIter iter;
+    GtkTreeModel *model = gtk_combo_box_get_model(combo);
+    NotesArea *na = (NotesArea *) dialog;
 
-	na->ignore_events = TRUE;
+    na->ignore_events = TRUE;
 
-	gtk_combo_box_get_active_iter (combo, &iter);
-	GttTask *task = tasks_model_get_task (model, &iter);
-	GttProject *project = gtt_task_get_parent (task);
+    gtk_combo_box_get_active_iter(combo, &iter);
+    GttTask *task = tasks_model_get_task(model, &iter);
+    GttProject *project = gtt_task_get_parent(task);
 
-	gtt_project_set_current_task (project, task);
+    gtt_project_set_current_task(project, task);
 
-	const char *str = gtt_task_get_notes (task);
-	if (!str) str = "";
-	xxxgtk_textview_set_text (na->task_notes, str);
+    const char *str = gtt_task_get_notes(task);
+    if (!str)
+        str = "";
+    xxxgtk_textview_set_text(na->task_notes, str);
 
-	na->ignore_events = FALSE;
+    na->ignore_events = FALSE;
 }
 
 /* ============================================================== */
 
-enum {
-	COL_ID,
-	COL_TASK_MEMO,
-	COL_TASK_POINTER,
-	NUM_COLS
+enum
+{
+    COL_ID,
+    COL_TASK_MEMO,
+    COL_TASK_POINTER,
+    NUM_COLS
 };
 
-
 /* ============================================================== */
 
-#define CONNECT_ENTRY(GLADE_NAME,CB)  ({                           \
-	GtkEntry * entry;                                               \
-	entry = GTK_ENTRY(glade_xml_get_widget (gtxml, GLADE_NAME));    \
-	g_signal_connect (G_OBJECT (entry), "changed",                  \
-	                G_CALLBACK (CB), dlg);                          \
-	entry; })
+#define CONNECT_ENTRY(GLADE_NAME, CB)                                      \
+    ({                                                                     \
+        GtkEntry *entry;                                                   \
+        entry = GTK_ENTRY(glade_xml_get_widget(gtxml, GLADE_NAME));        \
+        g_signal_connect(G_OBJECT(entry), "changed", G_CALLBACK(CB), dlg); \
+        entry;                                                             \
+    })
 
-#define CONNECT_TEXT(GLADE_NAME,CB)  ({                            \
-	GtkTextView *tv;                                                \
-	GtkTextBuffer *buff;                                            \
-	tv = GTK_TEXT_VIEW(glade_xml_get_widget (gtxml, GLADE_NAME));   \
-	buff = gtk_text_view_get_buffer (tv);                           \
-	g_signal_connect (G_OBJECT (buff), "changed",                   \
-	                G_CALLBACK (CB), dlg);                          \
-	tv; })
+#define CONNECT_TEXT(GLADE_NAME, CB)                                      \
+    ({                                                                    \
+        GtkTextView *tv;                                                  \
+        GtkTextBuffer *buff;                                              \
+        tv = GTK_TEXT_VIEW(glade_xml_get_widget(gtxml, GLADE_NAME));      \
+        buff = gtk_text_view_get_buffer(tv);                              \
+        g_signal_connect(G_OBJECT(buff), "changed", G_CALLBACK(CB), dlg); \
+        tv;                                                               \
+    })
 
-
-NotesArea *
-notes_area_new (void)
+NotesArea *notes_area_new(void)
 {
-	NotesArea *dlg;
-	GladeXML *gtxml;
+    NotesArea *dlg;
+    GladeXML *gtxml;
 
-	dlg = g_new0 (NotesArea, 1);
+    dlg = g_new0(NotesArea, 1);
 
-	gtxml = gtt_glade_xml_new ("glade/notes.glade", "top window");
-	dlg->gtxml = gtxml;
-	
-	dlg->vpane = GTK_PANED(glade_xml_get_widget (gtxml, "notes vpane"));
-	dlg->projects_tree_holder = GTK_CONTAINER(glade_xml_get_widget (gtxml, "ctree holder"));
-	dlg->hpane = GTK_PANED(glade_xml_get_widget (gtxml, "leftright hpane"));
-	dlg->close_proj = GTK_BUTTON(glade_xml_get_widget (gtxml, "close proj button"));
-	dlg->close_task = GTK_BUTTON(glade_xml_get_widget (gtxml, "close diary button"));
-	dlg->new_task = GTK_BUTTON(glade_xml_get_widget (gtxml, "new_diary_entry_button"));
-	dlg->edit_task = GTK_BUTTON(glade_xml_get_widget (gtxml, "edit_diary_entry_button"));
-	
-	dlg->proj_title = CONNECT_ENTRY ("proj title entry", proj_title_changed);
-	dlg->proj_desc = CONNECT_ENTRY ("proj desc entry", proj_desc_changed);
-	dlg->task_combo = GTK_COMBO_BOX (glade_xml_get_widget (gtxml, "diary_entry_combo"));
+    gtxml = gtt_glade_xml_new("glade/notes.glade", "top window");
+    dlg->gtxml = gtxml;
 
-	gtk_combo_box_set_model (dlg->task_combo, NULL);
-	GtkCellRenderer *cell;
-	cell = gtk_cell_renderer_text_new();
-	gtk_cell_layout_pack_start(GTK_CELL_LAYOUT(dlg->task_combo), cell, TRUE);
-	gtk_cell_layout_set_attributes(GTK_CELL_LAYOUT (dlg->task_combo), cell, "text", 0, NULL);
-	g_object_set (cell, "ellipsize", PANGO_ELLIPSIZE_END, NULL);
+    dlg->vpane = GTK_PANED(glade_xml_get_widget(gtxml, "notes vpane"));
+    dlg->projects_tree_holder = GTK_CONTAINER(glade_xml_get_widget(gtxml, "ctree holder"));
+    dlg->hpane = GTK_PANED(glade_xml_get_widget(gtxml, "leftright hpane"));
+    dlg->close_proj = GTK_BUTTON(glade_xml_get_widget(gtxml, "close proj button"));
+    dlg->close_task = GTK_BUTTON(glade_xml_get_widget(gtxml, "close diary button"));
+    dlg->new_task = GTK_BUTTON(glade_xml_get_widget(gtxml, "new_diary_entry_button"));
+    dlg->edit_task = GTK_BUTTON(glade_xml_get_widget(gtxml, "edit_diary_entry_button"));
 
-	dlg->proj_notes = CONNECT_TEXT ("proj notes textview", proj_notes_changed);
-	dlg->task_notes = CONNECT_TEXT ("diary notes textview", task_notes_changed);
+    dlg->proj_title = CONNECT_ENTRY("proj title entry", proj_title_changed);
+    dlg->proj_desc = CONNECT_ENTRY("proj desc entry", proj_desc_changed);
+    dlg->task_combo = GTK_COMBO_BOX(glade_xml_get_widget(gtxml, "diary_entry_combo"));
 
-	g_signal_connect (G_OBJECT (dlg->close_proj), "clicked",
-					  G_CALLBACK (close_proj_area), dlg);
+    gtk_combo_box_set_model(dlg->task_combo, NULL);
+    GtkCellRenderer *cell;
+    cell = gtk_cell_renderer_text_new();
+    gtk_cell_layout_pack_start(GTK_CELL_LAYOUT(dlg->task_combo), cell, TRUE);
+    gtk_cell_layout_set_attributes(GTK_CELL_LAYOUT(dlg->task_combo), cell, "text", 0, NULL);
+    g_object_set(cell, "ellipsize", PANGO_ELLIPSIZE_END, NULL);
 
-	g_signal_connect (G_OBJECT (dlg->close_task), "clicked",
-					  G_CALLBACK (close_task_area), dlg);
+    dlg->proj_notes = CONNECT_TEXT("proj notes textview", proj_notes_changed);
+    dlg->task_notes = CONNECT_TEXT("diary notes textview", task_notes_changed);
 
-	g_signal_connect (G_OBJECT (dlg->new_task), "clicked",
-					  G_CALLBACK (new_task_cb), dlg);
+    g_signal_connect(G_OBJECT(dlg->close_proj), "clicked", G_CALLBACK(close_proj_area), dlg);
 
-	g_signal_connect (G_OBJECT (dlg->edit_task), "clicked",
-					  G_CALLBACK (edit_task_cb), dlg);
+    g_signal_connect(G_OBJECT(dlg->close_task), "clicked", G_CALLBACK(close_task_area), dlg);
 
-	g_signal_connect (G_OBJECT (dlg->task_combo), "changed",
-					  G_CALLBACK(task_selected_cb), dlg);
+    g_signal_connect(G_OBJECT(dlg->new_task), "clicked", G_CALLBACK(new_task_cb), dlg);
 
-	gtk_widget_show (GTK_WIDGET(dlg->vpane));
+    g_signal_connect(G_OBJECT(dlg->edit_task), "clicked", G_CALLBACK(edit_task_cb), dlg);
 
-	dlg->proj = NULL;
-	dlg->ignore_events = FALSE;
-	dlg->proj_freeze = FALSE;
-	dlg->task_freeze = NULL;
+    g_signal_connect(G_OBJECT(dlg->task_combo), "changed", G_CALLBACK(task_selected_cb), dlg);
 
-	return dlg;
+    gtk_widget_show(GTK_WIDGET(dlg->vpane));
+
+    dlg->proj = NULL;
+    dlg->ignore_events = FALSE;
+    dlg->proj_freeze = FALSE;
+    dlg->task_freeze = NULL;
+
+    return dlg;
 }
 
-
-static void
-notes_area_choose_task (NotesArea *na, GttTask *task)
+static void notes_area_choose_task(NotesArea *na, GttTask *task)
 {
 
-	GtkTreeIter iter;
-	GtkTreeModel *model = gtk_combo_box_get_model (na->task_combo);
+    GtkTreeIter iter;
+    GtkTreeModel *model = gtk_combo_box_get_model(na->task_combo);
 
-	if (gtk_tree_model_get_iter_first (model, &iter))
-	{
-		do
-		{
-			GttTask *t = tasks_model_get_task (model, &iter);
+    if (gtk_tree_model_get_iter_first(model, &iter))
+    {
+        do
+        {
+            GttTask *t = tasks_model_get_task(model, &iter);
 
-			if (task == t)
-			{
-				gtk_combo_box_set_active_iter (na->task_combo, &iter);
-				break;
-			}
-		} while (gtk_tree_model_iter_next (model, &iter));
-	}
-	else
-	{
-		g_warning ("Trying to select task with empty tree model\n");
-	}
+            if (task == t)
+            {
+                gtk_combo_box_set_active_iter(na->task_combo, &iter);
+                break;
+            }
+        }
+        while (gtk_tree_model_iter_next(model, &iter));
+    }
+    else
+    {
+        g_warning("Trying to select task with empty tree model\n");
+    }
 }
 
 /* ============================================================== */
-void
-combo_model_add_task (gpointer task_p, gpointer model_p)
+void combo_model_add_task(gpointer task_p, gpointer model_p)
 {
-	GttTask *task = (GttTask *) task_p;
-	GtkListStore *model = GTK_LIST_STORE (model_p);
-	GtkTreeIter iter;
+    GttTask *task = (GttTask *) task_p;
+    GtkListStore *model = GTK_LIST_STORE(model_p);
+    GtkTreeIter iter;
 
-	gtk_list_store_append (model, &iter);
+    gtk_list_store_append(model, &iter);
 
-	gtk_list_store_set (model, &iter,
-						0, gtt_task_get_memo (task),
-						1, task,
-						-1);
+    gtk_list_store_set(model, &iter, 0, gtt_task_get_memo(task), 1, task, -1);
 }
 
 /* ============================================================== */
-static GtkTreeModel *
-build_task_combo_model (GttProject *proj)
+static GtkTreeModel *build_task_combo_model(GttProject *proj)
 {
-	GtkTreeModel *model = GTK_TREE_MODEL (gtk_list_store_new (2,
-															  G_TYPE_STRING,
-															  G_TYPE_POINTER));
+    GtkTreeModel *model = GTK_TREE_MODEL(gtk_list_store_new(2, G_TYPE_STRING, G_TYPE_POINTER));
 
-	g_list_foreach(gtt_project_get_tasks (proj),
-				   combo_model_add_task,
-				   model);
-	return model;
+    g_list_foreach(gtt_project_get_tasks(proj), combo_model_add_task, model);
+    return model;
 }
 
 /* ============================================================== */
@@ -450,148 +429,152 @@ build_task_combo_model (GttProject *proj)
  * into the GUI.
  */
 
-static void
-notes_area_do_set_project (NotesArea *na, GttProject *proj)
+static void notes_area_do_set_project(NotesArea *na, GttProject *proj)
 {
-	const char * str;
-	GttTask *tsk;
+    const char *str;
+    GttTask *tsk;
 
-	if (!na) return;
-	if (na->ignore_events) return;
+    if (!na)
+        return;
+    if (na->ignore_events)
+        return;
 
-	/* Calling gtk_entry_set_text makes 'changed' events happen,
-	 * which causes us to get the entry text, which exposes a gtk
-	 * bug.  So we work around the bug and save cpu time by ignoring
-	 * change events during a mass update. */
-	na->ignore_events = TRUE;
+    /* Calling gtk_entry_set_text makes 'changed' events happen,
+     * which causes us to get the entry text, which exposes a gtk
+     * bug.  So we work around the bug and save cpu time by ignoring
+     * change events during a mass update. */
+    na->ignore_events = TRUE;
 
-	/* Note Bene its OK to have the proj be null: this has the
-	 * effect of clearing all the fields out.
-	 */
-	na->proj = proj;
+    /* Note Bene its OK to have the proj be null: this has the
+     * effect of clearing all the fields out.
+     */
+    na->proj = proj;
 
-	/* Fetch data from the data engine, stuff it into the GUI. */
-	str = gtt_project_get_title (proj);
-	if (!str) str = "";
-	gtk_entry_set_text (na->proj_title, str);
+    /* Fetch data from the data engine, stuff it into the GUI. */
+    str = gtt_project_get_title(proj);
+    if (!str)
+        str = "";
+    gtk_entry_set_text(na->proj_title, str);
 
-	str = gtt_project_get_desc (proj);
-	if (!str) str = "";
-	gtk_entry_set_text (na->proj_desc, str);
+    str = gtt_project_get_desc(proj);
+    if (!str)
+        str = "";
+    gtk_entry_set_text(na->proj_desc, str);
 
-	str = gtt_project_get_notes (proj);
-	if (!str) str = "";
-	xxxgtk_textview_set_text (na->proj_notes, str);
+    str = gtt_project_get_notes(proj);
+    if (!str)
+        str = "";
+    xxxgtk_textview_set_text(na->proj_notes, str);
 
-	GtkTreeModel *model = build_task_combo_model (proj);
-	gtk_combo_box_set_model (na->task_combo, model);
-	g_object_unref (model);
+    GtkTreeModel *model = build_task_combo_model(proj);
+    gtk_combo_box_set_model(na->task_combo, model);
+    g_object_unref(model);
 
-	tsk = gtt_project_get_current_task (proj);
-	if (tsk == NULL)
-		tsk = gtt_project_get_first_task (proj);
+    tsk = gtt_project_get_current_task(proj);
+    if (tsk == NULL)
+        tsk = gtt_project_get_first_task(proj);
 
-	notes_area_choose_task (na, tsk);
+    notes_area_choose_task(na, tsk);
 
-	na->ignore_events = FALSE;
+    na->ignore_events = FALSE;
 }
 
 /* ============================================================== */
 
-static void
-redraw (GttProject *prj, gpointer data)
+static void redraw(GttProject *prj, gpointer data)
 {
-	NotesArea *na = data;
-	if (na->ignore_events) return;
-	notes_area_do_set_project (na, prj);
+    NotesArea *na = data;
+    if (na->ignore_events)
+        return;
+    notes_area_do_set_project(na, prj);
 }
 
 /* ============================================================== */
 
-void
-notes_area_set_project (NotesArea *na, GttProject *proj)
+void notes_area_set_project(NotesArea *na, GttProject *proj)
 {
-	if (na->proj != NULL) {
-		gtt_project_remove_notifier (na->proj, redraw, na);
-		na->proj = NULL;
-	}
-	if (proj != NULL) {
-		gtt_project_add_notifier (proj, redraw, na);
-	}
+    if (na->proj != NULL)
+    {
+        gtt_project_remove_notifier(na->proj, redraw, na);
+        na->proj = NULL;
+    }
+    if (proj != NULL)
+    {
+        gtt_project_add_notifier(proj, redraw, na);
+    }
 
-	notes_area_do_set_project (na, proj);
+    notes_area_do_set_project(na, proj);
 }
 
 /* ============================================================== */
 
-GtkWidget *
-notes_area_get_widget (NotesArea *nadlg)
+GtkWidget *notes_area_get_widget(NotesArea *nadlg)
 {
-	if (!nadlg) return NULL;
-	return GTK_WIDGET(nadlg->vpane);
+    if (!nadlg)
+        return NULL;
+    return GTK_WIDGET(nadlg->vpane);
 }
 
-static void
-projects_tree_selection_changed (GtkTreeSelection *selection, gpointer user_data)
+static void projects_tree_selection_changed(GtkTreeSelection *selection, gpointer user_data)
 {
-	NotesArea *nadlg = (NotesArea *) user_data;
-	GttProjectsTree *gpt = GTT_PROJECTS_TREE (gtk_tree_selection_get_tree_view (selection));
-	GttProject *prj = gtt_projects_tree_get_selected_project (gpt);
+    NotesArea *nadlg = (NotesArea *) user_data;
+    GttProjectsTree *gpt = GTT_PROJECTS_TREE(gtk_tree_selection_get_tree_view(selection));
+    GttProject *prj = gtt_projects_tree_get_selected_project(gpt);
 
-	notes_area_set_project (nadlg, prj);
-
+    notes_area_set_project(nadlg, prj);
 }
 
-static int
-projects_tree_clicked (GtkWidget *ptree, GdkEvent *event, gpointer data)
+static int projects_tree_clicked(GtkWidget *ptree, GdkEvent *event, gpointer data)
 {
-	GdkEventButton *bevent = (GdkEventButton *) event;
-	// GttProjectsTree *projects_tree = GTT_PROJECTS_TREE (ptree);
-	GtkMenuShell *menu;
+    GdkEventButton *bevent = (GdkEventButton *) event;
+    // GttProjectsTree *projects_tree = GTT_PROJECTS_TREE (ptree);
+    GtkMenuShell *menu;
 
-	if (!(event->type == GDK_BUTTON_PRESS && bevent->button == 3))
-	{
-		return FALSE;
-	}
+    if (!(event->type == GDK_BUTTON_PRESS && bevent->button == 3))
+    {
+        return FALSE;
+    }
 
-	menu = menus_get_popup ();
-	gtk_menu_popup (GTK_MENU (menu), NULL, NULL, NULL, NULL, 3, bevent->time);
+    menu = menus_get_popup();
+    gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL, 3, bevent->time);
 
-	return FALSE;
-
+    return FALSE;
 }
 
-void
-notes_area_add_projects_tree (NotesArea *nadlg, GttProjectsTree *ptree)
+void notes_area_add_projects_tree(NotesArea *nadlg, GttProjectsTree *ptree)
 {
-	if (!nadlg) return;
+    if (!nadlg)
+        return;
 
-	GtkTreeSelection *tree_selection = gtk_tree_view_get_selection (GTK_TREE_VIEW (ptree));
-	g_signal_connect (tree_selection, "changed", G_CALLBACK (projects_tree_selection_changed), nadlg);
+    GtkTreeSelection *tree_selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(ptree));
+    g_signal_connect(
+        tree_selection, "changed", G_CALLBACK(projects_tree_selection_changed), nadlg
+    );
 
-	gtk_container_add (nadlg->projects_tree_holder, GTK_WIDGET(ptree));
-	gtk_widget_show_all (GTK_WIDGET(nadlg->projects_tree_holder));
+    gtk_container_add(nadlg->projects_tree_holder, GTK_WIDGET(ptree));
+    gtk_widget_show_all(GTK_WIDGET(nadlg->projects_tree_holder));
 
-	g_signal_connect (GTK_WIDGET (ptree), "button_press_event",
-			  G_CALLBACK (projects_tree_clicked), NULL);
+    g_signal_connect(
+        GTK_WIDGET(ptree), "button_press_event", G_CALLBACK(projects_tree_clicked), NULL
+    );
 }
 
-
-void
-notes_area_get_pane_sizes (NotesArea *na, int *vp, int *hp)
+void notes_area_get_pane_sizes(NotesArea *na, int *vp, int *hp)
 {
-	if (!na) return;
-	if(vp) *vp = gtk_paned_get_position (na->vpane);
-	if(hp) *hp = gtk_paned_get_position (na->hpane);
+    if (!na)
+        return;
+    if (vp)
+        *vp = gtk_paned_get_position(na->vpane);
+    if (hp)
+        *hp = gtk_paned_get_position(na->hpane);
 }
 
-void
-notes_area_set_pane_sizes (NotesArea *na, int vp, int hp)
+void notes_area_set_pane_sizes(NotesArea *na, int vp, int hp)
 {
-	if (!na) return;
-	gtk_paned_set_position (na->vpane, vp);
-	gtk_paned_set_position (na->hpane, hp);
+    if (!na)
+        return;
+    gtk_paned_set_position(na->vpane, vp);
+    gtk_paned_set_position(na->hpane, hp);
 }
 
 /* ========================= END OF FILE ======================== */
-

--- a/src/notes-area.h
+++ b/src/notes-area.h
@@ -19,35 +19,35 @@
 #ifndef GTT_NOTES_AREA_H
 #define GTT_NOTES_AREA_H
 
-#include <gnome.h>
 #include "projects-tree.h"
+#include <gnome.h>
 
 typedef struct NotesArea_s NotesArea;
 
-NotesArea * notes_area_new (void);
+NotesArea *notes_area_new(void);
 
 /* The notes_area_set_project() routine binds a project to the
  *    notes area.  That is, the notes area will display (and edit)
  *    the indicated project.
  */
-void notes_area_set_project (NotesArea *na, GttProject *proj);
+void notes_area_set_project(NotesArea *na, GttProject *proj);
 
 /* returns the vpaned widget at the top of the notes area heirarchy */
-GtkWidget * notes_area_get_widget (NotesArea *na);
+GtkWidget *notes_area_get_widget(NotesArea *na);
 
 /* add the GttProjectsTree widget to the appropriate location */
-void notes_area_add_projects_tree (NotesArea *na, GttProjectsTree *projects_tree);
+void notes_area_add_projects_tree(NotesArea *na, GttProjectsTree *projects_tree);
 
 /* Set the position of the two divideders in the notes area:
  * the vertical divider between the ctree and the notes,
  * and the horiz divider between the proj on left and diary on right
  */
-void notes_area_get_pane_sizes (NotesArea *na, int *vp, int *hp);
-void notes_area_set_pane_sizes (NotesArea *na, int vp, int hp);
+void notes_area_get_pane_sizes(NotesArea *na, int *vp, int *hp);
+void notes_area_set_pane_sizes(NotesArea *na, int vp, int hp);
 
 /* The gtt_notes_timer_callback() routine is a 'private' routine,
  * a timeout callback that is called by the timer.
  */
-void gtt_notes_timer_callback (NotesArea *na);
+void gtt_notes_timer_callback(NotesArea *na);
 
 #endif /* GTT_NOTES_AREA_H */

--- a/src/plug-edit.c
+++ b/src/plug-edit.c
@@ -23,171 +23,174 @@
 
 #include "app.h"
 #include "dialog.h"
-#include "journal.h"
 #include "gconf-io.h"
+#include "journal.h"
 #include "menus.h"
 #include "plug-in.h"
 #include "util.h"
 
 struct PluginEditorDialog_s
 {
-	GladeXML  *gtxml;
-	GtkDialog *dialog;
+    GladeXML *gtxml;
+    GtkDialog *dialog;
 
-	GtkTreeView *treeview;
-	GtkTreeStore *treestore;
-	GArray *menus;   /* array of GnomeUIInfo */
+    GtkTreeView *treeview;
+    GtkTreeStore *treestore;
+    GArray *menus; /* array of GnomeUIInfo */
 
-	GtkTreeSelection *selection;
-	gboolean have_selection;
-	GtkTreeIter curr_selection;
-	gboolean do_redraw;
-	
-	GtkEntry  *plugin_name;    /* AKA 'Label' */
-	GtkFileChooser  *plugin_path;
-	GtkEntry  *plugin_tooltip;
+    GtkTreeSelection *selection;
+    gboolean have_selection;
+    GtkTreeIter curr_selection;
+    gboolean do_redraw;
 
-	GnomeApp  *app;
+    GtkEntry *plugin_name; /* AKA 'Label' */
+    GtkFileChooser *plugin_path;
+    GtkEntry *plugin_tooltip;
+
+    GnomeApp *app;
 };
 
-#define NCOLUMNS   4
-#define PTRCOL    (NCOLUMNS-1)
+#define NCOLUMNS 4
+#define PTRCOL (NCOLUMNS - 1)
 
 /* ============================================================ */
 /* Redraw one row of the tree widget */
 
-static void
-edit_plugin_redraw_row (struct PluginEditorDialog_s *ped,
-					 GtkTreeIter *iter, GnomeUIInfo *uientry)
+static void edit_plugin_redraw_row(
+    struct PluginEditorDialog_s *ped, GtkTreeIter *iter, GnomeUIInfo *uientry
+)
 {
-	GttPlugin *plg;
-	GValue val = {G_TYPE_INVALID};
-	GValue pval = {G_TYPE_INVALID};
+    GttPlugin *plg;
+    GValue val = { G_TYPE_INVALID };
+    GValue pval = { G_TYPE_INVALID };
 
-	if (!uientry || !uientry->user_data) return;
-	plg = uientry->user_data;
+    if (!uientry || !uientry->user_data)
+        return;
+    plg = uientry->user_data;
 
-	g_value_init(&val, G_TYPE_STRING);
-	g_value_set_string (&val, plg->name);
-	gtk_tree_store_set_value (ped->treestore, iter, 0, &val);
-	
-	g_value_set_string (&val, plg->path);
-	gtk_tree_store_set_value (ped->treestore, iter, 1, &val);
-	
-	g_value_set_string (&val, plg->tooltip);
-	gtk_tree_store_set_value (ped->treestore, iter, 2, &val);
-	
-	g_value_init(&pval, G_TYPE_POINTER);
-	g_value_set_pointer (&pval, uientry);
-	gtk_tree_store_set_value (ped->treestore, iter, PTRCOL, &pval);
+    g_value_init(&val, G_TYPE_STRING);
+    g_value_set_string(&val, plg->name);
+    gtk_tree_store_set_value(ped->treestore, iter, 0, &val);
+
+    g_value_set_string(&val, plg->path);
+    gtk_tree_store_set_value(ped->treestore, iter, 1, &val);
+
+    g_value_set_string(&val, plg->tooltip);
+    gtk_tree_store_set_value(ped->treestore, iter, 2, &val);
+
+    g_value_init(&pval, G_TYPE_POINTER);
+    g_value_set_pointer(&pval, uientry);
+    gtk_tree_store_set_value(ped->treestore, iter, PTRCOL, &pval);
 }
 
-static void
-edit_plugin_redraw_tree (struct PluginEditorDialog_s *ped)
+static void edit_plugin_redraw_tree(struct PluginEditorDialog_s *ped)
 {
-	int i,rc;
-	GtkTreeIter iter;
-	GtkTreeModel *model;
-	GnomeUIInfo *uientry;
+    int i, rc;
+    GtkTreeIter iter;
+    GtkTreeModel *model;
+    GnomeUIInfo *uientry;
 
-	/* Walk the current menu list */
-	model = GTK_TREE_MODEL(ped->treestore);
-	uientry = (GnomeUIInfo *)ped->menus->data;
+    /* Walk the current menu list */
+    model = GTK_TREE_MODEL(ped->treestore);
+    uientry = (GnomeUIInfo *) ped->menus->data;
 
-	rc = gtk_tree_model_get_iter_first (model, &iter);
-	for (i=0; i<ped->menus->len; i++)
-	{
-		if (GNOME_APP_UI_ENDOFINFO == uientry[i].type) break;
-   	if (0 == rc)
-		{
-			gtk_tree_store_append (ped->treestore, &iter, NULL);
-		}
-		edit_plugin_redraw_row (ped, &iter, &uientry[i]);
-		rc = gtk_tree_model_iter_next (model, &iter);
-	}
-	
-	/* Now, delete the excess rows */
-	while (rc)
-	{
-		GtkTreeIter next = iter;
-		rc = gtk_tree_model_iter_next (model, &next);
-		gtk_tree_store_remove (ped->treestore, &iter);
-		iter = next;
-	}
+    rc = gtk_tree_model_get_iter_first(model, &iter);
+    for (i = 0; i < ped->menus->len; i++)
+    {
+        if (GNOME_APP_UI_ENDOFINFO == uientry[i].type)
+            break;
+        if (0 == rc)
+        {
+            gtk_tree_store_append(ped->treestore, &iter, NULL);
+        }
+        edit_plugin_redraw_row(ped, &iter, &uientry[i]);
+        rc = gtk_tree_model_iter_next(model, &iter);
+    }
+
+    /* Now, delete the excess rows */
+    while (rc)
+    {
+        GtkTreeIter next = iter;
+        rc = gtk_tree_model_iter_next(model, &next);
+        gtk_tree_store_remove(ped->treestore, &iter);
+        iter = next;
+    }
 }
 
 /* ============================================================ */
 
-static void
-edit_plugin_widgets_to_item (PluginEditorDialog *dlg, GnomeUIInfo *gui)
+static void edit_plugin_widgets_to_item(PluginEditorDialog *dlg, GnomeUIInfo *gui)
 {
-	const char *title, *path, *tip;
-	GttPlugin *plg;
+    const char *title, *path, *tip;
+    GttPlugin *plg;
 
-	if (!gui) return;
+    if (!gui)
+        return;
 
-	/* Get the dialog contents */
-	title = gtk_entry_get_text (dlg->plugin_name);
-	path = gtk_file_chooser_get_uri (dlg->plugin_path);
+    /* Get the dialog contents */
+    title = gtk_entry_get_text(dlg->plugin_name);
+    path = gtk_file_chooser_get_uri(dlg->plugin_path);
 
-	if (!path)
-	{
-		GtkWidget *mb;
-		mb = gtk_message_dialog_new (NULL,
-		         GTK_DIALOG_MODAL,
-		         GTK_MESSAGE_WARNING,
-		         GTK_BUTTONS_CLOSE,
-	   	      _("You must specify a complete filepath to the report, "
-	   	        "including a leading slash.  The file that you specify "
-	   	        "must exist."));
-		g_signal_connect (G_OBJECT(mb), "response",
-		         G_CALLBACK (gtk_widget_destroy), mb);
-		gtk_widget_show (mb);
-	}
+    if (!path)
+    {
+        GtkWidget *mb;
+        mb = gtk_message_dialog_new(
+            NULL, GTK_DIALOG_MODAL, GTK_MESSAGE_WARNING, GTK_BUTTONS_CLOSE,
+            _("You must specify a complete filepath to the report, "
+              "including a leading slash.  The file that you specify "
+              "must exist.")
+        );
+        g_signal_connect(G_OBJECT(mb), "response", G_CALLBACK(gtk_widget_destroy), mb);
+        gtk_widget_show(mb);
+    }
 
-	tip = gtk_entry_get_text (dlg->plugin_tooltip);
-	if (!path) path="";
-	if (!tip) path="";
+    tip = gtk_entry_get_text(dlg->plugin_tooltip);
+    if (!path)
+        path = "";
+    if (!tip)
+        path = "";
 
-	/* set the values into the item */
-	plg = gui->user_data;
-	if (plg->name) g_free (plg->name);
-	plg->name = g_strdup (title);
-	if (plg->path) g_free (plg->path);
-	plg->path = g_strdup (path);
-	if (plg->tooltip) g_free (plg->tooltip);
-	plg->tooltip = g_strdup (tip);
+    /* set the values into the item */
+    plg = gui->user_data;
+    if (plg->name)
+        g_free(plg->name);
+    plg->name = g_strdup(title);
+    if (plg->path)
+        g_free(plg->path);
+    plg->path = g_strdup(path);
+    if (plg->tooltip)
+        g_free(plg->tooltip);
+    plg->tooltip = g_strdup(tip);
 
-	gui->type = GNOME_APP_UI_ITEM;
-	gui->label = plg->name;
-	gui->hint = plg->tooltip;
-	gui->moreinfo = invoke_report;
-	gui->unused_data = NULL;
-	gui->pixmap_type = GNOME_APP_PIXMAP_STOCK;
-	gui->pixmap_info = GNOME_STOCK_BLANK;
-	gui->accelerator_key = 0;
-	gui->ac_mods = (GdkModifierType) 0;
+    gui->type = GNOME_APP_UI_ITEM;
+    gui->label = plg->name;
+    gui->hint = plg->tooltip;
+    gui->moreinfo = invoke_report;
+    gui->unused_data = NULL;
+    gui->pixmap_type = GNOME_APP_PIXMAP_STOCK;
+    gui->pixmap_info = GNOME_STOCK_BLANK;
+    gui->accelerator_key = 0;
+    gui->ac_mods = (GdkModifierType) 0;
 }
 
-static void
-edit_plugin_item_to_widgets (PluginEditorDialog *dlg, GnomeUIInfo *gui)
+static void edit_plugin_item_to_widgets(PluginEditorDialog *dlg, GnomeUIInfo *gui)
 {
-	GttPlugin *plg;
+    GttPlugin *plg;
 
-	if (!gui) return;
-	plg = gui->user_data;
-	
-	gtk_entry_set_text (dlg->plugin_name, plg->name);
-	gtk_file_chooser_set_uri (dlg->plugin_path, plg->path);
-	gtk_entry_set_text (dlg->plugin_tooltip, plg->tooltip);
+    if (!gui)
+        return;
+    plg = gui->user_data;
+
+    gtk_entry_set_text(dlg->plugin_name, plg->name);
+    gtk_file_chooser_set_uri(dlg->plugin_path, plg->path);
+    gtk_entry_set_text(dlg->plugin_tooltip, plg->tooltip);
 }
 
-static void
-edit_plugin_clear_widgets (PluginEditorDialog *dlg)
+static void edit_plugin_clear_widgets(PluginEditorDialog *dlg)
 {
-	gtk_entry_set_text (dlg->plugin_name, _("New Item"));
-	gtk_file_chooser_unselect_all (dlg->plugin_path);
-	gtk_entry_set_text (dlg->plugin_tooltip, "");
+    gtk_entry_set_text(dlg->plugin_name, _("New Item"));
+    gtk_file_chooser_unselect_all(dlg->plugin_path);
+    gtk_entry_set_text(dlg->plugin_tooltip, "");
 }
 
 /* ============================================================ */
@@ -195,44 +198,43 @@ edit_plugin_clear_widgets (PluginEditorDialog *dlg)
  * tree-widget row.
  */
 
-static void
-edit_plugin_tree_selection_changed_cb (GtkTreeSelection *selection, gpointer data)
+static void edit_plugin_tree_selection_changed_cb(GtkTreeSelection *selection, gpointer data)
 {
-	PluginEditorDialog *dlg = data;
-	GtkTreeModel *model;
-	GtkTreeIter iter;
-	gboolean have_selection;
+    PluginEditorDialog *dlg = data;
+    GtkTreeModel *model;
+    GtkTreeIter iter;
+    gboolean have_selection;
 
-	have_selection = gtk_tree_selection_get_selected (selection, &model, &iter);
-	dlg->do_redraw = FALSE;
-	if (dlg->have_selection)
-	{
-		GnomeUIInfo *curr_item;
-		GValue val = {G_TYPE_INVALID};
-		gtk_tree_model_get_value (model, &dlg->curr_selection, PTRCOL, &val);
-		curr_item = g_value_get_pointer(&val);
+    have_selection = gtk_tree_selection_get_selected(selection, &model, &iter);
+    dlg->do_redraw = FALSE;
+    if (dlg->have_selection)
+    {
+        GnomeUIInfo *curr_item;
+        GValue val = { G_TYPE_INVALID };
+        gtk_tree_model_get_value(model, &dlg->curr_selection, PTRCOL, &val);
+        curr_item = g_value_get_pointer(&val);
 
-		/* Save current values of widgets to current item */
-		edit_plugin_widgets_to_item (dlg, curr_item);
-	}
+        /* Save current values of widgets to current item */
+        edit_plugin_widgets_to_item(dlg, curr_item);
+    }
 
-	if (have_selection)
-	{
-		GnomeUIInfo *curr_item;
-		GValue val = {G_TYPE_INVALID};
-		gtk_tree_model_get_value (model, &iter, PTRCOL, &val);
-		curr_item = g_value_get_pointer(&val);
+    if (have_selection)
+    {
+        GnomeUIInfo *curr_item;
+        GValue val = { G_TYPE_INVALID };
+        gtk_tree_model_get_value(model, &iter, PTRCOL, &val);
+        curr_item = g_value_get_pointer(&val);
 
-		dlg->have_selection = TRUE;
-		dlg->curr_selection = iter;
-		edit_plugin_item_to_widgets (dlg, curr_item);
-	}
-	else
-	{
-		dlg->have_selection = FALSE;
-		edit_plugin_clear_widgets (dlg);
-	}
-	dlg->do_redraw = TRUE;
+        dlg->have_selection = TRUE;
+        dlg->curr_selection = iter;
+        edit_plugin_item_to_widgets(dlg, curr_item);
+    }
+    else
+    {
+        dlg->have_selection = FALSE;
+        edit_plugin_clear_widgets(dlg);
+    }
+    dlg->do_redraw = TRUE;
 }
 
 /* ============================================================ */
@@ -241,23 +243,25 @@ edit_plugin_tree_selection_changed_cb (GtkTreeSelection *selection, gpointer dat
  *  ctree row to be redrawn.
  */
 
-static void
-edit_plugin_changed_cb (GtkWidget * w, gpointer data)
+static void edit_plugin_changed_cb(GtkWidget *w, gpointer data)
 {
-	GnomeUIInfo *curr_item;
-	GValue val = {G_TYPE_INVALID};
-	PluginEditorDialog *dlg = data;
+    GnomeUIInfo *curr_item;
+    GValue val = { G_TYPE_INVALID };
+    PluginEditorDialog *dlg = data;
 
-	if (!dlg->do_redraw) return;
-	if (FALSE == dlg->have_selection) return;
-	
-	gtk_tree_model_get_value (GTK_TREE_MODEL(dlg->treestore),
-	                &dlg->curr_selection, PTRCOL, &val);
-	curr_item = g_value_get_pointer(&val);
+    if (!dlg->do_redraw)
+        return;
+    if (FALSE == dlg->have_selection)
+        return;
 
-	/* Save current values of widgets to current item */
-	edit_plugin_widgets_to_item (dlg, curr_item);
-	edit_plugin_redraw_row (dlg, &dlg->curr_selection, curr_item);
+    gtk_tree_model_get_value(
+        GTK_TREE_MODEL(dlg->treestore), &dlg->curr_selection, PTRCOL, &val
+    );
+    curr_item = g_value_get_pointer(&val);
+
+    /* Save current values of widgets to current item */
+    edit_plugin_widgets_to_item(dlg, curr_item);
+    edit_plugin_redraw_row(dlg, &dlg->curr_selection, curr_item);
 }
 
 /* ============================================================ */
@@ -266,108 +270,107 @@ edit_plugin_changed_cb (GtkWidget * w, gpointer data)
  * that needs to be done on a per-edit frequency.
  */
 
-static void
-edit_plugin_setup (PluginEditorDialog *dlg)
+static void edit_plugin_setup(PluginEditorDialog *dlg)
 {
-	int i, nitems;
-	GnomeUIInfo *sysmenus;
-		
-	/* Copy-in existing menus from the system */
-	sysmenus = gtt_get_reports_menu ();
-	for (i=0; GNOME_APP_UI_ENDOFINFO != sysmenus[i].type; i++) {}
-	nitems = i+1;
+    int i, nitems;
+    GnomeUIInfo *sysmenus;
 
-	dlg->menus = g_array_new (TRUE, FALSE, sizeof (GnomeUIInfo));
-	dlg->menus = g_array_append_vals (dlg->menus, sysmenus, nitems);
-	sysmenus = (GnomeUIInfo *) dlg->menus->data;
-	for (i=0; i<nitems; i++)
-	{
-		GttPlugin *plg = sysmenus[i].user_data;
-		plg = gtt_plugin_copy (plg);
-		sysmenus[i].user_data = plg;
-		if (plg)
-		{
-			sysmenus[i].label = plg->name;
-			sysmenus[i].hint = plg->tooltip;
-		}
-	}
+    /* Copy-in existing menus from the system */
+    sysmenus = gtt_get_reports_menu();
+    for (i = 0; GNOME_APP_UI_ENDOFINFO != sysmenus[i].type; i++)
+    {
+    }
+    nitems = i + 1;
 
-	/* Redraw the tree */
-	edit_plugin_redraw_tree (dlg);
+    dlg->menus = g_array_new(TRUE, FALSE, sizeof(GnomeUIInfo));
+    dlg->menus = g_array_append_vals(dlg->menus, sysmenus, nitems);
+    sysmenus = (GnomeUIInfo *) dlg->menus->data;
+    for (i = 0; i < nitems; i++)
+    {
+        GttPlugin *plg = sysmenus[i].user_data;
+        plg = gtt_plugin_copy(plg);
+        sysmenus[i].user_data = plg;
+        if (plg)
+        {
+            sysmenus[i].label = plg->name;
+            sysmenus[i].hint = plg->tooltip;
+        }
+    }
 
-	/* Hook up the row-selection callback */
-	dlg->have_selection = FALSE;
+    /* Redraw the tree */
+    edit_plugin_redraw_tree(dlg);
 
-	/* clear out the various widgets */
-	edit_plugin_clear_widgets (dlg);
+    /* Hook up the row-selection callback */
+    dlg->have_selection = FALSE;
+
+    /* clear out the various widgets */
+    edit_plugin_clear_widgets(dlg);
 }
 
-static void
-edit_plugin_cleanup (PluginEditorDialog *dlg)
+static void edit_plugin_cleanup(PluginEditorDialog *dlg)
 {
-	GnomeUIInfo *sysmenus;
-	int i;
-	
-	/* Free our local copy of menu structure */
-	sysmenus = (GnomeUIInfo *) dlg->menus->data;
-	for (i=0; GNOME_APP_UI_ENDOFINFO != sysmenus[i].type; i++) {}
-	{
-		gtt_plugin_free (sysmenus[i].user_data);
-	}
-	g_array_free (dlg->menus, TRUE);
-	dlg->menus = NULL;
+    GnomeUIInfo *sysmenus;
+    int i;
 
-	/* Unselect row in tree widget. */
-	gtk_tree_selection_unselect_all (dlg->selection);
-	dlg->have_selection = FALSE;
+    /* Free our local copy of menu structure */
+    sysmenus = (GnomeUIInfo *) dlg->menus->data;
+    for (i = 0; GNOME_APP_UI_ENDOFINFO != sysmenus[i].type; i++)
+    {
+    }
+    {
+        gtt_plugin_free(sysmenus[i].user_data);
+    }
+    g_array_free(dlg->menus, TRUE);
+    dlg->menus = NULL;
 
-	/* Empty the tree widget too */
-	gtk_tree_store_clear (dlg->treestore);
+    /* Unselect row in tree widget. */
+    gtk_tree_selection_unselect_all(dlg->selection);
+    dlg->have_selection = FALSE;
+
+    /* Empty the tree widget too */
+    gtk_tree_store_clear(dlg->treestore);
 }
 
 /* ============================================================ */
 /* Copy the user's changes back to the system.
  */
 
-static void
-edit_plugin_apply_cb (GtkWidget * w, gpointer data)
+static void edit_plugin_apply_cb(GtkWidget *w, gpointer data)
 {
-	PluginEditorDialog *dlg = data;
-	GnomeUIInfo *dlgmenu, *sysmenu;
-	int i, nitems;
+    PluginEditorDialog *dlg = data;
+    GnomeUIInfo *dlgmenu, *sysmenu;
+    int i, nitems;
 
-
-	/* Copy from local copy to system menus */
-	dlgmenu = (GnomeUIInfo *) dlg->menus->data;
-	nitems = dlg->menus->len;
-	sysmenu = g_new0 (GnomeUIInfo, nitems);
-	memcpy (sysmenu, dlgmenu, nitems*sizeof(GnomeUIInfo));
-	for (i=0; i<nitems-1; i++)
-	{
-		GttPlugin *plg = dlgmenu[i].user_data;
-		plg = gtt_plugin_copy (plg);
-		sysmenu[i].user_data = plg;
-		if (plg)
-		{
-			sysmenu[i].label = plg->name;
-			sysmenu[i].hint = plg->tooltip;
-		}
-	}
-	gtt_set_reports_menu (dlg->app, sysmenu);
+    /* Copy from local copy to system menus */
+    dlgmenu = (GnomeUIInfo *) dlg->menus->data;
+    nitems = dlg->menus->len;
+    sysmenu = g_new0(GnomeUIInfo, nitems);
+    memcpy(sysmenu, dlgmenu, nitems * sizeof(GnomeUIInfo));
+    for (i = 0; i < nitems - 1; i++)
+    {
+        GttPlugin *plg = dlgmenu[i].user_data;
+        plg = gtt_plugin_copy(plg);
+        sysmenu[i].user_data = plg;
+        if (plg)
+        {
+            sysmenu[i].label = plg->name;
+            sysmenu[i].hint = plg->tooltip;
+        }
+    }
+    gtt_set_reports_menu(dlg->app, sysmenu);
 }
 
-static void
-edit_plugin_commit_cb (GtkWidget * w, gpointer data)
+static void edit_plugin_commit_cb(GtkWidget *w, gpointer data)
 {
-	PluginEditorDialog *dlg = data;
+    PluginEditorDialog *dlg = data;
 
-	edit_plugin_apply_cb (w, data);
-	edit_plugin_cleanup (dlg);
-	gtk_widget_hide (GTK_WIDGET(dlg->dialog));
+    edit_plugin_apply_cb(w, data);
+    edit_plugin_cleanup(dlg);
+    gtk_widget_hide(GTK_WIDGET(dlg->dialog));
 
-	/* Save to file, too.  That way, if system core dumps later,
-	 * at least we managed to get this set of changes saved. */
-	gtt_save_reports_menu();
+    /* Save to file, too.  That way, if system core dumps later,
+     * at least we managed to get this set of changes saved. */
+    gtt_save_reports_menu();
 }
 
 /* ============================================================ */
@@ -375,407 +378,431 @@ edit_plugin_commit_cb (GtkWidget * w, gpointer data)
  * and that's it.
  */
 
-static void
-edit_plugin_cancel_cb (GtkWidget * w, gpointer data)
+static void edit_plugin_cancel_cb(GtkWidget *w, gpointer data)
 {
-	PluginEditorDialog *dlg = data;
-	
-	edit_plugin_cleanup (dlg);
-	gtk_widget_hide (GTK_WIDGET(dlg->dialog));
+    PluginEditorDialog *dlg = data;
+
+    edit_plugin_cleanup(dlg);
+    gtk_widget_hide(GTK_WIDGET(dlg->dialog));
 }
 
 /* ============================================================ */
 /* Get numeric index of the selected row */
 
-static int
-edit_plugin_get_index_of_selected_item (PluginEditorDialog *dlg)
+static int edit_plugin_get_index_of_selected_item(PluginEditorDialog *dlg)
 {
-	int i;
-	GnomeUIInfo *curr_item;
-	GnomeUIInfo *sysmenus;
-	GValue val = {G_TYPE_INVALID};
+    int i;
+    GnomeUIInfo *curr_item;
+    GnomeUIInfo *sysmenus;
+    GValue val = { G_TYPE_INVALID };
 
-	if (FALSE == dlg->have_selection) return -1;
-	if (! dlg->menus) return -1;
+    if (FALSE == dlg->have_selection)
+        return -1;
+    if (!dlg->menus)
+        return -1;
 
-	/* Get selected item */
-	gtk_tree_model_get_value (GTK_TREE_MODEL(dlg->treestore),
-	                &dlg->curr_selection, PTRCOL, &val);
-	curr_item = g_value_get_pointer(&val);
+    /* Get selected item */
+    gtk_tree_model_get_value(
+        GTK_TREE_MODEL(dlg->treestore), &dlg->curr_selection, PTRCOL, &val
+    );
+    curr_item = g_value_get_pointer(&val);
 
-	sysmenus = (GnomeUIInfo *) dlg->menus->data;
-	for (i=0; GNOME_APP_UI_ENDOFINFO != sysmenus[i].type; i++)
-	{
-		if (curr_item == &sysmenus[i]) return i;
-	}
-	return -1;
+    sysmenus = (GnomeUIInfo *) dlg->menus->data;
+    for (i = 0; GNOME_APP_UI_ENDOFINFO != sysmenus[i].type; i++)
+    {
+        if (curr_item == &sysmenus[i])
+            return i;
+    }
+    return -1;
 }
 
 /* ============================================================ */
 /* Get the Iter, in the tree, of the indicated item */
 static void
-edit_plugin_get_iter_of_item (PluginEditorDialog *dlg,
-                GnomeUIInfo *item,
-                GtkTreeIter *iter)
+edit_plugin_get_iter_of_item(PluginEditorDialog *dlg, GnomeUIInfo *item, GtkTreeIter *iter)
 {
-	int i, rc;
-	GnomeUIInfo *uientry;
-	GtkTreeModel *model;
+    int i, rc;
+    GnomeUIInfo *uientry;
+    GtkTreeModel *model;
 
-	model = GTK_TREE_MODEL(dlg->treestore);
-	rc = gtk_tree_model_get_iter_first (model, iter);
-	
-	if (! dlg->menus) return;
-	uientry = (GnomeUIInfo *)dlg->menus->data;
+    model = GTK_TREE_MODEL(dlg->treestore);
+    rc = gtk_tree_model_get_iter_first(model, iter);
 
-	for (i=0; i<dlg->menus->len; i++)
-	{
-		if (GNOME_APP_UI_ENDOFINFO == uientry[i].type) break;
+    if (!dlg->menus)
+        return;
+    uientry = (GnomeUIInfo *) dlg->menus->data;
 
-   	if (0 == rc) break;
-		if (item == &uientry[i]) return;
-		
-		rc = gtk_tree_model_iter_next (model, iter);
-	}
+    for (i = 0; i < dlg->menus->len; i++)
+    {
+        if (GNOME_APP_UI_ENDOFINFO == uientry[i].type)
+            break;
+
+        if (0 == rc)
+            break;
+        if (item == &uientry[i])
+            return;
+
+        rc = gtk_tree_model_iter_next(model, iter);
+    }
 }
 
 /* ============================================================ */
 /* Add and delete menu items callbacks */
 
-static void
-edit_plugin_add_cb (GtkWidget * w, gpointer data)
+static void edit_plugin_add_cb(GtkWidget *w, gpointer data)
 {
-	PluginEditorDialog *dlg = data;
-	GnomeUIInfo item, *uientry;
-	GtkTreeIter iter;
-	int index;
-	GttPlugin *plg;
+    PluginEditorDialog *dlg = data;
+    GnomeUIInfo item, *uientry;
+    GtkTreeIter iter;
+    int index;
+    GttPlugin *plg;
 
-	/* Create a plugin, copy widget values into it. */
-	plg = gtt_plugin_new ("x", "/x");
-	if (!plg) return;
-	
-	item.user_data = plg;
-	edit_plugin_widgets_to_item (dlg, &item);
-	
-	/* Insert item into list, or, if no selection, append */
-	index = edit_plugin_get_index_of_selected_item (dlg);
-	if (0 > index) index = dlg->menus->len -1;
+    /* Create a plugin, copy widget values into it. */
+    plg = gtt_plugin_new("x", "/x");
+    if (!plg)
+        return;
 
-	g_array_insert_val (dlg->menus, index, item);
-	
-	/* Redraw the tree */
-	edit_plugin_redraw_tree (dlg);
-	
-	/* Select the new row. Not strictly needed, unless there
-	 * had not been any selection previously.
-	 */
-	uientry = (GnomeUIInfo *) dlg->menus->data;
-	edit_plugin_get_iter_of_item (dlg, &uientry[index], &iter);
-	gtk_tree_selection_select_iter (dlg->selection, &iter);
+    item.user_data = plg;
+    edit_plugin_widgets_to_item(dlg, &item);
+
+    /* Insert item into list, or, if no selection, append */
+    index = edit_plugin_get_index_of_selected_item(dlg);
+    if (0 > index)
+        index = dlg->menus->len - 1;
+
+    g_array_insert_val(dlg->menus, index, item);
+
+    /* Redraw the tree */
+    edit_plugin_redraw_tree(dlg);
+
+    /* Select the new row. Not strictly needed, unless there
+     * had not been any selection previously.
+     */
+    uientry = (GnomeUIInfo *) dlg->menus->data;
+    edit_plugin_get_iter_of_item(dlg, &uientry[index], &iter);
+    gtk_tree_selection_select_iter(dlg->selection, &iter);
 }
 
-static void
-edit_plugin_delete_cb (GtkWidget * w, gpointer data)
+static void edit_plugin_delete_cb(GtkWidget *w, gpointer data)
 {
-	int row;
-	GnomeUIInfo *sysmenus;
-	PluginEditorDialog *dlg = data;
+    int row;
+    GnomeUIInfo *sysmenus;
+    PluginEditorDialog *dlg = data;
 
-	if (FALSE == dlg->have_selection) return;
+    if (FALSE == dlg->have_selection)
+        return;
 
-	/* Get selected item */
-	row = edit_plugin_get_index_of_selected_item (dlg);
-	if (-1 == row) return;
+    /* Get selected item */
+    row = edit_plugin_get_index_of_selected_item(dlg);
+    if (-1 == row)
+        return;
 
-	/* DO NOT delete the end-of-array marker */
-	sysmenus = (GnomeUIInfo *) dlg->menus->data;
-	if (GNOME_APP_UI_ENDOFINFO == sysmenus[row].type) return;
+    /* DO NOT delete the end-of-array marker */
+    sysmenus = (GnomeUIInfo *) dlg->menus->data;
+    if (GNOME_APP_UI_ENDOFINFO == sysmenus[row].type)
+        return;
 
-	dlg->menus = g_array_remove_index (dlg->menus, row);
-	/* XXX mem leak .. should delete ui item */
+    dlg->menus = g_array_remove_index(dlg->menus, row);
+    /* XXX mem leak .. should delete ui item */
 
-	/* Redraw the tree */
-	edit_plugin_redraw_tree (dlg);
+    /* Redraw the tree */
+    edit_plugin_redraw_tree(dlg);
 
-	/* Update selected row, as appropriate */
-	dlg->have_selection = FALSE;
-	edit_plugin_tree_selection_changed_cb (dlg->selection, dlg);
+    /* Update selected row, as appropriate */
+    dlg->have_selection = FALSE;
+    edit_plugin_tree_selection_changed_cb(dlg->selection, dlg);
 }
 
 /* ============================================================ */
-#define ITER_EQ(a,b) (((a).stamp == (b).stamp) && \
-                      ((a).user_data == (b).user_data) && \
-                      ((a).user_data2 == (b).user_data2) && \
-                      ((a).user_data3 == (b).user_data3))
+#define ITER_EQ(a, b)                                             \
+    (((a).stamp == (b).stamp) && ((a).user_data == (b).user_data) \
+     && ((a).user_data2 == (b).user_data2) && ((a).user_data3 == (b).user_data3))
 
-static gboolean
-gtk_tree_model_iter_prev (GtkTreeModel *tree_model, GtkTreeIter  *iter)
+static gboolean gtk_tree_model_iter_prev(GtkTreeModel *tree_model, GtkTreeIter *iter)
 {
-	int rc;
-	GtkTreeIter cur, prev;
+    int rc;
+    GtkTreeIter cur, prev;
 
-	rc = gtk_tree_model_get_iter_first (tree_model, &cur);
-	if (ITER_EQ (cur, *iter)) return 0;
-	while (rc)
-	{
-		prev = cur;
-		rc = gtk_tree_model_iter_next (tree_model, &cur);
-		if (0 == rc) break;
-		if (ITER_EQ (cur, *iter))
-		{
-			*iter = prev;
-			return 1;
-		}
-	}
-	return 0;
+    rc = gtk_tree_model_get_iter_first(tree_model, &cur);
+    if (ITER_EQ(cur, *iter))
+        return 0;
+    while (rc)
+    {
+        prev = cur;
+        rc = gtk_tree_model_iter_next(tree_model, &cur);
+        if (0 == rc)
+            break;
+        if (ITER_EQ(cur, *iter))
+        {
+            *iter = prev;
+            return 1;
+        }
+    }
+    return 0;
 }
 
-static void
-edit_plugin_set_selection (PluginEditorDialog *dlg, int offset)
+static void edit_plugin_set_selection(PluginEditorDialog *dlg, int offset)
 {
-	GtkTreeModel *model;
-	GtkTreeIter iter;
-	gboolean have_sel;
-	int rc;
+    GtkTreeModel *model;
+    GtkTreeIter iter;
+    gboolean have_sel;
+    int rc;
 
-	have_sel = gtk_tree_selection_get_selected (dlg->selection, &model, &iter);
-	if (!have_sel) return;
+    have_sel = gtk_tree_selection_get_selected(dlg->selection, &model, &iter);
+    if (!have_sel)
+        return;
 
-	if (0 < offset)
-	{
-		while (offset)
-		{
-			rc = gtk_tree_model_iter_next (model, &iter);
-			if (0 == rc) return;
-			offset --;
-		}
-		gtk_tree_selection_select_iter (dlg->selection, &iter);
-	}
-	else
-	{
-		while (offset)
-		{
-			rc = gtk_tree_model_iter_prev (model, &iter);
-			if (0 == rc) return;
-			offset ++;
-		}
-		gtk_tree_selection_select_iter (dlg->selection, &iter);
-	}
+    if (0 < offset)
+    {
+        while (offset)
+        {
+            rc = gtk_tree_model_iter_next(model, &iter);
+            if (0 == rc)
+                return;
+            offset--;
+        }
+        gtk_tree_selection_select_iter(dlg->selection, &iter);
+    }
+    else
+    {
+        while (offset)
+        {
+            rc = gtk_tree_model_iter_prev(model, &iter);
+            if (0 == rc)
+                return;
+            offset++;
+        }
+        gtk_tree_selection_select_iter(dlg->selection, &iter);
+    }
 }
 
 /* ============================================================ */
 /* Swap current selection with menu item at offset */
 
-static void
-edit_plugin_move_menu_item (PluginEditorDialog *dlg, int offset)
+static void edit_plugin_move_menu_item(PluginEditorDialog *dlg, int offset)
 {
-	int row, rowb;
-	GnomeUIInfo *sysmenus, itema, itemb;
+    int row, rowb;
+    GnomeUIInfo *sysmenus, itema, itemb;
 
-	if (FALSE == dlg->have_selection) return;
+    if (FALSE == dlg->have_selection)
+        return;
 
-	/* Get selected item */
-	row = edit_plugin_get_index_of_selected_item (dlg);
-	if (-1 == row) return;
+    /* Get selected item */
+    row = edit_plugin_get_index_of_selected_item(dlg);
+    if (-1 == row)
+        return;
 
-	/* DO NOT move the end-of-array marker */
-	sysmenus = (GnomeUIInfo *) dlg->menus->data;
-	if (GNOME_APP_UI_ENDOFINFO == sysmenus[row].type) return;
+    /* DO NOT move the end-of-array marker */
+    sysmenus = (GnomeUIInfo *) dlg->menus->data;
+    if (GNOME_APP_UI_ENDOFINFO == sysmenus[row].type)
+        return;
 
-	rowb = row + offset;
-	if ((0 > rowb) || (rowb >= dlg->menus->len)) return;
+    rowb = row + offset;
+    if ((0 > rowb) || (rowb >= dlg->menus->len))
+        return;
 
-	itema = g_array_index (dlg->menus, GnomeUIInfo, row);
-	itemb = g_array_index (dlg->menus, GnomeUIInfo, rowb);
-	
-	g_array_index (dlg->menus, GnomeUIInfo, row) = itemb;
-	g_array_index (dlg->menus, GnomeUIInfo, rowb) = itema;
+    itema = g_array_index(dlg->menus, GnomeUIInfo, row);
+    itemb = g_array_index(dlg->menus, GnomeUIInfo, rowb);
 
-	/* Redraw the tree */
-	dlg->have_selection = FALSE;
-	edit_plugin_redraw_tree (dlg);
-	edit_plugin_set_selection (dlg, offset);
+    g_array_index(dlg->menus, GnomeUIInfo, row) = itemb;
+    g_array_index(dlg->menus, GnomeUIInfo, rowb) = itema;
+
+    /* Redraw the tree */
+    dlg->have_selection = FALSE;
+    edit_plugin_redraw_tree(dlg);
+    edit_plugin_set_selection(dlg, offset);
 }
 
-static void
-edit_plugin_up_button_cb (GtkWidget * w, gpointer data)
+static void edit_plugin_up_button_cb(GtkWidget *w, gpointer data)
 {
-	edit_plugin_move_menu_item (data, -1);
+    edit_plugin_move_menu_item(data, -1);
 }
 
-static void
-edit_plugin_down_button_cb (GtkWidget * w, gpointer data)
+static void edit_plugin_down_button_cb(GtkWidget *w, gpointer data)
 {
-	edit_plugin_move_menu_item (data, 1);
-}
-
-/* ============================================================ */
-
-static void
-edit_plugin_left_button_cb (GtkWidget * w, gpointer data)
-{
-	printf ("left button clicked\n");
+    edit_plugin_move_menu_item(data, 1);
 }
 
 /* ============================================================ */
 
-static void
-edit_plugin_right_button_cb (GtkWidget * w, gpointer data)
+static void edit_plugin_left_button_cb(GtkWidget *w, gpointer data)
 {
-	printf ("right button clicked\n");
+    printf("left button clicked\n");
+}
+
+/* ============================================================ */
+
+static void edit_plugin_right_button_cb(GtkWidget *w, gpointer data)
+{
+    printf("right button clicked\n");
 }
 
 /* ============================================================ */
 /* Create a new copy of the edit dialog; intialize all widgets, etc. */
 
-PluginEditorDialog *
-edit_plugin_dialog_new (void)
+PluginEditorDialog *edit_plugin_dialog_new(void)
 {
-	PluginEditorDialog *dlg;
-	GladeXML *gtxml;
-	GtkWidget *e;
-	int i;
-	const char *col_titles[NCOLUMNS];
+    PluginEditorDialog *dlg;
+    GladeXML *gtxml;
+    GtkWidget *e;
+    int i;
+    const char *col_titles[NCOLUMNS];
 
-	dlg = g_malloc(sizeof(PluginEditorDialog));
-	dlg->app = GNOME_APP (app_window);
+    dlg = g_malloc(sizeof(PluginEditorDialog));
+    dlg->app = GNOME_APP(app_window);
 
-	gtxml = gtt_glade_xml_new ("glade/plugin_editor.glade", "Plugin Editor");
-	dlg->gtxml = gtxml;
+    gtxml = gtt_glade_xml_new("glade/plugin_editor.glade", "Plugin Editor");
+    dlg->gtxml = gtxml;
 
-	dlg->dialog = GTK_DIALOG (glade_xml_get_widget (gtxml,  "Plugin Editor"));
+    dlg->dialog = GTK_DIALOG(glade_xml_get_widget(gtxml, "Plugin Editor"));
 
-	/* ------------------------------------------------------ */
-	/* Dialog dismissal buttons */
-	
-	glade_xml_signal_connect_data (gtxml, "on_ok_button_clicked",
-		GTK_SIGNAL_FUNC (edit_plugin_commit_cb), dlg);
+    /* ------------------------------------------------------ */
+    /* Dialog dismissal buttons */
 
-	glade_xml_signal_connect_data (gtxml, "on_apply_button_clicked",
-		GTK_SIGNAL_FUNC (edit_plugin_apply_cb), dlg);
+    glade_xml_signal_connect_data(
+        gtxml, "on_ok_button_clicked", GTK_SIGNAL_FUNC(edit_plugin_commit_cb), dlg
+    );
 
-	glade_xml_signal_connect_data (gtxml, "on_cancel_button_clicked",
-		GTK_SIGNAL_FUNC (edit_plugin_cancel_cb), dlg);
+    glade_xml_signal_connect_data(
+        gtxml, "on_apply_button_clicked", GTK_SIGNAL_FUNC(edit_plugin_apply_cb), dlg
+    );
 
-	/* ------------------------------------------------------ */
-	/* Menu item add/delete buttons */
-	glade_xml_signal_connect_data (gtxml, "on_add_button_clicked",
-		GTK_SIGNAL_FUNC (edit_plugin_add_cb), dlg);
+    glade_xml_signal_connect_data(
+        gtxml, "on_cancel_button_clicked", GTK_SIGNAL_FUNC(edit_plugin_cancel_cb), dlg
+    );
 
-	glade_xml_signal_connect_data (gtxml, "on_delete_button_clicked",
-		GTK_SIGNAL_FUNC (edit_plugin_delete_cb), dlg);
+    /* ------------------------------------------------------ */
+    /* Menu item add/delete buttons */
+    glade_xml_signal_connect_data(
+        gtxml, "on_add_button_clicked", GTK_SIGNAL_FUNC(edit_plugin_add_cb), dlg
+    );
 
-	/* ------------------------------------------------------ */
-	/* Grab the various entry boxes and hook them up */
-	e = glade_xml_get_widget (gtxml, "plugin name");
-	dlg->plugin_name = GTK_ENTRY(e);
+    glade_xml_signal_connect_data(
+        gtxml, "on_delete_button_clicked", GTK_SIGNAL_FUNC(edit_plugin_delete_cb), dlg
+    );
 
-	e = glade_xml_get_widget (gtxml, "plugin path");
-	dlg->plugin_path = GTK_FILE_CHOOSER(e);
+    /* ------------------------------------------------------ */
+    /* Grab the various entry boxes and hook them up */
+    e = glade_xml_get_widget(gtxml, "plugin name");
+    dlg->plugin_name = GTK_ENTRY(e);
 
-	e = glade_xml_get_widget (gtxml, "plugin tooltip");
-	dlg->plugin_tooltip = GTK_ENTRY(e);
+    e = glade_xml_get_widget(gtxml, "plugin path");
+    dlg->plugin_path = GTK_FILE_CHOOSER(e);
 
-	/* ------------------------------------------------------ */
-	/* Inpout widget changed events */
-	glade_xml_signal_connect_data (gtxml, "on_plugin_name_changed",
-		GTK_SIGNAL_FUNC (edit_plugin_changed_cb), dlg);
+    e = glade_xml_get_widget(gtxml, "plugin tooltip");
+    dlg->plugin_tooltip = GTK_ENTRY(e);
 
-	glade_xml_signal_connect_data (gtxml, "on_plugin_path_changed",
-		GTK_SIGNAL_FUNC (edit_plugin_changed_cb), dlg);
+    /* ------------------------------------------------------ */
+    /* Inpout widget changed events */
+    glade_xml_signal_connect_data(
+        gtxml, "on_plugin_name_changed", GTK_SIGNAL_FUNC(edit_plugin_changed_cb), dlg
+    );
 
-	glade_xml_signal_connect_data (gtxml, "on_plugin_tooltip_changed",
-		GTK_SIGNAL_FUNC (edit_plugin_changed_cb), dlg);
+    glade_xml_signal_connect_data(
+        gtxml, "on_plugin_path_changed", GTK_SIGNAL_FUNC(edit_plugin_changed_cb), dlg
+    );
 
-	/* ------------------------------------------------------ */
-	/* Menu order change buttons */
-	
-	glade_xml_signal_connect_data (gtxml, "on_up_button_clicked",
-		GTK_SIGNAL_FUNC (edit_plugin_up_button_cb), dlg);
+    glade_xml_signal_connect_data(
+        gtxml, "on_plugin_tooltip_changed", GTK_SIGNAL_FUNC(edit_plugin_changed_cb), dlg
+    );
 
-	glade_xml_signal_connect_data (gtxml, "on_down_button_clicked",
-		GTK_SIGNAL_FUNC (edit_plugin_down_button_cb), dlg);
+    /* ------------------------------------------------------ */
+    /* Menu order change buttons */
 
-	glade_xml_signal_connect_data (gtxml, "on_left_button_clicked",
-		GTK_SIGNAL_FUNC (edit_plugin_left_button_cb), dlg);
+    glade_xml_signal_connect_data(
+        gtxml, "on_up_button_clicked", GTK_SIGNAL_FUNC(edit_plugin_up_button_cb), dlg
+    );
 
-	glade_xml_signal_connect_data (gtxml, "on_right_button_clicked",
-		GTK_SIGNAL_FUNC (edit_plugin_right_button_cb), dlg);
+    glade_xml_signal_connect_data(
+        gtxml, "on_down_button_clicked", GTK_SIGNAL_FUNC(edit_plugin_down_button_cb), dlg
+    );
 
-	/* ------------------------------------------------------ */
-	/* Set up the Treeview Widget */
-	e = glade_xml_get_widget (gtxml, "editor treeview");
-	dlg->treeview = GTK_TREE_VIEW (e);
+    glade_xml_signal_connect_data(
+        gtxml, "on_left_button_clicked", GTK_SIGNAL_FUNC(edit_plugin_left_button_cb), dlg
+    );
 
-	{
-		GType col_type[NCOLUMNS];
-		for (i=0;i<NCOLUMNS-1;i++) { col_type[i] = G_TYPE_STRING; }
-		col_type[NCOLUMNS-1] = G_TYPE_POINTER;
-      dlg->treestore = gtk_tree_store_newv (NCOLUMNS, col_type);
-	}
-	gtk_tree_view_set_model (dlg->treeview, GTK_TREE_MODEL(dlg->treestore));
+    glade_xml_signal_connect_data(
+        gtxml, "on_right_button_clicked", GTK_SIGNAL_FUNC(edit_plugin_right_button_cb), dlg
+    );
 
-	/* Set up the columns in the treeview widget */
-	col_titles[0] = "Name";
-	col_titles[1] = "Path";
-	col_titles[2] = "Tooltip";
-	for (i=0; i<NCOLUMNS-1; i++)
-	{
-		GtkTreeViewColumn *col;
-		GtkCellRenderer *renderer;
+    /* ------------------------------------------------------ */
+    /* Set up the Treeview Widget */
+    e = glade_xml_get_widget(gtxml, "editor treeview");
+    dlg->treeview = GTK_TREE_VIEW(e);
 
-		renderer = gtk_cell_renderer_text_new ();
+    {
+        GType col_type[NCOLUMNS];
+        for (i = 0; i < NCOLUMNS - 1; i++)
+        {
+            col_type[i] = G_TYPE_STRING;
+        }
+        col_type[NCOLUMNS - 1] = G_TYPE_POINTER;
+        dlg->treestore = gtk_tree_store_newv(NCOLUMNS, col_type);
+    }
+    gtk_tree_view_set_model(dlg->treeview, GTK_TREE_MODEL(dlg->treestore));
 
-		col = gtk_tree_view_column_new_with_attributes (
-		                 col_titles[i],
-		                 renderer, "text", i, NULL);
-		
-		gtk_tree_view_insert_column (dlg->treeview, col, i);
-	}
+    /* Set up the columns in the treeview widget */
+    col_titles[0] = "Name";
+    col_titles[1] = "Path";
+    col_titles[2] = "Tooltip";
+    for (i = 0; i < NCOLUMNS - 1; i++)
+    {
+        GtkTreeViewColumn *col;
+        GtkCellRenderer *renderer;
 
-	/* Copy-in existing menus from the system */
-	edit_plugin_setup (dlg);
+        renderer = gtk_cell_renderer_text_new();
 
-	/* Hook up the row-selection callback */
-	dlg->have_selection = FALSE;
-	dlg->selection = gtk_tree_view_get_selection (dlg->treeview);
-	gtk_tree_selection_set_mode (dlg->selection, GTK_SELECTION_SINGLE);
-	g_signal_connect (G_OBJECT (dlg->selection), "changed",
-	            G_CALLBACK (edit_plugin_tree_selection_changed_cb), dlg);
+        col = gtk_tree_view_column_new_with_attributes(
+            col_titles[i], renderer, "text", i, NULL
+        );
 
-	gtk_widget_hide_on_delete (GTK_WIDGET(dlg->dialog));
+        gtk_tree_view_insert_column(dlg->treeview, col, i);
+    }
 
-	return dlg;
+    /* Copy-in existing menus from the system */
+    edit_plugin_setup(dlg);
+
+    /* Hook up the row-selection callback */
+    dlg->have_selection = FALSE;
+    dlg->selection = gtk_tree_view_get_selection(dlg->treeview);
+    gtk_tree_selection_set_mode(dlg->selection, GTK_SELECTION_SINGLE);
+    g_signal_connect(
+        G_OBJECT(dlg->selection), "changed", G_CALLBACK(edit_plugin_tree_selection_changed_cb),
+        dlg
+    );
+
+    gtk_widget_hide_on_delete(GTK_WIDGET(dlg->dialog));
+
+    return dlg;
 }
 
 /* ============================================================ */
 
-void
-edit_plugin_dialog_show(PluginEditorDialog *dlg)
+void edit_plugin_dialog_show(PluginEditorDialog *dlg)
 {
-	if (!dlg) return;
-	gtk_widget_show(GTK_WIDGET(dlg->dialog));
+    if (!dlg)
+        return;
+    gtk_widget_show(GTK_WIDGET(dlg->dialog));
 }
 
-void
-edit_plugin_dialog_destroy(PluginEditorDialog *dlg)
+void edit_plugin_dialog_destroy(PluginEditorDialog *dlg)
 {
-	if (!dlg) return;
-	gtk_widget_destroy (GTK_WIDGET(dlg->dialog));
-	g_free (dlg);
+    if (!dlg)
+        return;
+    gtk_widget_destroy(GTK_WIDGET(dlg->dialog));
+    g_free(dlg);
 }
 
 /* ============================================================ */
 
 static PluginEditorDialog *epdlg = NULL;
 
-void
-report_menu_edit(GtkWidget *widget, gpointer data)
+void report_menu_edit(GtkWidget *widget, gpointer data)
 {
-	if (!epdlg) epdlg = edit_plugin_dialog_new ();
-	edit_plugin_setup (epdlg);
-	gtk_widget_show(GTK_WIDGET(epdlg->dialog));
+    if (!epdlg)
+        epdlg = edit_plugin_dialog_new();
+    edit_plugin_setup(epdlg);
+    gtk_widget_show(GTK_WIDGET(epdlg->dialog));
 }
 
 /* ====================== END OF FILE ========================= */

--- a/src/plug-in.c
+++ b/src/plug-in.c
@@ -31,209 +31,212 @@
 
 struct NewPluginDialog_s
 {
-	GladeXML  *gtxml;
-	GtkDialog *dialog;
-	GtkEntry  *plugin_name;
-	GtkFileChooser  *plugin_path;
-	GtkEntry  *plugin_tooltip;
-	GnomeApp  *app;
+    GladeXML *gtxml;
+    GtkDialog *dialog;
+    GtkEntry *plugin_name;
+    GtkFileChooser *plugin_path;
+    GtkEntry *plugin_tooltip;
+    GnomeApp *app;
 };
 
 /* ============================================================ */
 
-GttPlugin *
-gtt_plugin_new (const char * nam, const char * pth)
+GttPlugin *gtt_plugin_new(const char *nam, const char *pth)
 {
-	GttPlugin *plg;
+    GttPlugin *plg;
 
-	if (!nam || !pth) return NULL;
+    if (!nam || !pth)
+        return NULL;
 
-	plg = g_new0 (GttPlugin, 1);
-	plg->name = g_strdup(nam);
-	plg->path = g_strdup(pth);
-	plg->tooltip = NULL;
+    plg = g_new0(GttPlugin, 1);
+    plg->name = g_strdup(nam);
+    plg->path = g_strdup(pth);
+    plg->tooltip = NULL;
 
-	return plg;
+    return plg;
 }
 
-GttPlugin *
-gtt_plugin_copy (GttPlugin *orig)
+GttPlugin *gtt_plugin_copy(GttPlugin *orig)
 {
-	GttPlugin *plg;
+    GttPlugin *plg;
 
-	if (!orig) return NULL;
+    if (!orig)
+        return NULL;
 
-	plg = g_new0 (GttPlugin, 1);
-	plg->name = NULL;
-	if (orig->name) plg->name = g_strdup(orig->name);
-	
-	plg->path = NULL;
-	if (orig->path) plg->path = g_strdup(orig->path);
-	
-	plg->tooltip = NULL;
-	if (orig->tooltip) plg->tooltip = g_strdup(orig->tooltip);
-	
-	plg->last_url = NULL;
-	if (orig->last_url) plg->last_url = g_strdup(orig->last_url);
-	
-	return plg;
+    plg = g_new0(GttPlugin, 1);
+    plg->name = NULL;
+    if (orig->name)
+        plg->name = g_strdup(orig->name);
+
+    plg->path = NULL;
+    if (orig->path)
+        plg->path = g_strdup(orig->path);
+
+    plg->tooltip = NULL;
+    if (orig->tooltip)
+        plg->tooltip = g_strdup(orig->tooltip);
+
+    plg->last_url = NULL;
+    if (orig->last_url)
+        plg->last_url = g_strdup(orig->last_url);
+
+    return plg;
 }
 
-void
-gtt_plugin_free (GttPlugin *plg)
+void gtt_plugin_free(GttPlugin *plg)
 {
-	if (!plg) return;
-	if (plg->name) g_free (plg->name);
-	if (plg->path) g_free (plg->path);
-	if (plg->tooltip) g_free (plg->tooltip);
-	if (plg->last_url) g_free (plg->last_url);
-}
-
-/* ============================================================ */
-
-static void
-new_plugin_create_cb (GtkWidget * w, gpointer data)
-{
-	const char *title, *tip;
-	NewPluginDialog *dlg = data;
-
-	/* Get the dialog contents */
-	title = gtk_entry_get_text (dlg->plugin_name);
-	char* path = gtk_file_chooser_get_uri (dlg->plugin_path);
-	tip = gtk_entry_get_text (dlg->plugin_tooltip);
-
-	/* Do a basic sanity check */
-	GnomeVFSURI *parsed_uri;
-	parsed_uri = gnome_vfs_uri_new (path);
-	gboolean exists = gnome_vfs_uri_exists (parsed_uri);
-	gnome_vfs_uri_unref (parsed_uri);
-	if (!exists)
-	{
-		gchar *msg;
-		GtkWidget *mb;
-		msg = g_strdup_printf (_("Unable to open the report file %s\n"), path);
-		mb = gnome_message_box_new (msg,
-			GNOME_MESSAGE_BOX_ERROR,
-			GTK_STOCK_CLOSE,
-			NULL);
-		gtk_widget_show (mb);
-		/* g_free (msg);   XXX memory leak needs fixing. */
-	}
-	else
-	{
-		GttPlugin *plg;
-		GnomeUIInfo entry[2];
-		
-		/* Create the plugin */
-		plg = gtt_plugin_new (title,path);
-		plg->tooltip = g_strdup (tip);
-	
-		/* Add the thing to the Reports menu */
-		entry[0].type = GNOME_APP_UI_ITEM;
-		entry[0].label = plg->name;
-		entry[0].hint = plg->tooltip;
-		entry[0].moreinfo = invoke_report;
-		entry[0].user_data = plg;
-		entry[0].unused_data = NULL;
-		entry[0].pixmap_type = GNOME_APP_PIXMAP_STOCK;
-		entry[0].pixmap_info = GNOME_STOCK_MENU_BLANK;
-		entry[0].accelerator_key = 0;
-		entry[0].ac_mods = (GdkModifierType) 0;
-	
-		entry[1].type = GNOME_APP_UI_ENDOFINFO;
-	
-		// gnome_app_insert_menus (dlg->app,  N_("Reports/<Separator>"), entry);
-
-		gtt_reports_menu_prepend_entry(dlg->app, entry);
-
-	   /* Save to file, too.  That way, if system core dumps later,
-		 * at least we managed to get this set of changes saved. */
-		gtt_save_reports_menu();
-
-		/* zero-out entries, so next time user doesn't see them again */
-		/* Uh, no, don't
-		gtk_entry_set_text (dlg->plugin_name, "");
-		gtk_entry_set_text (dlg->plugin_path, "");
-		gtk_entry_set_text (dlg->plugin_tooltip, "");
-		*/
-	}
-	g_free (path);
-	gtk_widget_hide (GTK_WIDGET(dlg->dialog));
-}
-
-static void
-new_plugin_cancel_cb (GtkWidget * w, gpointer data)
-{
-	NewPluginDialog *dlg = data;
-	gtk_widget_hide (GTK_WIDGET(dlg->dialog));
+    if (!plg)
+        return;
+    if (plg->name)
+        g_free(plg->name);
+    if (plg->path)
+        g_free(plg->path);
+    if (plg->tooltip)
+        g_free(plg->tooltip);
+    if (plg->last_url)
+        g_free(plg->last_url);
 }
 
 /* ============================================================ */
 
-
-NewPluginDialog *
-new_plugin_dialog_new (void)
+static void new_plugin_create_cb(GtkWidget *w, gpointer data)
 {
-	NewPluginDialog *dlg;
-	GladeXML *gtxml;
-	GtkWidget *e;
+    const char *title, *tip;
+    NewPluginDialog *dlg = data;
 
-	dlg = g_malloc(sizeof(NewPluginDialog));
-	dlg->app = GNOME_APP (app_window);
+    /* Get the dialog contents */
+    title = gtk_entry_get_text(dlg->plugin_name);
+    char *path = gtk_file_chooser_get_uri(dlg->plugin_path);
+    tip = gtk_entry_get_text(dlg->plugin_tooltip);
 
-	gtxml = gtt_glade_xml_new ("glade/plugin.glade", "Plugin New");
-	dlg->gtxml = gtxml;
+    /* Do a basic sanity check */
+    GnomeVFSURI *parsed_uri;
+    parsed_uri = gnome_vfs_uri_new(path);
+    gboolean exists = gnome_vfs_uri_exists(parsed_uri);
+    gnome_vfs_uri_unref(parsed_uri);
+    if (!exists)
+    {
+        gchar *msg;
+        GtkWidget *mb;
+        msg = g_strdup_printf(_("Unable to open the report file %s\n"), path);
+        mb = gnome_message_box_new(msg, GNOME_MESSAGE_BOX_ERROR, GTK_STOCK_CLOSE, NULL);
+        gtk_widget_show(mb);
+        /* g_free (msg);   XXX memory leak needs fixing. */
+    }
+    else
+    {
+        GttPlugin *plg;
+        GnomeUIInfo entry[2];
 
-	dlg->dialog = GTK_DIALOG (glade_xml_get_widget (gtxml,  "Plugin New"));
+        /* Create the plugin */
+        plg = gtt_plugin_new(title, path);
+        plg->tooltip = g_strdup(tip);
 
-	glade_xml_signal_connect_data (gtxml, "on_ok_button_clicked",
-		GTK_SIGNAL_FUNC (new_plugin_create_cb), dlg);
+        /* Add the thing to the Reports menu */
+        entry[0].type = GNOME_APP_UI_ITEM;
+        entry[0].label = plg->name;
+        entry[0].hint = plg->tooltip;
+        entry[0].moreinfo = invoke_report;
+        entry[0].user_data = plg;
+        entry[0].unused_data = NULL;
+        entry[0].pixmap_type = GNOME_APP_PIXMAP_STOCK;
+        entry[0].pixmap_info = GNOME_STOCK_MENU_BLANK;
+        entry[0].accelerator_key = 0;
+        entry[0].ac_mods = (GdkModifierType) 0;
 
-	glade_xml_signal_connect_data (gtxml, "on_cancel_button_clicked",
-		GTK_SIGNAL_FUNC (new_plugin_cancel_cb), dlg);
+        entry[1].type = GNOME_APP_UI_ENDOFINFO;
 
-	/* ------------------------------------------------------ */
-	/* grab the various entry boxes and hook them up */
-	e = glade_xml_get_widget (gtxml, "plugin name");
-	dlg->plugin_name = GTK_ENTRY(e);
+        // gnome_app_insert_menus (dlg->app,  N_("Reports/<Separator>"), entry);
 
-	e = glade_xml_get_widget (gtxml, "plugin path");
-	dlg->plugin_path = GTK_FILE_CHOOSER(e);
+        gtt_reports_menu_prepend_entry(dlg->app, entry);
 
-	e = glade_xml_get_widget (gtxml, "plugin tooltip");
-	dlg->plugin_tooltip = GTK_ENTRY(e);
+        /* Save to file, too.  That way, if system core dumps later,
+         * at least we managed to get this set of changes saved. */
+        gtt_save_reports_menu();
 
-	gtk_widget_hide_on_delete (GTK_WIDGET(dlg->dialog));
+        /* zero-out entries, so next time user doesn't see them again */
+        /* Uh, no, don't
+        gtk_entry_set_text (dlg->plugin_name, "");
+        gtk_entry_set_text (dlg->plugin_path, "");
+        gtk_entry_set_text (dlg->plugin_tooltip, "");
+        */
+    }
+    g_free(path);
+    gtk_widget_hide(GTK_WIDGET(dlg->dialog));
+}
 
-	return dlg;
+static void new_plugin_cancel_cb(GtkWidget *w, gpointer data)
+{
+    NewPluginDialog *dlg = data;
+    gtk_widget_hide(GTK_WIDGET(dlg->dialog));
 }
 
 /* ============================================================ */
 
-void
-new_plugin_dialog_show(NewPluginDialog *dlg)
+NewPluginDialog *new_plugin_dialog_new(void)
 {
-	if (!dlg) return;
-	gtk_widget_show(GTK_WIDGET(dlg->dialog));
+    NewPluginDialog *dlg;
+    GladeXML *gtxml;
+    GtkWidget *e;
+
+    dlg = g_malloc(sizeof(NewPluginDialog));
+    dlg->app = GNOME_APP(app_window);
+
+    gtxml = gtt_glade_xml_new("glade/plugin.glade", "Plugin New");
+    dlg->gtxml = gtxml;
+
+    dlg->dialog = GTK_DIALOG(glade_xml_get_widget(gtxml, "Plugin New"));
+
+    glade_xml_signal_connect_data(
+        gtxml, "on_ok_button_clicked", GTK_SIGNAL_FUNC(new_plugin_create_cb), dlg
+    );
+
+    glade_xml_signal_connect_data(
+        gtxml, "on_cancel_button_clicked", GTK_SIGNAL_FUNC(new_plugin_cancel_cb), dlg
+    );
+
+    /* ------------------------------------------------------ */
+    /* grab the various entry boxes and hook them up */
+    e = glade_xml_get_widget(gtxml, "plugin name");
+    dlg->plugin_name = GTK_ENTRY(e);
+
+    e = glade_xml_get_widget(gtxml, "plugin path");
+    dlg->plugin_path = GTK_FILE_CHOOSER(e);
+
+    e = glade_xml_get_widget(gtxml, "plugin tooltip");
+    dlg->plugin_tooltip = GTK_ENTRY(e);
+
+    gtk_widget_hide_on_delete(GTK_WIDGET(dlg->dialog));
+
+    return dlg;
 }
 
-void
-new_plugin_dialog_destroy(NewPluginDialog *dlg)
+/* ============================================================ */
+
+void new_plugin_dialog_show(NewPluginDialog *dlg)
 {
-	if (!dlg) return;
-	gtk_widget_destroy (GTK_WIDGET(dlg->dialog));
-	g_free (dlg);
+    if (!dlg)
+        return;
+    gtk_widget_show(GTK_WIDGET(dlg->dialog));
+}
+
+void new_plugin_dialog_destroy(NewPluginDialog *dlg)
+{
+    if (!dlg)
+        return;
+    gtk_widget_destroy(GTK_WIDGET(dlg->dialog));
+    g_free(dlg);
 }
 
 /* ============================================================ */
 
 static NewPluginDialog *pdlg = NULL;
 
-void
-new_report(GtkWidget *widget, gpointer data)
+void new_report(GtkWidget *widget, gpointer data)
 {
-	if (!pdlg) pdlg = new_plugin_dialog_new ();
-	gtk_widget_show(GTK_WIDGET(pdlg->dialog));
+    if (!pdlg)
+        pdlg = new_plugin_dialog_new();
+    gtk_widget_show(GTK_WIDGET(pdlg->dialog));
 }
 
 /* ====================== END OF FILE ========================= */

--- a/src/plug-in.h
+++ b/src/plug-in.h
@@ -30,17 +30,17 @@
 
 typedef struct GttPlugin_s
 {
-	char * name;      /* Name of report, shows up in menu */
-	char * tooltip;
-	char * path;      /* Path to report in file system */
-	char * last_url;  /* Place where user last saved this report */
+    char *name; /* Name of report, shows up in menu */
+    char *tooltip;
+    char *path;     /* Path to report in file system */
+    char *last_url; /* Place where user last saved this report */
 
 } GttPlugin;
 
 /* Simple allocator */
-GttPlugin * gtt_plugin_new (const char * name, const char * path);
-GttPlugin * gtt_plugin_copy (GttPlugin *orig);
-void gtt_plugin_free (GttPlugin *plg);
+GttPlugin *gtt_plugin_new(const char *name, const char *path);
+GttPlugin *gtt_plugin_copy(GttPlugin *orig);
+void gtt_plugin_free(GttPlugin *plg);
 
 /*-------------------------------------------- */
 /* A really simple, stupid GUI that allows user to enter in the path
@@ -51,7 +51,7 @@ void gtt_plugin_free (GttPlugin *plg);
 
 typedef struct NewPluginDialog_s NewPluginDialog;
 
-NewPluginDialog * new_plugin_dialog_new (void);
+NewPluginDialog *new_plugin_dialog_new(void);
 void new_plugin_dialog_show(NewPluginDialog *dlg);
 void new_plugin_dialog_destroy(NewPluginDialog *dlg);
 
@@ -64,11 +64,10 @@ void new_report(GtkWidget *widget, gpointer data);
 
 typedef struct PluginEditorDialog_s PluginEditorDialog;
 
-PluginEditorDialog * edit_plugin_dialog_new (void);
+PluginEditorDialog *edit_plugin_dialog_new(void);
 void edit_plugin_dialog_show(PluginEditorDialog *dlg);
 void edit_plugin_dialog_destroy(PluginEditorDialog *dlg);
 
 void report_menu_edit(GtkWidget *widget, gpointer data);
-
 
 #endif /* __GTT_PLUG_IN_H__ */

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -33,7 +33,6 @@
 #include "toolbar.h"
 #include "util.h"
 
-
 /* globals */
 int config_show_secs = 0;
 int config_show_statusbar = 1;
@@ -82,912 +81,906 @@ int config_weekstart_offset = 0;
 int config_time_format = TIME_FORMAT_LOCALE;
 
 char *config_currency_symbol = NULL;
-int  config_currency_use_locale = 1;
+int config_currency_use_locale = 1;
 
-char * config_data_url = NULL;
+char *config_data_url = NULL;
 
 typedef struct _PrefsDialog
 {
-	GladeXML *gtxml;
-	GnomePropertyBox *dlg;
-	GtkCheckButton *show_secs;
-	GtkCheckButton *show_statusbar;
-	GtkCheckButton *show_clist_titles;
-	GtkCheckButton *show_subprojects;
+    GladeXML *gtxml;
+    GnomePropertyBox *dlg;
+    GtkCheckButton *show_secs;
+    GtkCheckButton *show_statusbar;
+    GtkCheckButton *show_clist_titles;
+    GtkCheckButton *show_subprojects;
 
-	GtkCheckButton *show_title_importance;
-	GtkCheckButton *show_title_urgency;
-	GtkCheckButton *show_title_status;
-	GtkCheckButton *show_title_ever;
-	GtkCheckButton *show_title_year;
-	GtkCheckButton *show_title_month;
-	GtkCheckButton *show_title_week;
-	GtkCheckButton *show_title_lastweek;
-	GtkCheckButton *show_title_day;
-	GtkCheckButton *show_title_yesterday;
-	GtkCheckButton *show_title_current;
-	GtkCheckButton *show_title_desc;
-	GtkCheckButton *show_title_task;
-	GtkCheckButton *show_title_estimated_start;
-	GtkCheckButton *show_title_estimated_end;
-	GtkCheckButton *show_title_due_date;
-	GtkCheckButton *show_title_sizing;
-	GtkCheckButton *show_title_percent_complete;
+    GtkCheckButton *show_title_importance;
+    GtkCheckButton *show_title_urgency;
+    GtkCheckButton *show_title_status;
+    GtkCheckButton *show_title_ever;
+    GtkCheckButton *show_title_year;
+    GtkCheckButton *show_title_month;
+    GtkCheckButton *show_title_week;
+    GtkCheckButton *show_title_lastweek;
+    GtkCheckButton *show_title_day;
+    GtkCheckButton *show_title_yesterday;
+    GtkCheckButton *show_title_current;
+    GtkCheckButton *show_title_desc;
+    GtkCheckButton *show_title_task;
+    GtkCheckButton *show_title_estimated_start;
+    GtkCheckButton *show_title_estimated_end;
+    GtkCheckButton *show_title_due_date;
+    GtkCheckButton *show_title_sizing;
+    GtkCheckButton *show_title_percent_complete;
 
-	GtkCheckButton *logfileuse;
-	GtkWidget      *logfilename_l;
-	GtkFileChooser *logfilename;
-	GtkWidget      *logfilestart_l;
-	GtkEntry       *logfilestart;
-	GtkWidget      *logfilestop_l;
-	GtkEntry       *logfilestop;
-	GtkWidget      *logfileminsecs_l;
-	GtkEntry       *logfileminsecs;
+    GtkCheckButton *logfileuse;
+    GtkWidget *logfilename_l;
+    GtkFileChooser *logfilename;
+    GtkWidget *logfilestart_l;
+    GtkEntry *logfilestart;
+    GtkWidget *logfilestop_l;
+    GtkEntry *logfilestop;
+    GtkWidget *logfileminsecs_l;
+    GtkEntry *logfileminsecs;
 
-	GtkEntry       *shell_start;
-	GtkEntry       *shell_stop;
+    GtkEntry *shell_start;
+    GtkEntry *shell_stop;
 
-	GtkCheckButton *show_toolbar;
-	GtkCheckButton *show_tb_tips;
-	GtkCheckButton *show_tb_new;
-	GtkCheckButton *show_tb_ccp;
-	GtkCheckButton *show_tb_journal;
-	GtkCheckButton *show_tb_pref;
-	GtkCheckButton *show_tb_timer;
-	GtkCheckButton *show_tb_prop;
-	GtkCheckButton *show_tb_help;
-	GtkCheckButton *show_tb_exit;
+    GtkCheckButton *show_toolbar;
+    GtkCheckButton *show_tb_tips;
+    GtkCheckButton *show_tb_new;
+    GtkCheckButton *show_tb_ccp;
+    GtkCheckButton *show_tb_journal;
+    GtkCheckButton *show_tb_pref;
+    GtkCheckButton *show_tb_timer;
+    GtkCheckButton *show_tb_prop;
+    GtkCheckButton *show_tb_help;
+    GtkCheckButton *show_tb_exit;
 
-	GtkEntry       *idle_secs;
-	GtkEntry       *no_project_secs;
-	GtkEntry       *daystart_secs;
-	GtkComboBox  *daystart_menu;
-	GtkComboBox  *weekstart_menu;
+    GtkEntry *idle_secs;
+    GtkEntry *no_project_secs;
+    GtkEntry *daystart_secs;
+    GtkComboBox *daystart_menu;
+    GtkComboBox *weekstart_menu;
 
-	GtkRadioButton *time_format_am_pm;
-	GtkRadioButton *time_format_24_hs;
-	GtkRadioButton *time_format_locale;
+    GtkRadioButton *time_format_am_pm;
+    GtkRadioButton *time_format_24_hs;
+    GtkRadioButton *time_format_locale;
 
-	GtkEntry       *currency_symbol;
-	GtkWidget      *currency_symbol_label;
-	GtkCheckButton *currency_use_locale;
+    GtkEntry *currency_symbol;
+    GtkWidget *currency_symbol_label;
+    GtkCheckButton *currency_use_locale;
 
 } PrefsDialog;
 
-
-
 /* Update the properties of the project view according to current settings */
 
-void
-prefs_update_projects_view (void)
+void prefs_update_projects_view(void)
 {
-	GList *columns = NULL;
+    GList *columns = NULL;
 
-	if (config_show_title_importance)
-	{
-		columns = g_list_insert (columns, "importance", -1);
-	}
+    if (config_show_title_importance)
+    {
+        columns = g_list_insert(columns, "importance", -1);
+    }
 
-	if (config_show_title_urgency)
-	{
-		columns = g_list_insert (columns, "urgency", -1);
-	}
-	
-	if (config_show_title_status)
-	{
-		columns = g_list_insert (columns, "status", -1);
-	}
+    if (config_show_title_urgency)
+    {
+        columns = g_list_insert(columns, "urgency", -1);
+    }
 
-	if (config_show_title_ever)
-	{
-		columns = g_list_insert (columns, "time_ever", -1);
-	}
+    if (config_show_title_status)
+    {
+        columns = g_list_insert(columns, "status", -1);
+    }
 
-	if (config_show_title_year)
-	{
-		columns = g_list_insert (columns, "time_year", -1);
-	}
+    if (config_show_title_ever)
+    {
+        columns = g_list_insert(columns, "time_ever", -1);
+    }
 
-	if (config_show_title_month)
-	{
-		columns = g_list_insert (columns, "time_month", -1);
-	}
+    if (config_show_title_year)
+    {
+        columns = g_list_insert(columns, "time_year", -1);
+    }
 
-	if (config_show_title_week)
-	{
-		columns = g_list_insert (columns, "time_week", -1);
-	}
+    if (config_show_title_month)
+    {
+        columns = g_list_insert(columns, "time_month", -1);
+    }
 
-	if (config_show_title_lastweek)
-	{
-		columns = g_list_insert (columns, "time_lastweek", -1);
-	}
+    if (config_show_title_week)
+    {
+        columns = g_list_insert(columns, "time_week", -1);
+    }
 
-	if (config_show_title_yesterday)
-	{
-		columns = g_list_insert (columns, "time_yesterday", -1);
-	}
+    if (config_show_title_lastweek)
+    {
+        columns = g_list_insert(columns, "time_lastweek", -1);
+    }
 
-	if (config_show_title_day)
-	{
-		columns = g_list_insert (columns, "time_today", -1);
-	}
+    if (config_show_title_yesterday)
+    {
+        columns = g_list_insert(columns, "time_yesterday", -1);
+    }
 
-	if (config_show_title_current)
-	{
-		columns = g_list_insert (columns, "time_task", -1);
-	}
+    if (config_show_title_day)
+    {
+        columns = g_list_insert(columns, "time_today", -1);
+    }
 
-	/* The title column is mandatory */
-	columns = g_list_insert (columns, "title", -1);
+    if (config_show_title_current)
+    {
+        columns = g_list_insert(columns, "time_task", -1);
+    }
 
-	if (config_show_title_desc)
-	{
-		columns = g_list_insert (columns, "description", -1);
-	}
+    /* The title column is mandatory */
+    columns = g_list_insert(columns, "title", -1);
 
-	if (config_show_title_task)
-	{
-		columns = g_list_insert (columns, "task", -1);
-	}
+    if (config_show_title_desc)
+    {
+        columns = g_list_insert(columns, "description", -1);
+    }
 
-	if (config_show_title_estimated_start)
-	{
-		columns = g_list_insert (columns, "estimated_start", -1);
-	}
+    if (config_show_title_task)
+    {
+        columns = g_list_insert(columns, "task", -1);
+    }
 
-	if (config_show_title_estimated_end)
-	{
-		columns = g_list_insert (columns, "estimated_end", -1);
-	}
+    if (config_show_title_estimated_start)
+    {
+        columns = g_list_insert(columns, "estimated_start", -1);
+    }
 
-	if (config_show_title_due_date)
-	{
-		columns = g_list_insert (columns, "due_date", -1);
-	}
+    if (config_show_title_estimated_end)
+    {
+        columns = g_list_insert(columns, "estimated_end", -1);
+    }
 
-	if (config_show_title_sizing)
-	{
-		columns = g_list_insert (columns, "sizing", -1);
-	}
+    if (config_show_title_due_date)
+    {
+        columns = g_list_insert(columns, "due_date", -1);
+    }
 
-	if (config_show_title_percent_complete)
-	{
-		columns = g_list_insert (columns, "percent_done", -1);
-	}
+    if (config_show_title_sizing)
+    {
+        columns = g_list_insert(columns, "sizing", -1);
+    }
 
-	gtt_projects_tree_set_visible_columns (projects_tree, columns);
-	g_list_free (columns);
+    if (config_show_title_percent_complete)
+    {
+        columns = g_list_insert(columns, "percent_done", -1);
+    }
 
-	gtk_tree_view_set_enable_tree_lines (GTK_TREE_VIEW (projects_tree),
-										 config_show_subprojects);
-	gtk_tree_view_set_headers_visible (GTK_TREE_VIEW (projects_tree),
-									   config_show_clist_titles);
+    gtt_projects_tree_set_visible_columns(projects_tree, columns);
+    g_list_free(columns);
+
+    gtk_tree_view_set_enable_tree_lines(GTK_TREE_VIEW(projects_tree), config_show_subprojects);
+    gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(projects_tree), config_show_clist_titles);
 }
 
-void
-prefs_set_show_secs ()
+void prefs_set_show_secs()
 {
-	gtt_projects_tree_set_show_seconds (projects_tree, config_show_secs);
+    gtt_projects_tree_set_show_seconds(projects_tree, config_show_secs);
 }
-
 
 /* ============================================================== */
 /** parse an HH:MM:SS string for the time returning seconds
  * XXX should probably use getdate or fdate or something like that
  */
 
-static int
-scan_time_string (const char *str)
+static int scan_time_string(const char *str)
 {
-	int hours=0, minutes=0, seconds = 0;
-	char buff[24];
-	strncpy (buff, str, 24);
-	buff[23]=0;
-	char * p = strchr (buff, ':');
-	if (p) *p = 0;
-	hours = atoi (buff);
-	if (p)
-	{
-		char *m = ++p;
-		p = strchr (m, ':');
-		if (p) *p = 0;
-		minutes = atoi (m);
-		if (p)
-		{
-			seconds = atoi(++p);
-		}
-	}
-	seconds %= 60;
-	minutes %= 60;
-	hours %= 24;
+    int hours = 0, minutes = 0, seconds = 0;
+    char buff[24];
+    strncpy(buff, str, 24);
+    buff[23] = 0;
+    char *p = strchr(buff, ':');
+    if (p)
+        *p = 0;
+    hours = atoi(buff);
+    if (p)
+    {
+        char *m = ++p;
+        p = strchr(m, ':');
+        if (p)
+            *p = 0;
+        minutes = atoi(m);
+        if (p)
+        {
+            seconds = atoi(++p);
+        }
+    }
+    seconds %= 60;
+    minutes %= 60;
+    hours %= 24;
 
-	int totalsecs = hours*3600 + minutes*60 + seconds;
-	if (12*3600 < totalsecs) totalsecs -= 24*3600;
-	return totalsecs;
+    int totalsecs = hours * 3600 + minutes * 60 + seconds;
+    if (12 * 3600 < totalsecs)
+        totalsecs -= 24 * 3600;
+    return totalsecs;
 }
 
 /* ============================================================== */
 
-static void
-toolbar_sensitive_cb(GtkWidget *w, PrefsDialog *odlg)
+static void toolbar_sensitive_cb(GtkWidget *w, PrefsDialog *odlg)
 {
-	int state;
-	
-	state = GTK_TOGGLE_BUTTON(odlg->show_toolbar)->active;
-	gtk_widget_set_sensitive(GTK_WIDGET(odlg->show_tb_new), state);
-	gtk_widget_set_sensitive(GTK_WIDGET(odlg->show_tb_ccp), state);
-	gtk_widget_set_sensitive(GTK_WIDGET(odlg->show_tb_journal), state);
-	gtk_widget_set_sensitive(GTK_WIDGET(odlg->show_tb_pref), state);
-	gtk_widget_set_sensitive(GTK_WIDGET(odlg->show_tb_timer), state);
-	gtk_widget_set_sensitive(GTK_WIDGET(odlg->show_tb_prop), state);
-	gtk_widget_set_sensitive(GTK_WIDGET(odlg->show_tb_help), state);
-	gtk_widget_set_sensitive(GTK_WIDGET(odlg->show_tb_exit), state);
-	
-	// gtk_widget_set_sensitive(odlg->logfilename_l, state);
+    int state;
+
+    state = GTK_TOGGLE_BUTTON(odlg->show_toolbar)->active;
+    gtk_widget_set_sensitive(GTK_WIDGET(odlg->show_tb_new), state);
+    gtk_widget_set_sensitive(GTK_WIDGET(odlg->show_tb_ccp), state);
+    gtk_widget_set_sensitive(GTK_WIDGET(odlg->show_tb_journal), state);
+    gtk_widget_set_sensitive(GTK_WIDGET(odlg->show_tb_pref), state);
+    gtk_widget_set_sensitive(GTK_WIDGET(odlg->show_tb_timer), state);
+    gtk_widget_set_sensitive(GTK_WIDGET(odlg->show_tb_prop), state);
+    gtk_widget_set_sensitive(GTK_WIDGET(odlg->show_tb_help), state);
+    gtk_widget_set_sensitive(GTK_WIDGET(odlg->show_tb_exit), state);
+
+    // gtk_widget_set_sensitive(odlg->logfilename_l, state);
 }
 
 /* ============================================================== */
 
-#define ENTRY_TO_CHAR(a, b) {                               \
-   const char *s = gtk_entry_get_text(a);                   \
-   if (s[0]) {                                              \
-      if (b) g_free(b);                                     \
-      b = g_strdup(s);                                      \
-   } else {                                                 \
-      if (b) g_free(b);                                     \
-      b = NULL;                                             \
-   }                                                        \
-}
+#define ENTRY_TO_CHAR(a, b)                    \
+    {                                          \
+        const char *s = gtk_entry_get_text(a); \
+        if (s[0])                              \
+        {                                      \
+            if (b)                             \
+                g_free(b);                     \
+            b = g_strdup(s);                   \
+        }                                      \
+        else                                   \
+        {                                      \
+            if (b)                             \
+                g_free(b);                     \
+            b = NULL;                          \
+        }                                      \
+    }
 
-#define SHOW_CHECK(TOK) {                                   \
-   int state = GTK_TOGGLE_BUTTON(odlg->show_##TOK)->active; \
-   if (config_show_##TOK != state) {                        \
-      change = 1;                                           \
-      config_show_##TOK = state;                            \
-   }                                                        \
-}
+#define SHOW_CHECK(TOK)                                          \
+    {                                                            \
+        int state = GTK_TOGGLE_BUTTON(odlg->show_##TOK)->active; \
+        if (config_show_##TOK != state)                          \
+        {                                                        \
+            change = 1;                                          \
+            config_show_##TOK = state;                           \
+        }                                                        \
+    }
 
-#define SET_VAL(to,from) {                                  \
-   if (to != from) {                                        \
-      change = 1;                                           \
-      to = from;                                            \
-   }                                                        \
-}
+#define SET_VAL(to, from) \
+    {                     \
+        if (to != from)   \
+        {                 \
+            change = 1;   \
+            to = from;    \
+        }                 \
+    }
 
-
-static void
-prefs_set(GnomePropertyBox * pb, gint page, PrefsDialog *odlg)
+static void prefs_set(GnomePropertyBox *pb, gint page, PrefsDialog *odlg)
 {
-	int state;
+    int state;
 
-	if (0 == page)
-	{
-		int change = 0;
+    if (0 == page)
+    {
+        int change = 0;
 
-		SHOW_CHECK (title_importance);
-		SHOW_CHECK (title_urgency);
-		SHOW_CHECK (title_status);
-		SHOW_CHECK (title_ever);
-		SHOW_CHECK (title_year);
-		SHOW_CHECK (title_month);
-		SHOW_CHECK (title_week);
-		SHOW_CHECK (title_lastweek);
-		SHOW_CHECK (title_day);
-		SHOW_CHECK (title_yesterday);
-		SHOW_CHECK (title_current);
-		SHOW_CHECK (title_desc);
-		SHOW_CHECK (title_task);
-		SHOW_CHECK (title_estimated_start);
-		SHOW_CHECK (title_estimated_end);
-		SHOW_CHECK (title_due_date);
-		SHOW_CHECK (title_sizing);
-		SHOW_CHECK (title_percent_complete);
+        SHOW_CHECK(title_importance);
+        SHOW_CHECK(title_urgency);
+        SHOW_CHECK(title_status);
+        SHOW_CHECK(title_ever);
+        SHOW_CHECK(title_year);
+        SHOW_CHECK(title_month);
+        SHOW_CHECK(title_week);
+        SHOW_CHECK(title_lastweek);
+        SHOW_CHECK(title_day);
+        SHOW_CHECK(title_yesterday);
+        SHOW_CHECK(title_current);
+        SHOW_CHECK(title_desc);
+        SHOW_CHECK(title_task);
+        SHOW_CHECK(title_estimated_start);
+        SHOW_CHECK(title_estimated_end);
+        SHOW_CHECK(title_due_date);
+        SHOW_CHECK(title_sizing);
+        SHOW_CHECK(title_percent_complete);
 
-		if (change)
-		{
-			prefs_update_projects_view ();
-		}
-	
-	}
-	if (1 == page)
-	{
+        if (change)
+        {
+            prefs_update_projects_view();
+        }
+    }
+    if (1 == page)
+    {
 
-		/* display options */
-		state = GTK_TOGGLE_BUTTON(odlg->show_secs)->active;
-		if (state != config_show_secs) {
-			config_show_secs = state;
-			prefs_set_show_secs ();
-			update_status_bar();
-			if (status_bar)
-			gtk_widget_queue_resize(status_bar);
-			start_main_timer ();
-		}
-		if (GTK_TOGGLE_BUTTON(odlg->show_statusbar)->active) {
-			gtk_widget_show(GTK_WIDGET(status_bar));
-			config_show_statusbar = 1;
-		} else {
-			gtk_widget_hide(GTK_WIDGET(status_bar));
-			config_show_statusbar = 0;
-		}
-		if (GTK_TOGGLE_BUTTON(odlg->show_clist_titles)->active) {
-			config_show_clist_titles = 1;
-		} else {
-			config_show_clist_titles = 0;
-		}
-	
-		if (GTK_TOGGLE_BUTTON(odlg->show_subprojects)->active) {
-			config_show_subprojects = 1;
-		} else {
-			config_show_subprojects = 0;
-		}
-		prefs_update_projects_view ();
-	}
+        /* display options */
+        state = GTK_TOGGLE_BUTTON(odlg->show_secs)->active;
+        if (state != config_show_secs)
+        {
+            config_show_secs = state;
+            prefs_set_show_secs();
+            update_status_bar();
+            if (status_bar)
+                gtk_widget_queue_resize(status_bar);
+            start_main_timer();
+        }
+        if (GTK_TOGGLE_BUTTON(odlg->show_statusbar)->active)
+        {
+            gtk_widget_show(GTK_WIDGET(status_bar));
+            config_show_statusbar = 1;
+        }
+        else
+        {
+            gtk_widget_hide(GTK_WIDGET(status_bar));
+            config_show_statusbar = 0;
+        }
+        if (GTK_TOGGLE_BUTTON(odlg->show_clist_titles)->active)
+        {
+            config_show_clist_titles = 1;
+        }
+        else
+        {
+            config_show_clist_titles = 0;
+        }
 
-	if (2 == page)
-	{
-		/* shell command options */
-		ENTRY_TO_CHAR(odlg->shell_start, config_shell_start);
-		ENTRY_TO_CHAR(odlg->shell_stop, config_shell_stop);
-	}
+        if (GTK_TOGGLE_BUTTON(odlg->show_subprojects)->active)
+        {
+            config_show_subprojects = 1;
+        }
+        else
+        {
+            config_show_subprojects = 0;
+        }
+        prefs_update_projects_view();
+    }
 
-	if (3 == page)
-	{
-		/* log file options */
-		config_logfile_use = GTK_TOGGLE_BUTTON(odlg->logfileuse)->active;
-		config_logfile_name = gtk_file_chooser_get_filename (odlg->logfilename);
-		ENTRY_TO_CHAR(odlg->logfilestart, config_logfile_start);
-		ENTRY_TO_CHAR(odlg->logfilestop, config_logfile_stop);
-		config_logfile_min_secs = atoi (gtk_entry_get_text(odlg->logfileminsecs));
-	}
+    if (2 == page)
+    {
+        /* shell command options */
+        ENTRY_TO_CHAR(odlg->shell_start, config_shell_start);
+        ENTRY_TO_CHAR(odlg->shell_stop, config_shell_stop);
+    }
 
-	if (4 == page)
-	{
-		int change = 0;
+    if (3 == page)
+    {
+        /* log file options */
+        config_logfile_use = GTK_TOGGLE_BUTTON(odlg->logfileuse)->active;
+        config_logfile_name = gtk_file_chooser_get_filename(odlg->logfilename);
+        ENTRY_TO_CHAR(odlg->logfilestart, config_logfile_start);
+        ENTRY_TO_CHAR(odlg->logfilestop, config_logfile_stop);
+        config_logfile_min_secs = atoi(gtk_entry_get_text(odlg->logfileminsecs));
+    }
 
-		/* toolbar */
-		config_show_toolbar = GTK_TOGGLE_BUTTON(odlg->show_toolbar)->active;
-		config_show_tb_tips = GTK_TOGGLE_BUTTON(odlg->show_tb_tips)->active;
-	
-		/* toolbar sections */
-		SHOW_CHECK (tb_new);
-		SHOW_CHECK (tb_ccp);
-		SHOW_CHECK (tb_journal);
-		SHOW_CHECK (tb_prop);
-		SHOW_CHECK (tb_timer);
-		SHOW_CHECK (tb_pref);
-		SHOW_CHECK (tb_help);
-		SHOW_CHECK (tb_exit);
+    if (4 == page)
+    {
+        int change = 0;
 
-		if (change)
-		{
-			update_toolbar_sections();
-		}
+        /* toolbar */
+        config_show_toolbar = GTK_TOGGLE_BUTTON(odlg->show_toolbar)->active;
+        config_show_tb_tips = GTK_TOGGLE_BUTTON(odlg->show_tb_tips)->active;
 
-		toolbar_set_states();
-	}
+        /* toolbar sections */
+        SHOW_CHECK(tb_new);
+        SHOW_CHECK(tb_ccp);
+        SHOW_CHECK(tb_journal);
+        SHOW_CHECK(tb_prop);
+        SHOW_CHECK(tb_timer);
+        SHOW_CHECK(tb_pref);
+        SHOW_CHECK(tb_help);
+        SHOW_CHECK(tb_exit);
 
-	if (5 == page)
-	{
-		int change = 0;
-		config_idle_timeout = atoi(gtk_entry_get_text(GTK_ENTRY(odlg->idle_secs)));
-		config_no_project_timeout = atoi(gtk_entry_get_text(GTK_ENTRY(odlg->no_project_secs)));
+        if (change)
+        {
+            update_toolbar_sections();
+        }
 
-		if (timer_is_running ())
-		{
-			start_idle_timer ();
-		}
-		else
-		{
-			start_no_project_timer ();
-		}
+        toolbar_set_states();
+    }
 
-		/* Hunt for the hour-of night on which to start */
-		const char * buff = gtk_entry_get_text (odlg->daystart_secs);
-		int off = scan_time_string (buff);
-		SET_VAL (config_daystart_offset,off);
+    if (5 == page)
+    {
+        int change = 0;
+        config_idle_timeout = atoi(gtk_entry_get_text(GTK_ENTRY(odlg->idle_secs)));
+        config_no_project_timeout = atoi(gtk_entry_get_text(GTK_ENTRY(odlg->no_project_secs)));
 
-		int day = gtk_combo_box_get_active (odlg->weekstart_menu);
-		SET_VAL (config_weekstart_offset, day);
+        if (timer_is_running())
+        {
+            start_idle_timer();
+        }
+        else
+        {
+            start_no_project_timer();
+        }
 
-		if (change)
-		{
-			/* Need to recompute everything, including the bining */
-			gtt_project_list_compute_secs();
-			gtt_projects_tree_update_all_rows (projects_tree);
-		}
-	}
+        /* Hunt for the hour-of night on which to start */
+        const char *buff = gtk_entry_get_text(odlg->daystart_secs);
+        int off = scan_time_string(buff);
+        SET_VAL(config_daystart_offset, off);
 
-	if (6 == page)
-	{
-		if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(odlg->time_format_am_pm)))
-		{
-			config_time_format = TIME_FORMAT_AM_PM;
-		}
-		if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(odlg->time_format_24_hs)))
-		{
-			config_time_format = TIME_FORMAT_24_HS;
-		}
-		if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(odlg->time_format_locale)))
-		{
-			config_time_format = TIME_FORMAT_LOCALE;
-		}
+        int day = gtk_combo_box_get_active(odlg->weekstart_menu);
+        SET_VAL(config_weekstart_offset, day);
 
-		ENTRY_TO_CHAR(odlg->currency_symbol, config_currency_symbol);
-		int state = GTK_TOGGLE_BUTTON(odlg->currency_use_locale)->active;
-		if (config_currency_use_locale != state) {
-			 config_currency_use_locale = state;
-		}
-	}
+        if (change)
+        {
+            /* Need to recompute everything, including the bining */
+            gtt_project_list_compute_secs();
+            gtt_projects_tree_update_all_rows(projects_tree);
+        }
+    }
 
-	/* Also save them the to file at this point */
-	save_properties();
+    if (6 == page)
+    {
+        if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(odlg->time_format_am_pm)))
+        {
+            config_time_format = TIME_FORMAT_AM_PM;
+        }
+        if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(odlg->time_format_24_hs)))
+        {
+            config_time_format = TIME_FORMAT_24_HS;
+        }
+        if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(odlg->time_format_locale)))
+        {
+            config_time_format = TIME_FORMAT_LOCALE;
+        }
+
+        ENTRY_TO_CHAR(odlg->currency_symbol, config_currency_symbol);
+        int state = GTK_TOGGLE_BUTTON(odlg->currency_use_locale)->active;
+        if (config_currency_use_locale != state)
+        {
+            config_currency_use_locale = state;
+        }
+    }
+
+    /* Also save them the to file at this point */
+    save_properties();
 }
 
 /* ============================================================== */
 
-static void
-logfile_sensitive_cb(GtkWidget *w, PrefsDialog *odlg)
+static void logfile_sensitive_cb(GtkWidget *w, PrefsDialog *odlg)
 {
-	int state;
-	
-	state = GTK_TOGGLE_BUTTON(odlg->logfileuse)->active;
-	gtk_widget_set_sensitive(GTK_WIDGET(odlg->logfilename), state);
-	gtk_widget_set_sensitive(odlg->logfilename_l, state);
-	gtk_widget_set_sensitive(GTK_WIDGET(odlg->logfilestart), state);
-	gtk_widget_set_sensitive(odlg->logfilestart_l, state);
-	gtk_widget_set_sensitive(GTK_WIDGET(odlg->logfilestop), state);
-	gtk_widget_set_sensitive(odlg->logfilestop_l, state);
-	gtk_widget_set_sensitive(GTK_WIDGET(odlg->logfileminsecs), state);
-	gtk_widget_set_sensitive(odlg->logfileminsecs_l, state);
+    int state;
+
+    state = GTK_TOGGLE_BUTTON(odlg->logfileuse)->active;
+    gtk_widget_set_sensitive(GTK_WIDGET(odlg->logfilename), state);
+    gtk_widget_set_sensitive(odlg->logfilename_l, state);
+    gtk_widget_set_sensitive(GTK_WIDGET(odlg->logfilestart), state);
+    gtk_widget_set_sensitive(odlg->logfilestart_l, state);
+    gtk_widget_set_sensitive(GTK_WIDGET(odlg->logfilestop), state);
+    gtk_widget_set_sensitive(odlg->logfilestop_l, state);
+    gtk_widget_set_sensitive(GTK_WIDGET(odlg->logfileminsecs), state);
+    gtk_widget_set_sensitive(odlg->logfileminsecs_l, state);
 }
 
-static void
-currency_sensitive_cb(GtkWidget *w, PrefsDialog *odlg)
+static void currency_sensitive_cb(GtkWidget *w, PrefsDialog *odlg)
 {
-	int state;
-	
-	state = GTK_TOGGLE_BUTTON(w)->active;
-	gtk_widget_set_sensitive(GTK_WIDGET(odlg->currency_symbol), !state);
-	gtk_widget_set_sensitive(GTK_WIDGET(odlg->currency_symbol_label), !state);
-}
+    int state;
 
+    state = GTK_TOGGLE_BUTTON(w)->active;
+    gtk_widget_set_sensitive(GTK_WIDGET(odlg->currency_symbol), !state);
+    gtk_widget_set_sensitive(GTK_WIDGET(odlg->currency_symbol_label), !state);
+}
 
 #define SET_ACTIVE(TOK) \
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(odlg->show_##TOK), \
-		config_show_##TOK);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(odlg->show_##TOK), config_show_##TOK);
 
-static void
-options_dialog_set(PrefsDialog *odlg)
+static void options_dialog_set(PrefsDialog *odlg)
 {
-	char s[30];
+    char s[30];
 
-	SET_ACTIVE(secs);
-	SET_ACTIVE(statusbar);
-	SET_ACTIVE(clist_titles);
-	SET_ACTIVE(subprojects);
+    SET_ACTIVE(secs);
+    SET_ACTIVE(statusbar);
+    SET_ACTIVE(clist_titles);
+    SET_ACTIVE(subprojects);
 
-	SET_ACTIVE(title_importance);
-	SET_ACTIVE(title_urgency);
-	SET_ACTIVE(title_status);
-	SET_ACTIVE(title_ever);
-	SET_ACTIVE(title_year);
-	SET_ACTIVE(title_month);
-	SET_ACTIVE(title_week);
-	SET_ACTIVE(title_lastweek);
-	SET_ACTIVE(title_day);
-	SET_ACTIVE(title_yesterday);
-	SET_ACTIVE(title_current);
-	SET_ACTIVE(title_desc);
-	SET_ACTIVE(title_task);
-	SET_ACTIVE(title_estimated_start);
-	SET_ACTIVE(title_estimated_end);
-	SET_ACTIVE(title_due_date);
-	SET_ACTIVE(title_sizing);
-	SET_ACTIVE(title_percent_complete);
+    SET_ACTIVE(title_importance);
+    SET_ACTIVE(title_urgency);
+    SET_ACTIVE(title_status);
+    SET_ACTIVE(title_ever);
+    SET_ACTIVE(title_year);
+    SET_ACTIVE(title_month);
+    SET_ACTIVE(title_week);
+    SET_ACTIVE(title_lastweek);
+    SET_ACTIVE(title_day);
+    SET_ACTIVE(title_yesterday);
+    SET_ACTIVE(title_current);
+    SET_ACTIVE(title_desc);
+    SET_ACTIVE(title_task);
+    SET_ACTIVE(title_estimated_start);
+    SET_ACTIVE(title_estimated_end);
+    SET_ACTIVE(title_due_date);
+    SET_ACTIVE(title_sizing);
+    SET_ACTIVE(title_percent_complete);
 
-	if (config_shell_start)
-		gtk_entry_set_text(odlg->shell_start, config_shell_start);
-	else
-		gtk_entry_set_text(odlg->shell_start, "");
-	
-	if (config_shell_stop)
-		gtk_entry_set_text(odlg->shell_stop, config_shell_stop);
-	else
-		gtk_entry_set_text(odlg->shell_stop, "");
-	
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(odlg->logfileuse), config_logfile_use);
-	if (config_logfile_name)
-		gtk_file_chooser_set_filename (odlg->logfilename, config_logfile_name);
-	else
-		gtk_file_chooser_unselect_all (odlg->logfilename);
-	
-	if (config_logfile_start)
-		gtk_entry_set_text(odlg->logfilestart, config_logfile_start);
-	else
-		gtk_entry_set_text(odlg->logfilestart, "");
-	
-	if (config_logfile_stop)
-		gtk_entry_set_text(odlg->logfilestop, config_logfile_stop);
-	else
-		gtk_entry_set_text(odlg->logfilestop, "");
+    if (config_shell_start)
+        gtk_entry_set_text(odlg->shell_start, config_shell_start);
+    else
+        gtk_entry_set_text(odlg->shell_start, "");
 
-	g_snprintf(s, sizeof (s), "%d", config_logfile_min_secs);
-	gtk_entry_set_text(GTK_ENTRY(odlg->logfileminsecs), s);
+    if (config_shell_stop)
+        gtk_entry_set_text(odlg->shell_stop, config_shell_stop);
+    else
+        gtk_entry_set_text(odlg->shell_stop, "");
 
-	logfile_sensitive_cb(NULL, odlg);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(odlg->logfileuse), config_logfile_use);
+    if (config_logfile_name)
+        gtk_file_chooser_set_filename(odlg->logfilename, config_logfile_name);
+    else
+        gtk_file_chooser_unselect_all(odlg->logfilename);
 
-	/* toolbar sections */
-	SET_ACTIVE(toolbar);
-	SET_ACTIVE(tb_tips);
-	SET_ACTIVE(tb_new);
-	SET_ACTIVE(tb_ccp);
-	SET_ACTIVE(tb_journal);
-	SET_ACTIVE(tb_prop);
-	SET_ACTIVE(tb_timer);
-	SET_ACTIVE(tb_pref);
-	SET_ACTIVE(tb_help);
-	SET_ACTIVE(tb_exit);
-	
-	toolbar_sensitive_cb(NULL, odlg);
+    if (config_logfile_start)
+        gtk_entry_set_text(odlg->logfilestart, config_logfile_start);
+    else
+        gtk_entry_set_text(odlg->logfilestart, "");
 
-	/* misc section */
-	g_snprintf(s, sizeof (s), "%d", config_idle_timeout);
-	gtk_entry_set_text(GTK_ENTRY(odlg->idle_secs), s);
+    if (config_logfile_stop)
+        gtk_entry_set_text(odlg->logfilestop, config_logfile_stop);
+    else
+        gtk_entry_set_text(odlg->logfilestop, "");
 
-	g_snprintf(s, sizeof (s), "%d", config_no_project_timeout);
-	gtk_entry_set_text(GTK_ENTRY(odlg->no_project_secs), s);
+    g_snprintf(s, sizeof(s), "%d", config_logfile_min_secs);
+    gtk_entry_set_text(GTK_ENTRY(odlg->logfileminsecs), s);
 
-	/* Set the correct menu item based on current values */
-	int hour;
-	if (0<config_daystart_offset)
-	{
-		hour = (config_daystart_offset +1800)/3600;
-	}
-	else
-	{
-		hour = (config_daystart_offset -1800)/3600;
-	}
-	if (-3 > hour) hour = -3; /* menu runs from 9pm */
-	if (6 < hour) hour = 6;   /* menu runs till 6am */
-	hour += 3;  /* menu starts at 9PM */
-	gtk_combo_box_set_active (odlg->daystart_menu, hour);
+    logfile_sensitive_cb(NULL, odlg);
 
-	/* Print the daystart offset as a string in 24 hour time */
-	int secs = config_daystart_offset;
-	if (0 > secs) secs += 24*3600;
-	char buff[24];
-	xxxqof_print_hours_elapsed_buff (buff, 24, secs, config_show_secs);
-	gtk_entry_set_text (odlg->daystart_secs, buff);
+    /* toolbar sections */
+    SET_ACTIVE(toolbar);
+    SET_ACTIVE(tb_tips);
+    SET_ACTIVE(tb_new);
+    SET_ACTIVE(tb_ccp);
+    SET_ACTIVE(tb_journal);
+    SET_ACTIVE(tb_prop);
+    SET_ACTIVE(tb_timer);
+    SET_ACTIVE(tb_pref);
+    SET_ACTIVE(tb_help);
+    SET_ACTIVE(tb_exit);
 
-	/* Set the correct menu item based on current values */
-	int day = config_weekstart_offset;
-	gtk_combo_box_set_active (odlg->weekstart_menu, day);
+    toolbar_sensitive_cb(NULL, odlg);
 
-	switch (config_time_format)
-	{
-	case TIME_FORMAT_AM_PM:
-		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(odlg->time_format_am_pm), TRUE);
-		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(odlg->time_format_24_hs), FALSE);
-		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(odlg->time_format_locale), FALSE);
-		break;
-	case TIME_FORMAT_24_HS:
-		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(odlg->time_format_am_pm), FALSE);
-		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(odlg->time_format_24_hs), TRUE);
-		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(odlg->time_format_locale), FALSE);
-		break;
-	
-	case TIME_FORMAT_LOCALE:
-		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(odlg->time_format_am_pm), FALSE);
-		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(odlg->time_format_24_hs), FALSE);
-		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(odlg->time_format_locale), TRUE);
-		break;
-	
-	
-	}
+    /* misc section */
+    g_snprintf(s, sizeof(s), "%d", config_idle_timeout);
+    gtk_entry_set_text(GTK_ENTRY(odlg->idle_secs), s);
 
-	g_snprintf(s, sizeof (s), "%s", config_currency_symbol);
-	gtk_entry_set_text(GTK_ENTRY(odlg->currency_symbol), s);
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(odlg->currency_use_locale),
-	                             config_currency_use_locale);
+    g_snprintf(s, sizeof(s), "%d", config_no_project_timeout);
+    gtk_entry_set_text(GTK_ENTRY(odlg->no_project_secs), s);
 
+    /* Set the correct menu item based on current values */
+    int hour;
+    if (0 < config_daystart_offset)
+    {
+        hour = (config_daystart_offset + 1800) / 3600;
+    }
+    else
+    {
+        hour = (config_daystart_offset - 1800) / 3600;
+    }
+    if (-3 > hour)
+        hour = -3; /* menu runs from 9pm */
+    if (6 < hour)
+        hour = 6; /* menu runs till 6am */
+    hour += 3;    /* menu starts at 9PM */
+    gtk_combo_box_set_active(odlg->daystart_menu, hour);
 
-	/* set to unmodified as it reflects the current state of the app */
-	gnome_property_box_set_modified(GNOME_PROPERTY_BOX(odlg->dlg), FALSE);
+    /* Print the daystart offset as a string in 24 hour time */
+    int secs = config_daystart_offset;
+    if (0 > secs)
+        secs += 24 * 3600;
+    char buff[24];
+    xxxqof_print_hours_elapsed_buff(buff, 24, secs, config_show_secs);
+    gtk_entry_set_text(odlg->daystart_secs, buff);
+
+    /* Set the correct menu item based on current values */
+    int day = config_weekstart_offset;
+    gtk_combo_box_set_active(odlg->weekstart_menu, day);
+
+    switch (config_time_format)
+    {
+    case TIME_FORMAT_AM_PM:
+        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(odlg->time_format_am_pm), TRUE);
+        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(odlg->time_format_24_hs), FALSE);
+        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(odlg->time_format_locale), FALSE);
+        break;
+    case TIME_FORMAT_24_HS:
+        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(odlg->time_format_am_pm), FALSE);
+        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(odlg->time_format_24_hs), TRUE);
+        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(odlg->time_format_locale), FALSE);
+        break;
+
+    case TIME_FORMAT_LOCALE:
+        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(odlg->time_format_am_pm), FALSE);
+        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(odlg->time_format_24_hs), FALSE);
+        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(odlg->time_format_locale), TRUE);
+        break;
+    }
+
+    g_snprintf(s, sizeof(s), "%s", config_currency_symbol);
+    gtk_entry_set_text(GTK_ENTRY(odlg->currency_symbol), s);
+    gtk_toggle_button_set_active(
+        GTK_TOGGLE_BUTTON(odlg->currency_use_locale), config_currency_use_locale
+    );
+
+    /* set to unmodified as it reflects the current state of the app */
+    gnome_property_box_set_modified(GNOME_PROPERTY_BOX(odlg->dlg), FALSE);
 }
 
 /* ============================================================== */
 
-static void
-daystart_menu_changed (gpointer data, GtkComboBox *w)
+static void daystart_menu_changed(gpointer data, GtkComboBox *w)
 {
-	PrefsDialog *dlg = data;
+    PrefsDialog *dlg = data;
 
-	int hour = gtk_combo_box_get_active (dlg->daystart_menu);
+    int hour = gtk_combo_box_get_active(dlg->daystart_menu);
 
-	g_return_if_fail (hour >= 0);
+    g_return_if_fail(hour >= 0);
 
-	hour += -3;  /* menu starts at 9PM */
+    hour += -3; /* menu starts at 9PM */
 
-	int secs = hour * 3600;
-	if (0 > secs) secs += 24*3600;
-	char buff[24];
-	xxxqof_print_hours_elapsed_buff (buff, 24, secs, config_show_secs);
-	gtk_entry_set_text (dlg->daystart_secs, buff);
+    int secs = hour * 3600;
+    if (0 > secs)
+        secs += 24 * 3600;
+    char buff[24];
+    xxxqof_print_hours_elapsed_buff(buff, 24, secs, config_show_secs);
+    gtk_entry_set_text(dlg->daystart_secs, buff);
 }
 
 /* ============================================================== */
 
-#define GETWID(strname)                                            \
-({                                                                 \
-	GtkWidget *e;                                                   \
-	e = glade_xml_get_widget (gtxml, strname);                      \
-	gtk_signal_connect_object(GTK_OBJECT(e), "changed",             \
-	                  GTK_SIGNAL_FUNC(gnome_property_box_changed),  \
-	                  GTK_OBJECT(dlg->dlg));                        \
-	e;                                                              \
-})
+#define GETWID(strname)                                                            \
+    ({                                                                             \
+        GtkWidget *e;                                                              \
+        e = glade_xml_get_widget(gtxml, strname);                                  \
+        gtk_signal_connect_object(                                                 \
+            GTK_OBJECT(e), "changed", GTK_SIGNAL_FUNC(gnome_property_box_changed), \
+            GTK_OBJECT(dlg->dlg)                                                   \
+        );                                                                         \
+        e;                                                                         \
+    })
 
-#define GETCHWID(strname)                                          \
-({                                                                 \
-	GtkWidget *e;                                                   \
-	e = glade_xml_get_widget (gtxml, strname);                      \
-	gtk_signal_connect_object(GTK_OBJECT(e), "toggled",             \
-	                  GTK_SIGNAL_FUNC(gnome_property_box_changed),  \
-	                  GTK_OBJECT(dlg->dlg));                        \
-	e;                                                              \
-})
+#define GETCHWID(strname)                                                          \
+    ({                                                                             \
+        GtkWidget *e;                                                              \
+        e = glade_xml_get_widget(gtxml, strname);                                  \
+        gtk_signal_connect_object(                                                 \
+            GTK_OBJECT(e), "toggled", GTK_SIGNAL_FUNC(gnome_property_box_changed), \
+            GTK_OBJECT(dlg->dlg)                                                   \
+        );                                                                         \
+        e;                                                                         \
+    })
 
-static void
-display_options(PrefsDialog *dlg)
+static void display_options(PrefsDialog *dlg)
 {
-	GtkWidget *w;
-	GladeXML *gtxml = dlg->gtxml;
+    GtkWidget *w;
+    GladeXML *gtxml = dlg->gtxml;
 
-	w = GETCHWID ("show secs");
-	dlg->show_secs = GTK_CHECK_BUTTON(w);
+    w = GETCHWID("show secs");
+    dlg->show_secs = GTK_CHECK_BUTTON(w);
 
-	w = GETCHWID ("show statusbar");
-	dlg->show_statusbar = GTK_CHECK_BUTTON(w);
+    w = GETCHWID("show statusbar");
+    dlg->show_statusbar = GTK_CHECK_BUTTON(w);
 
-	w = GETCHWID ("show header");
-	dlg->show_clist_titles = GTK_CHECK_BUTTON(w);
+    w = GETCHWID("show header");
+    dlg->show_clist_titles = GTK_CHECK_BUTTON(w);
 
-	w = GETCHWID ("show sub");
-	dlg->show_subprojects = GTK_CHECK_BUTTON(w);
+    w = GETCHWID("show sub");
+    dlg->show_subprojects = GTK_CHECK_BUTTON(w);
 }
 
-#define DLGWID(strname)					\
-	w = GETCHWID ("show " #strname);		\
-	dlg->show_title_##strname = GTK_CHECK_BUTTON(w);
+#define DLGWID(strname)             \
+    w = GETCHWID("show " #strname); \
+    dlg->show_title_##strname = GTK_CHECK_BUTTON(w);
 
-
-static void
-field_options(PrefsDialog *dlg)
+static void field_options(PrefsDialog *dlg)
 {
-	GtkWidget *w;
-	GladeXML *gtxml = dlg->gtxml;
+    GtkWidget *w;
+    GladeXML *gtxml = dlg->gtxml;
 
-	DLGWID (importance);
-	DLGWID (urgency);
-	DLGWID (status);
-	DLGWID (ever);
-	DLGWID (year);
-	DLGWID (month);
-	DLGWID (week);
-	DLGWID (lastweek);
-	DLGWID (day);
-	DLGWID (yesterday);
-	DLGWID (current);
-	DLGWID (desc);
-	DLGWID (task);
-	DLGWID (estimated_start);
-	DLGWID (estimated_end);
-	DLGWID (due_date);
-	DLGWID (sizing);
-	DLGWID (percent_complete);
+    DLGWID(importance);
+    DLGWID(urgency);
+    DLGWID(status);
+    DLGWID(ever);
+    DLGWID(year);
+    DLGWID(month);
+    DLGWID(week);
+    DLGWID(lastweek);
+    DLGWID(day);
+    DLGWID(yesterday);
+    DLGWID(current);
+    DLGWID(desc);
+    DLGWID(task);
+    DLGWID(estimated_start);
+    DLGWID(estimated_end);
+    DLGWID(due_date);
+    DLGWID(sizing);
+    DLGWID(percent_complete);
 }
 
-
-static void
-shell_command_options (PrefsDialog *dlg)
+static void shell_command_options(PrefsDialog *dlg)
 {
-	GtkWidget *e;
-	GladeXML *gtxml = dlg->gtxml;
+    GtkWidget *e;
+    GladeXML *gtxml = dlg->gtxml;
 
-	e = GETWID ("start project");
-	dlg->shell_start = GTK_ENTRY(e);
+    e = GETWID("start project");
+    dlg->shell_start = GTK_ENTRY(e);
 
-	e = GETWID ("stop project");
-	dlg->shell_stop = GTK_ENTRY(e);
+    e = GETWID("stop project");
+    dlg->shell_stop = GTK_ENTRY(e);
 }
 
-static void
-logfile_options(PrefsDialog *dlg)
+static void logfile_options(PrefsDialog *dlg)
 {
-	GtkWidget *w;
-	GladeXML *gtxml = dlg->gtxml;
+    GtkWidget *w;
+    GladeXML *gtxml = dlg->gtxml;
 
-	w = GETCHWID ("use logfile");
-	dlg->logfileuse = GTK_CHECK_BUTTON(w);
-	gtk_signal_connect(GTK_OBJECT(w), "clicked",
-		   GTK_SIGNAL_FUNC(logfile_sensitive_cb),
-		   (gpointer *)dlg);
+    w = GETCHWID("use logfile");
+    dlg->logfileuse = GTK_CHECK_BUTTON(w);
+    gtk_signal_connect(
+        GTK_OBJECT(w), "clicked", GTK_SIGNAL_FUNC(logfile_sensitive_cb), (gpointer *) dlg
+    );
 
-	w = glade_xml_get_widget (gtxml, "filename label");
-	dlg->logfilename_l = w;
+    w = glade_xml_get_widget(gtxml, "filename label");
+    dlg->logfilename_l = w;
 
-	w = glade_xml_get_widget (gtxml, "logfile path");
-	dlg->logfilename = GTK_FILE_CHOOSER(w);
-	gtk_signal_connect_object (GTK_OBJECT (dlg->logfilename),
-							   "file-set",
-							   GTK_SIGNAL_FUNC (gnome_property_box_changed),
-							   GTK_OBJECT (dlg->dlg));
+    w = glade_xml_get_widget(gtxml, "logfile path");
+    dlg->logfilename = GTK_FILE_CHOOSER(w);
+    gtk_signal_connect_object(
+        GTK_OBJECT(dlg->logfilename), "file-set", GTK_SIGNAL_FUNC(gnome_property_box_changed),
+        GTK_OBJECT(dlg->dlg)
+    );
 
-	w = glade_xml_get_widget (gtxml, "fstart label");
-	dlg->logfilestart_l = w;
+    w = glade_xml_get_widget(gtxml, "fstart label");
+    dlg->logfilestart_l = w;
 
-	w = GETWID ("fstart");
-	dlg->logfilestart = GTK_ENTRY(w);
+    w = GETWID("fstart");
+    dlg->logfilestart = GTK_ENTRY(w);
 
-	w = glade_xml_get_widget (gtxml, "fstop label");
-	dlg->logfilestop_l = w;
+    w = glade_xml_get_widget(gtxml, "fstop label");
+    dlg->logfilestop_l = w;
 
-	w = GETWID ("fstop");
-	dlg->logfilestop = GTK_ENTRY(w);
+    w = GETWID("fstop");
+    dlg->logfilestop = GTK_ENTRY(w);
 
-	w = glade_xml_get_widget (gtxml, "fmin label");
-	dlg->logfileminsecs_l = w;
+    w = glade_xml_get_widget(gtxml, "fmin label");
+    dlg->logfileminsecs_l = w;
 
-	w = GETWID ("fmin");
-	dlg->logfileminsecs = GTK_ENTRY(w);
+    w = GETWID("fmin");
+    dlg->logfileminsecs = GTK_ENTRY(w);
 }
 
-#define TBWID(strname)					\
-	w = GETCHWID ("show " #strname);		\
-	dlg->show_tb_##strname = GTK_CHECK_BUTTON(w);
+#define TBWID(strname)              \
+    w = GETCHWID("show " #strname); \
+    dlg->show_tb_##strname = GTK_CHECK_BUTTON(w);
 
-static void
-toolbar_options(PrefsDialog *dlg)
+static void toolbar_options(PrefsDialog *dlg)
 {
-	GtkWidget *w;
-	GladeXML *gtxml = dlg->gtxml;
+    GtkWidget *w;
+    GladeXML *gtxml = dlg->gtxml;
 
-	w = GETCHWID ("show toolbar");
-	dlg->show_toolbar = GTK_CHECK_BUTTON(w);
-	
-	gtk_signal_connect(GTK_OBJECT(w), "clicked",
-		   GTK_SIGNAL_FUNC(toolbar_sensitive_cb),
-		   (gpointer *)dlg);
-	
-	TBWID (tips);
-	TBWID (new);
-	TBWID (ccp);
-	TBWID (journal);
-	TBWID (prop);
-	TBWID (timer);
-	TBWID (pref);
-	TBWID (help);
-	TBWID (exit);
+    w = GETCHWID("show toolbar");
+    dlg->show_toolbar = GTK_CHECK_BUTTON(w);
+
+    gtk_signal_connect(
+        GTK_OBJECT(w), "clicked", GTK_SIGNAL_FUNC(toolbar_sensitive_cb), (gpointer *) dlg
+    );
+
+    TBWID(tips);
+    TBWID(new);
+    TBWID(ccp);
+    TBWID(journal);
+    TBWID(prop);
+    TBWID(timer);
+    TBWID(pref);
+    TBWID(help);
+    TBWID(exit);
 }
 
-static void
-misc_options(PrefsDialog *dlg)
+static void misc_options(PrefsDialog *dlg)
 {
-	GtkWidget *w;
-	GladeXML *gtxml = dlg->gtxml;
+    GtkWidget *w;
+    GladeXML *gtxml = dlg->gtxml;
 
-	w = GETWID ("idle secs");
-	dlg->idle_secs = GTK_ENTRY(w);
-	
-	w = GETWID ("no project secs");
-	dlg->no_project_secs = GTK_ENTRY(w);
+    w = GETWID("idle secs");
+    dlg->idle_secs = GTK_ENTRY(w);
 
-	w = GETWID ("daystart entry");
-	dlg->daystart_secs = GTK_ENTRY(w);
+    w = GETWID("no project secs");
+    dlg->no_project_secs = GTK_ENTRY(w);
 
-	w = GETWID ("daystart combobox");
-	dlg->daystart_menu = GTK_COMBO_BOX(w);
+    w = GETWID("daystart entry");
+    dlg->daystart_secs = GTK_ENTRY(w);
 
-	gtk_signal_connect_object(GTK_OBJECT(w), "changed",
-	                  GTK_SIGNAL_FUNC(daystart_menu_changed),
-	                  dlg);
+    w = GETWID("daystart combobox");
+    dlg->daystart_menu = GTK_COMBO_BOX(w);
 
-	w = GETWID ("weekstart combobox");
-	dlg->weekstart_menu = GTK_COMBO_BOX(w);
+    gtk_signal_connect_object(
+        GTK_OBJECT(w), "changed", GTK_SIGNAL_FUNC(daystart_menu_changed), dlg
+    );
+
+    w = GETWID("weekstart combobox");
+    dlg->weekstart_menu = GTK_COMBO_BOX(w);
 }
 
-static void
-time_format_options(PrefsDialog *dlg)
+static void time_format_options(PrefsDialog *dlg)
 {
-	GtkWidget *w;
-	GladeXML *gtxml = dlg->gtxml;
+    GtkWidget *w;
+    GladeXML *gtxml = dlg->gtxml;
 
-	w = GETCHWID("time_format_am_pm");
-	dlg->time_format_am_pm = GTK_RADIO_BUTTON(w);
+    w = GETCHWID("time_format_am_pm");
+    dlg->time_format_am_pm = GTK_RADIO_BUTTON(w);
 
-	w = GETCHWID("time_format_24_hs");
-	dlg->time_format_24_hs = GTK_RADIO_BUTTON(w);
+    w = GETCHWID("time_format_24_hs");
+    dlg->time_format_24_hs = GTK_RADIO_BUTTON(w);
 
-	w = GETCHWID("time_format_locale");
-	dlg->time_format_locale = GTK_RADIO_BUTTON(w);
+    w = GETCHWID("time_format_locale");
+    dlg->time_format_locale = GTK_RADIO_BUTTON(w);
 }
 
-static void
-currency_options(PrefsDialog *dlg)
+static void currency_options(PrefsDialog *dlg)
 {
-	GtkWidget *w;
-	GladeXML *gtxml = dlg->gtxml;
+    GtkWidget *w;
+    GladeXML *gtxml = dlg->gtxml;
 
-	w = GETWID ("currency_symbol");
-	dlg->currency_symbol = GTK_ENTRY(w);
+    w = GETWID("currency_symbol");
+    dlg->currency_symbol = GTK_ENTRY(w);
 
-	w = glade_xml_get_widget (gtxml, "currency_symbol_label");
-	dlg->currency_symbol_label = w;
+    w = glade_xml_get_widget(gtxml, "currency_symbol_label");
+    dlg->currency_symbol_label = w;
 
-	w = GETCHWID ("currency_use_locale");
-	dlg->currency_use_locale = GTK_CHECK_BUTTON(w);
+    w = GETCHWID("currency_use_locale");
+    dlg->currency_use_locale = GTK_CHECK_BUTTON(w);
 
-	gtk_signal_connect(GTK_OBJECT(w), "clicked",
-	                   GTK_SIGNAL_FUNC(currency_sensitive_cb),
-	                   (gpointer *)dlg);
+    gtk_signal_connect(
+        GTK_OBJECT(w), "clicked", GTK_SIGNAL_FUNC(currency_sensitive_cb), (gpointer *) dlg
+    );
 }
 
 /* ============================================================== */
 
-static void
-help_cb (GnomePropertyBox *propertybox, gint page_num, gpointer data)
+static void help_cb(GnomePropertyBox *propertybox, gint page_num, gpointer data)
 {
-	gtt_help_popup (GTK_WIDGET(propertybox), data);
+    gtt_help_popup(GTK_WIDGET(propertybox), data);
 }
 
-static PrefsDialog *
-prefs_dialog_new (void)
+static PrefsDialog *prefs_dialog_new(void)
 {
-	PrefsDialog *dlg;
-	GladeXML *gtxml;
+    PrefsDialog *dlg;
+    GladeXML *gtxml;
 
-	dlg = g_malloc(sizeof(PrefsDialog));
+    dlg = g_malloc(sizeof(PrefsDialog));
 
-	gtxml = gtt_glade_xml_new ("glade/prefs.glade", "Global Preferences");
-	dlg->gtxml = gtxml;
+    gtxml = gtt_glade_xml_new("glade/prefs.glade", "Global Preferences");
+    dlg->gtxml = gtxml;
 
-	dlg->dlg = GNOME_PROPERTY_BOX (glade_xml_get_widget (gtxml,  "Global Preferences"));
+    dlg->dlg = GNOME_PROPERTY_BOX(glade_xml_get_widget(gtxml, "Global Preferences"));
 
-	gtk_signal_connect(GTK_OBJECT(dlg->dlg), "help",
-			   GTK_SIGNAL_FUNC(help_cb),
-			   "preferences");
+    gtk_signal_connect(GTK_OBJECT(dlg->dlg), "help", GTK_SIGNAL_FUNC(help_cb), "preferences");
 
-	gtk_signal_connect(GTK_OBJECT(dlg->dlg), "apply",
-			   GTK_SIGNAL_FUNC(prefs_set), dlg);
+    gtk_signal_connect(GTK_OBJECT(dlg->dlg), "apply", GTK_SIGNAL_FUNC(prefs_set), dlg);
 
-	/* ------------------------------------------------------ */
-	/* grab the various entry boxes and hook them up */
-	display_options (dlg);
-	field_options (dlg);
-	shell_command_options (dlg);
-	logfile_options (dlg);
-	toolbar_options (dlg);
-	misc_options (dlg);
-	time_format_options (dlg);
-	currency_options (dlg);
+    /* ------------------------------------------------------ */
+    /* grab the various entry boxes and hook them up */
+    display_options(dlg);
+    field_options(dlg);
+    shell_command_options(dlg);
+    logfile_options(dlg);
+    toolbar_options(dlg);
+    misc_options(dlg);
+    time_format_options(dlg);
+    currency_options(dlg);
 
-	gnome_dialog_close_hides(GNOME_DIALOG(dlg->dlg), TRUE);
-	return dlg;
+    gnome_dialog_close_hides(GNOME_DIALOG(dlg->dlg), TRUE);
+    return dlg;
 }
-
 
 /* ============================================================== */
 
 static PrefsDialog *dlog = NULL;
 
-void
-prefs_dialog_show(void)
+void prefs_dialog_show(void)
 {
-	if (!dlog) dlog = prefs_dialog_new();
+    if (!dlog)
+        dlog = prefs_dialog_new();
 
-	options_dialog_set (dlog);
-	gtk_widget_show(GTK_WIDGET(dlog->dlg));
+    options_dialog_set(dlog);
+    gtk_widget_show(GTK_WIDGET(dlog->dlg));
 }
 
 /* ==================== END OF FILE ============================= */

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -16,10 +16,8 @@
  *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-
 #ifndef __GLOBAL_PREFS_H__
 #define __GLOBAL_PREFS_H__
-
 
 extern int config_show_secs;
 extern int config_show_statusbar;
@@ -71,18 +69,18 @@ extern int config_weekstart_offset;
 extern int config_time_format;
 
 extern char *config_currency_symbol;
-extern int  config_currency_use_locale;
-#define TIME_FORMAT_AM_PM  1
-#define TIME_FORMAT_24_HS  2
+extern int config_currency_use_locale;
+#define TIME_FORMAT_AM_PM 1
+#define TIME_FORMAT_24_HS 2
 #define TIME_FORMAT_LOCALE 3
 
 /* Pop up a dialog box for setting user preferences */
-void prefs_dialog_show (void);
+void prefs_dialog_show(void);
 
 /* update the list of visible columns in the main projects tree based
    on current user preference */
-void prefs_update_projects_view_columns (void);
-void prefs_update_projects_view (void);
-void prefs_set_show_secs (void);
+void prefs_update_projects_view_columns(void);
+void prefs_update_projects_view(void);
+void prefs_set_show_secs(void);
 
 #endif /* __GLOBAL_PREFS_H__ */

--- a/src/proj-query.c
+++ b/src/proj-query.c
@@ -21,20 +21,19 @@
 #include <glib.h>
 
 #include "cur-proj.h"
-#include "proj.h"
 #include "proj-query.h"
+#include "proj.h"
 
 /* =========================================================== */
 
-GList *
-gtt_project_get_unfinished (void)
+GList *gtt_project_get_unfinished(void)
 {
-	GList *prjlist;
+    GList *prjlist;
 
-	/* XXX under construction */
-	prjlist = gtt_project_list_get_list (master_list);
+    /* XXX under construction */
+    prjlist = gtt_project_list_get_list(master_list);
 
-	return prjlist;
+    return prjlist;
 }
 
 /* =========================== END OF FILE ========================= */

--- a/src/proj-query.h
+++ b/src/proj-query.h
@@ -19,8 +19,8 @@
 #ifndef __GTT_PROJ_QUERY_H__
 #define __GTT_PROJ_QUERY_H__
 
-#include <glib.h>
 #include "proj.h"
+#include <glib.h>
 
 /* This file contains routines that return various info about
  * the data in the system.  In some fancier world, these would
@@ -32,13 +32,12 @@
  * future.)
  */
 
-
 /* The gtt_project_get_unfinished() routine returns a list
  *    of projects that are not marked as 'completed' or
  *    'cancelled'.  The returned list is a flat list, not
  *    a heirarchical list.
  */
 
-GList * gtt_project_get_unfinished (void);
+GList *gtt_project_get_unfinished(void);
 
 #endif /* __GTT_PROJ_QUERY_H__ */

--- a/src/proj.c
+++ b/src/proj.c
@@ -21,26 +21,26 @@
 
 #include <glib.h>
 #include <libintl.h> /*conflicts with <libgnome/gnome-i18n.h> on some systems */
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <qof.h>
 
 #include "err-throw.h"
 #include "log.h"
-#include "prefs.h"  /* XXX tmp hack for config_* */
+#include "prefs.h" /* XXX tmp hack for config_* */
 #include "proj.h"
 #include "proj_p.h"
-#include "query.h"  /* temp hack for query */
+#include "query.h" /* temp hack for query */
 
 #define _(X) gettext(X)
 
 /* XXX replace this notifier by GObject signals someday */
 typedef struct notif_s
 {
-	GttProjectChanged func;
-	gpointer user_data;
+    GttProjectChanged func;
+    gpointer user_data;
 } Notifier;
 
 /* hack alert -- plist should be made to belong to a book
@@ -48,1269 +48,1265 @@ typedef struct notif_s
  * there's only one global list, and tha is bad and broken. But
  * there it is.
  */
-GttProjectList * global_plist = NULL;
+GttProjectList *global_plist = NULL;
 
 QofBook *global_book = NULL;
 
-static void proj_refresh_time (GttProject *proj);
-static void proj_modified (GttProject *proj);
-static int task_suspend (GttTask *tsk);
-static void gtt_interval_unhook (GttInterval * ivl);
+static void proj_refresh_time(GttProject *proj);
+static void proj_modified(GttProject *proj);
+static int task_suspend(GttTask *tsk);
+static void gtt_interval_unhook(GttInterval *ivl);
 
 /* ============================================================= */
 
 static int next_free_id = 1;
 
-GttProject *
-gtt_project_new(void)
+GttProject *gtt_project_new(void)
 {
-	GttProject *proj;
+    GttProject *proj;
 
-	proj = g_new0(GttProject, 1);
-	proj->title = g_strdup ("");
-	proj->desc = g_strdup ("");
-	proj->notes = g_strdup ("");
-	proj->custid = NULL;
+    proj = g_new0(GttProject, 1);
+    proj->title = g_strdup("");
+    proj->desc = g_strdup("");
+    proj->notes = g_strdup("");
+    proj->custid = NULL;
 
-	proj->min_interval = 3;
-	proj->auto_merge_interval = 60;
-	proj->auto_merge_gap = 60;
+    proj->min_interval = 3;
+    proj->auto_merge_interval = 60;
+    proj->auto_merge_gap = 60;
 
-	proj->billrate = 10.0;
-	proj->overtime_rate = 15.0;
-	proj->overover_rate = 20.0;
-	proj->flat_fee = 1000.0;
+    proj->billrate = 10.0;
+    proj->overtime_rate = 15.0;
+    proj->overover_rate = 20.0;
+    proj->flat_fee = 1000.0;
 
-	proj->estimated_start = -1;
-	proj->estimated_end = -1;
-	proj->due_date = -1;
-	proj->sizing = 0;
-	proj->percent_complete = 0;
-	proj->urgency = GTT_UNDEFINED;
-	proj->importance = GTT_UNDEFINED;
-	proj->status = GTT_NOT_STARTED;
+    proj->estimated_start = -1;
+    proj->estimated_end = -1;
+    proj->due_date = -1;
+    proj->sizing = 0;
+    proj->percent_complete = 0;
+    proj->urgency = GTT_UNDEFINED;
+    proj->importance = GTT_UNDEFINED;
+    proj->status = GTT_NOT_STARTED;
 
-	proj->task_list = NULL;
-	proj->sub_projects = NULL;
-	proj->parent = NULL;
-	proj->listeners = NULL;
-	proj->private_data = NULL;
+    proj->task_list = NULL;
+    proj->sub_projects = NULL;
+    proj->parent = NULL;
+    proj->listeners = NULL;
+    proj->private_data = NULL;
 
-	proj->being_destroyed = FALSE;
-	proj->frozen = FALSE;
-	proj->dirty_time = FALSE;
+    proj->being_destroyed = FALSE;
+    proj->frozen = FALSE;
+    proj->dirty_time = FALSE;
 
-	proj->secs_ever = 0;
-	proj->secs_day = 0;
-	proj->secs_yesterday = 0;
-	proj->secs_week = 0;
-	proj->secs_lastweek = 0;
-	proj->secs_month = 0;
-	proj->secs_year = 0;
+    proj->secs_ever = 0;
+    proj->secs_day = 0;
+    proj->secs_yesterday = 0;
+    proj->secs_week = 0;
+    proj->secs_lastweek = 0;
+    proj->secs_month = 0;
+    proj->secs_year = 0;
 
-	proj->id = next_free_id;
-	next_free_id ++;
+    proj->id = next_free_id;
+    next_free_id++;
 
-	qof_instance_init (&proj->inst, GTT_PROJECT_ID, global_book);
-	return proj;
+    qof_instance_init(&proj->inst, GTT_PROJECT_ID, global_book);
+    return proj;
 }
 
-
-GttProject *
-gtt_project_new_title_desc(const char *t, const char *d)
+GttProject *gtt_project_new_title_desc(const char *t, const char *d)
 {
-	GttProject *proj;
+    GttProject *proj;
 
-	proj = gtt_project_new();
-	if (t) { g_free(proj->title); proj->title = g_strdup (t); }
-	if (d) { g_free(proj->desc); proj->desc = g_strdup (d); }
-	return proj;
+    proj = gtt_project_new();
+    if (t)
+    {
+        g_free(proj->title);
+        proj->title = g_strdup(t);
+    }
+    if (d)
+    {
+        g_free(proj->desc);
+        proj->desc = g_strdup(d);
+    }
+    return proj;
 }
 
-
-
-GttProject *
-gtt_project_dup(GttProject *proj)
+GttProject *gtt_project_dup(GttProject *proj)
 {
-	GList *node;
-	GttProject *p;
+    GList *node;
+    GttProject *p;
 
-	if (!proj) return NULL;
-	p = gtt_project_new();
+    if (!proj)
+        return NULL;
+    p = gtt_project_new();
 
-	g_free(p->title);
-	g_free(p->desc);
-	g_free(p->notes);
+    g_free(p->title);
+    g_free(p->desc);
+    g_free(p->notes);
 
-	p->title = g_strdup(proj->title);
-	p->desc = g_strdup(proj->desc);
-	p->notes = g_strdup(proj->notes);
-	if (proj->custid) p->custid = g_strdup(proj->custid);
+    p->title = g_strdup(proj->title);
+    p->desc = g_strdup(proj->desc);
+    p->notes = g_strdup(proj->notes);
+    if (proj->custid)
+        p->custid = g_strdup(proj->custid);
 
-	p->min_interval = proj->min_interval;
-	p->auto_merge_interval = proj->auto_merge_interval;
-	p->auto_merge_gap = proj->auto_merge_gap;
+    p->min_interval = proj->min_interval;
+    p->auto_merge_interval = proj->auto_merge_interval;
+    p->auto_merge_gap = proj->auto_merge_gap;
 
-	p->billrate = proj->billrate;
-	p->overtime_rate = proj->overtime_rate;
-	p->overover_rate = proj->overover_rate;
-	p->flat_fee = proj->flat_fee;
+    p->billrate = proj->billrate;
+    p->overtime_rate = proj->overtime_rate;
+    p->overover_rate = proj->overover_rate;
+    p->flat_fee = proj->flat_fee;
 
-	p->estimated_start = proj->estimated_start;
-	p->estimated_end = proj->estimated_end;
-	p->due_date = proj->due_date;
-	p->sizing = proj->sizing;
-	p->percent_complete = proj->percent_complete;
-	p->urgency = proj->urgency;
-	p->importance = proj->importance;
-	p->status = proj->status;
+    p->estimated_start = proj->estimated_start;
+    p->estimated_end = proj->estimated_end;
+    p->due_date = proj->due_date;
+    p->sizing = proj->sizing;
+    p->percent_complete = proj->percent_complete;
+    p->urgency = proj->urgency;
+    p->importance = proj->importance;
+    p->status = proj->status;
 
+    /* Don't copy the tasks.  Do copy the sub-projects */
+    for (node = proj->sub_projects; node; node = node->next)
+    {
+        GttProject *sub = node->data;
+        sub = gtt_project_dup(sub);
+        gtt_project_append_project(p, sub);
+    }
 
-	/* Don't copy the tasks.  Do copy the sub-projects */
-	for (node=proj->sub_projects; node; node=node->next)
-	{
-		GttProject *sub = node->data;
-		sub = gtt_project_dup (sub);
-		gtt_project_append_project (p, sub);
-	}
-
-	p->sub_projects = NULL;
-	return p;
+    p->sub_projects = NULL;
+    return p;
 }
-
 
 /* remove the project from any lists, etc. */
-void
-gtt_project_remove(GttProject *p)
+void gtt_project_remove(GttProject *p)
 {
-	/* if we are in someone elses list, remove */
-	if (p->parent)
-	{
-		p->parent->sub_projects =
-			g_list_remove (p->parent->sub_projects, p);
-		p->parent = NULL;
-	}
-	else
-	{
-		/* else we are in the master list ... remove */
-		global_plist->prj_list = g_list_remove(global_plist->prj_list, p);
-	}
+    /* if we are in someone elses list, remove */
+    if (p->parent)
+    {
+        p->parent->sub_projects = g_list_remove(p->parent->sub_projects, p);
+        p->parent = NULL;
+    }
+    else
+    {
+        /* else we are in the master list ... remove */
+        global_plist->prj_list = g_list_remove(global_plist->prj_list, p);
+    }
 }
 
-
-void
-gtt_project_destroy(GttProject *proj)
+void gtt_project_destroy(GttProject *proj)
 {
-	if (!proj) return;
+    if (!proj)
+        return;
 
-	proj->being_destroyed = TRUE;
-	gtt_project_remove(proj);
+    proj->being_destroyed = TRUE;
+    gtt_project_remove(proj);
 
-	if (proj->title) g_free(proj->title);
-	proj->title = NULL;
+    if (proj->title)
+        g_free(proj->title);
+    proj->title = NULL;
 
-	if (proj->desc) g_free(proj->desc);
-	proj->desc = NULL;
+    if (proj->desc)
+        g_free(proj->desc);
+    proj->desc = NULL;
 
-	if (proj->notes) g_free(proj->desc);
-	proj->notes = NULL;
+    if (proj->notes)
+        g_free(proj->desc);
+    proj->notes = NULL;
 
-	if (proj->custid) g_free(proj->custid);
-	proj->custid = NULL;
+    if (proj->custid)
+        g_free(proj->custid);
+    proj->custid = NULL;
 
-	if (proj->task_list)
-	{
-		while (proj->task_list)
-		{
-			/* destroying a task pops it off the list */
-			gtt_task_destroy (proj->task_list->data);
-		}
-	}
-	proj->task_list = NULL;
+    if (proj->task_list)
+    {
+        while (proj->task_list)
+        {
+            /* destroying a task pops it off the list */
+            gtt_task_destroy(proj->task_list->data);
+        }
+    }
+    proj->task_list = NULL;
 
-	if (proj->sub_projects)
-	{
-		while (proj->sub_projects)
-		{
-			/* destroying a sub-project pops it off the list */
-			gtt_project_destroy (proj->sub_projects->data);
-		}
-	}
+    if (proj->sub_projects)
+    {
+        while (proj->sub_projects)
+        {
+            /* destroying a sub-project pops it off the list */
+            gtt_project_destroy(proj->sub_projects->data);
+        }
+    }
 
-	/* remove notifiers as well */
-	{
-		Notifier * ntf;
-		GList *node;
+    /* remove notifiers as well */
+    {
+        Notifier *ntf;
+        GList *node;
 
-		for (node = proj->listeners; node; node=node->next)
-		{
-			ntf = node->data;
-			g_free (ntf);
-		}
-		if (proj->listeners) g_list_free (proj->listeners);
-	}
-	proj->private_data = NULL;
-	g_free(proj);
+        for (node = proj->listeners; node; node = node->next)
+        {
+            ntf = node->data;
+            g_free(ntf);
+        }
+        if (proj->listeners)
+            g_list_free(proj->listeners);
+    }
+    proj->private_data = NULL;
+    g_free(proj);
 }
 
-void
-gtt_project_set_guid (GttProject *prj, const GUID *guid)
+void gtt_project_set_guid(GttProject *prj, const GUID *guid)
 {
-	qof_entity_set_guid (&prj->inst.entity, guid);
+    qof_entity_set_guid(&prj->inst.entity, guid);
 }
 
-
-const GUID *
-gtt_project_get_guid (GttProject *prj)
+const GUID *gtt_project_get_guid(GttProject *prj)
 {
-	return qof_entity_get_guid (&prj->inst.entity);
+    return qof_entity_get_guid(&prj->inst.entity);
 }
 
 /* ========================================================= */
 /* set/get project titles and descriptions */
 
-void
-gtt_project_set_title(GttProject *proj, const char *t)
+void gtt_project_set_title(GttProject *proj, const char *t)
 {
-	if (!proj) return;
-	if (proj->title) g_free(proj->title);
-	if (!t)
-	{
-		proj->title = g_strdup ("");
-		return;
-	}
-	proj->title = g_strdup(t);
-	proj_modified (proj);
+    if (!proj)
+        return;
+    if (proj->title)
+        g_free(proj->title);
+    if (!t)
+    {
+        proj->title = g_strdup("");
+        return;
+    }
+    proj->title = g_strdup(t);
+    proj_modified(proj);
 }
 
-
-
-void
-gtt_project_set_desc(GttProject *proj, const char *d)
+void gtt_project_set_desc(GttProject *proj, const char *d)
 {
-	if (!proj) return;
-	if (proj->desc) g_free(proj->desc);
-	if (!d)
-	{
-		proj->desc = g_strdup ("");
-		return;
-	}
-	proj->desc = g_strdup(d);
-	proj_modified (proj);
+    if (!proj)
+        return;
+    if (proj->desc)
+        g_free(proj->desc);
+    if (!d)
+    {
+        proj->desc = g_strdup("");
+        return;
+    }
+    proj->desc = g_strdup(d);
+    proj_modified(proj);
 }
 
-void
-gtt_project_set_notes(GttProject *proj, const char *d)
+void gtt_project_set_notes(GttProject *proj, const char *d)
 {
-	if (!proj) return;
-	if (proj->notes) g_free(proj->notes);
-	if (!d) {
-		proj->notes = g_strdup ("");
-		return;
-	}
-	proj->notes = g_strdup(d);
-	proj_modified (proj);
+    if (!proj)
+        return;
+    if (proj->notes)
+        g_free(proj->notes);
+    if (!d)
+    {
+        proj->notes = g_strdup("");
+        return;
+    }
+    proj->notes = g_strdup(d);
+    proj_modified(proj);
 }
 
-void
-gtt_project_set_custid(GttProject *proj, const char *d)
+void gtt_project_set_custid(GttProject *proj, const char *d)
 {
-	if (!proj) return;
-	if (proj->custid) g_free(proj->custid);
-	if (!d)
-	{
-		proj->custid = NULL;
-		return;
-	}
-	proj->custid = g_strdup(d);
-	proj_modified (proj);
+    if (!proj)
+        return;
+    if (proj->custid)
+        g_free(proj->custid);
+    if (!d)
+    {
+        proj->custid = NULL;
+        return;
+    }
+    proj->custid = g_strdup(d);
+    proj_modified(proj);
 }
 
-const char *
-gtt_project_get_title (GttProject *proj)
+const char *gtt_project_get_title(GttProject *proj)
 {
-	if (!proj) return NULL;
-	return (proj->title);
+    if (!proj)
+        return NULL;
+    return (proj->title);
 }
 
-const char *
-gtt_project_get_desc (GttProject *proj)
+const char *gtt_project_get_desc(GttProject *proj)
 {
-	if (!proj) return NULL;
-	return (proj->desc);
+    if (!proj)
+        return NULL;
+    return (proj->desc);
 }
 
-const char *
-gtt_project_get_notes (GttProject *proj)
+const char *gtt_project_get_notes(GttProject *proj)
 {
-	if (!proj) return NULL;
-	return (proj->notes);
+    if (!proj)
+        return NULL;
+    return (proj->notes);
 }
 
-const char *
-gtt_project_get_custid (GttProject *proj)
+const char *gtt_project_get_custid(GttProject *proj)
 {
-	if (!proj) return NULL;
-	return (proj->custid);
+    if (!proj)
+        return NULL;
+    return (proj->custid);
 }
 
-void
-gtt_project_set_billrate (GttProject *proj, double r)
+void gtt_project_set_billrate(GttProject *proj, double r)
 {
-	if (!proj) return;
-	proj->billrate = r;
-	proj_modified (proj);
+    if (!proj)
+        return;
+    proj->billrate = r;
+    proj_modified(proj);
 }
 
-double
-gtt_project_get_billrate (GttProject *proj)
+double gtt_project_get_billrate(GttProject *proj)
 {
-	if (!proj) return 0.0;
-	return proj->billrate;
+    if (!proj)
+        return 0.0;
+    return proj->billrate;
 }
 
-void
-gtt_project_set_overtime_rate (GttProject *proj, double r)
+void gtt_project_set_overtime_rate(GttProject *proj, double r)
 {
-	if (!proj) return;
-	proj->overtime_rate = r;
-	proj_modified (proj);
+    if (!proj)
+        return;
+    proj->overtime_rate = r;
+    proj_modified(proj);
 }
 
-double
-gtt_project_get_overtime_rate (GttProject *proj)
+double gtt_project_get_overtime_rate(GttProject *proj)
 {
-	if (!proj) return 0.0;
-	return proj->overtime_rate;
+    if (!proj)
+        return 0.0;
+    return proj->overtime_rate;
 }
 
-void
-gtt_project_set_overover_rate (GttProject *proj, double r)
+void gtt_project_set_overover_rate(GttProject *proj, double r)
 {
-	if (!proj) return;
-	proj->overover_rate = r;
-	proj_modified (proj);
+    if (!proj)
+        return;
+    proj->overover_rate = r;
+    proj_modified(proj);
 }
 
-double
-gtt_project_get_overover_rate (GttProject *proj)
+double gtt_project_get_overover_rate(GttProject *proj)
 {
-	if (!proj) return 0.0;
-	return proj->overover_rate;
+    if (!proj)
+        return 0.0;
+    return proj->overover_rate;
 }
 
-void
-gtt_project_set_flat_fee (GttProject *proj, double r)
+void gtt_project_set_flat_fee(GttProject *proj, double r)
 {
-	if (!proj) return;
-	proj->flat_fee = r;
-	proj_modified (proj);
+    if (!proj)
+        return;
+    proj->flat_fee = r;
+    proj_modified(proj);
 }
 
-double
-gtt_project_get_flat_fee (GttProject *proj)
+double gtt_project_get_flat_fee(GttProject *proj)
 {
-	if (!proj) return 0.0;
-	return proj->flat_fee;
+    if (!proj)
+        return 0.0;
+    return proj->flat_fee;
 }
 
-void
-gtt_project_set_min_interval (GttProject *proj, int r)
+void gtt_project_set_min_interval(GttProject *proj, int r)
 {
-	if (!proj) return;
-	proj->min_interval = r;
-	proj_modified (proj);
+    if (!proj)
+        return;
+    proj->min_interval = r;
+    proj_modified(proj);
 }
 
-int
-gtt_project_get_min_interval (GttProject *proj)
+int gtt_project_get_min_interval(GttProject *proj)
 {
-	if (!proj) return 3;
-	return proj->min_interval;
+    if (!proj)
+        return 3;
+    return proj->min_interval;
 }
 
-void
-gtt_project_set_auto_merge_interval (GttProject *proj, int r)
+void gtt_project_set_auto_merge_interval(GttProject *proj, int r)
 {
-	if (!proj) return;
-	proj->auto_merge_interval = r;
-	proj_modified (proj);
+    if (!proj)
+        return;
+    proj->auto_merge_interval = r;
+    proj_modified(proj);
 }
 
-int
-gtt_project_get_auto_merge_interval (GttProject *proj)
+int gtt_project_get_auto_merge_interval(GttProject *proj)
 {
-	if (!proj) return 0;
-	return proj->auto_merge_interval;
+    if (!proj)
+        return 0;
+    return proj->auto_merge_interval;
 }
 
-void
-gtt_project_set_auto_merge_gap (GttProject *proj, int r)
+void gtt_project_set_auto_merge_gap(GttProject *proj, int r)
 {
-	if (!proj) return;
-	proj->auto_merge_gap = r;
-	proj_modified (proj);
+    if (!proj)
+        return;
+    proj->auto_merge_gap = r;
+    proj_modified(proj);
 }
 
-int
-gtt_project_get_auto_merge_gap (GttProject *proj)
+int gtt_project_get_auto_merge_gap(GttProject *proj)
 {
-	if (!proj) return 0;
-	return proj->auto_merge_gap;
+    if (!proj)
+        return 0;
+    return proj->auto_merge_gap;
 }
 
-void
-gtt_project_set_private_data (GttProject *proj, gpointer data)
+void gtt_project_set_private_data(GttProject *proj, gpointer data)
 {
-	if (!proj) return;
-	proj->private_data = data;
+    if (!proj)
+        return;
+    proj->private_data = data;
 }
 
-gpointer
-gtt_project_get_private_data (GttProject *proj)
+gpointer gtt_project_get_private_data(GttProject *proj)
 {
-	if (!proj) return NULL;
-	return proj->private_data;
+    if (!proj)
+        return NULL;
+    return proj->private_data;
 }
 
-void
-gtt_project_set_estimated_start (GttProject *proj, time_t r)
+void gtt_project_set_estimated_start(GttProject *proj, time_t r)
 {
-	if (!proj) return;
-	proj->estimated_start = r;
-	proj_modified (proj);
+    if (!proj)
+        return;
+    proj->estimated_start = r;
+    proj_modified(proj);
 }
 
-time_t
-gtt_project_get_estimated_start (GttProject *proj)
+time_t gtt_project_get_estimated_start(GttProject *proj)
 {
-	if (!proj) return 0;
-	return proj->estimated_start;
+    if (!proj)
+        return 0;
+    return proj->estimated_start;
 }
 
-void
-gtt_project_set_estimated_end (GttProject *proj, time_t r)
+void gtt_project_set_estimated_end(GttProject *proj, time_t r)
 {
-	if (!proj) return;
-	proj->estimated_end = r;
-	proj_modified (proj);
+    if (!proj)
+        return;
+    proj->estimated_end = r;
+    proj_modified(proj);
 }
 
-time_t
-gtt_project_get_estimated_end (GttProject *proj)
+time_t gtt_project_get_estimated_end(GttProject *proj)
 {
-	if (!proj) return 0;
-	return proj->estimated_end;
+    if (!proj)
+        return 0;
+    return proj->estimated_end;
 }
 
-void
-gtt_project_set_due_date (GttProject *proj, time_t r)
+void gtt_project_set_due_date(GttProject *proj, time_t r)
 {
-	if (!proj) return;
-	proj->due_date = r;
-	proj_modified (proj);
+    if (!proj)
+        return;
+    proj->due_date = r;
+    proj_modified(proj);
 }
 
-time_t
-gtt_project_get_due_date (GttProject *proj)
+time_t gtt_project_get_due_date(GttProject *proj)
 {
-	if (!proj) return 0;
-	return proj->due_date;
+    if (!proj)
+        return 0;
+    return proj->due_date;
 }
 
-void
-gtt_project_set_sizing (GttProject *proj, int r)
+void gtt_project_set_sizing(GttProject *proj, int r)
 {
-	if (!proj) return;
-	proj->sizing = r;
-	proj_modified (proj);
+    if (!proj)
+        return;
+    proj->sizing = r;
+    proj_modified(proj);
 }
 
-int
-gtt_project_get_sizing (GttProject *proj)
+int gtt_project_get_sizing(GttProject *proj)
 {
-	if (!proj) return 0;
-	return proj->sizing;
+    if (!proj)
+        return 0;
+    return proj->sizing;
 }
 
-void
-gtt_project_set_percent_complete (GttProject *proj, int r)
+void gtt_project_set_percent_complete(GttProject *proj, int r)
 {
-	if (!proj) return;
-	if (0 > r) r = 0;
-	if (100 < r) r = 100;
-	proj->percent_complete = r;
-	proj_modified (proj);
+    if (!proj)
+        return;
+    if (0 > r)
+        r = 0;
+    if (100 < r)
+        r = 100;
+    proj->percent_complete = r;
+    proj_modified(proj);
 }
 
-int
-gtt_project_get_percent_complete (GttProject *proj)
+int gtt_project_get_percent_complete(GttProject *proj)
 {
-	if (!proj) return 0;
-	return proj->percent_complete;
+    if (!proj)
+        return 0;
+    return proj->percent_complete;
 }
 
-void
-gtt_project_set_urgency (GttProject *proj, GttRank r)
+void gtt_project_set_urgency(GttProject *proj, GttRank r)
 {
-	if (!proj) return;
-	proj->urgency = r;
-	proj_modified (proj);
+    if (!proj)
+        return;
+    proj->urgency = r;
+    proj_modified(proj);
 }
 
-GttRank
-gtt_project_get_urgency (GttProject *proj)
+GttRank gtt_project_get_urgency(GttProject *proj)
 {
-	if (!proj) return 0;
-	return proj->urgency;
+    if (!proj)
+        return 0;
+    return proj->urgency;
 }
 
-void
-gtt_project_set_importance (GttProject *proj, GttRank r)
+void gtt_project_set_importance(GttProject *proj, GttRank r)
 {
-	if (!proj) return;
-	proj->importance = r;
-	proj_modified (proj);
+    if (!proj)
+        return;
+    proj->importance = r;
+    proj_modified(proj);
 }
 
-GttRank
-gtt_project_get_importance (GttProject *proj)
+GttRank gtt_project_get_importance(GttProject *proj)
 {
-	if (!proj) return 0;
-	return proj->importance;
+    if (!proj)
+        return 0;
+    return proj->importance;
 }
 
-void
-gtt_project_set_status (GttProject *proj, GttProjectStatus r)
+void gtt_project_set_status(GttProject *proj, GttProjectStatus r)
 {
-	if (!proj) return;
-	proj->status = r;
-	proj_modified (proj);
+    if (!proj)
+        return;
+    proj->status = r;
+    proj_modified(proj);
 }
 
-GttProjectStatus
-gtt_project_get_status (GttProject *proj)
+GttProjectStatus gtt_project_get_status(GttProject *proj)
 {
-	if (!proj) return 0;
-	return proj->status;
+    if (!proj)
+        return 0;
+    return proj->status;
 }
 
 /* =========================================================== */
 
-void
-gtt_project_set_id (GttProject *proj, int new_id)
+void gtt_project_set_id(GttProject *proj, int new_id)
 {
-	if (!proj) return;
+    if (!proj)
+        return;
 
-	if (gtt_project_locate_from_id (new_id))
-	{
-		g_warning ("a project with id =%d already exists\n", new_id);
-	}
+    if (gtt_project_locate_from_id(new_id))
+    {
+        g_warning("a project with id =%d already exists\n", new_id);
+    }
 
-	/* We try to conserve id numbers by seeing if this was a fresh
-	 * project. Conserving numbers is good, since things are less
-	 * confusing when looking at the data. */
-	if ((proj->id+1) == next_free_id) next_free_id--;
+    /* We try to conserve id numbers by seeing if this was a fresh
+     * project. Conserving numbers is good, since things are less
+     * confusing when looking at the data. */
+    if ((proj->id + 1) == next_free_id)
+        next_free_id--;
 
-	proj->id = new_id;
-	if (new_id >= next_free_id) next_free_id = new_id + 1;
+    proj->id = new_id;
+    if (new_id >= next_free_id)
+        next_free_id = new_id + 1;
 }
 
-int
-gtt_project_get_id (GttProject *proj)
+int gtt_project_get_id(GttProject *proj)
 {
-	if (!proj) return -1;
-	return proj->id;
+    if (!proj)
+        return -1;
+    return proj->id;
 }
 
 /* =========================================================== */
 /* compatibility interface */
 
-static time_t
-get_midnight (time_t last)
+static time_t get_midnight(time_t last)
 {
-	struct tm lt;
-	time_t midnight;
+    struct tm lt;
+    time_t midnight;
 
-	if (0 >= last)
-	{
-		last = time(0);
-	}
+    if (0 >= last)
+    {
+        last = time(0);
+    }
 
-	/* If config_daystart_offset == 3*3600 then the new day
-	 * will start at 3AM, for example.  */
-	last -= config_daystart_offset;
+    /* If config_daystart_offset == 3*3600 then the new day
+     * will start at 3AM, for example.  */
+    last -= config_daystart_offset;
 
-	memcpy (&lt, localtime (&last), sizeof (struct tm));
-	lt.tm_sec = 0;
-	lt.tm_min = 0;
-	lt.tm_hour = 0;
-	midnight = mktime (&lt);
+    memcpy(&lt, localtime(&last), sizeof(struct tm));
+    lt.tm_sec = 0;
+    lt.tm_min = 0;
+    lt.tm_hour = 0;
+    midnight = mktime(&lt);
 
-	midnight += config_daystart_offset;
+    midnight += config_daystart_offset;
 
-	return midnight;
+    return midnight;
 }
 
-static time_t
-get_sunday (time_t last)
+static time_t get_sunday(time_t last)
 {
-	struct tm lt;
-	time_t sunday;
+    struct tm lt;
+    time_t sunday;
 
-	if (0 >= last)
-	{
-		last = time(0);
-	}
+    if (0 >= last)
+    {
+        last = time(0);
+    }
 
-	memcpy (&lt, localtime (&last), sizeof (struct tm));
-	lt.tm_sec = 0;
-	lt.tm_min = 0;
-	lt.tm_hour = 0;
-	lt.tm_mday -= lt.tm_wday;
-	sunday = mktime (&lt);
+    memcpy(&lt, localtime(&last), sizeof(struct tm));
+    lt.tm_sec = 0;
+    lt.tm_min = 0;
+    lt.tm_hour = 0;
+    lt.tm_mday -= lt.tm_wday;
+    sunday = mktime(&lt);
 
-	/* If config_weekstart_offset == 1 then a new week starts
-	 * on monday, not sunday. */
-	sunday += 24*3600* config_weekstart_offset + config_daystart_offset;
+    /* If config_weekstart_offset == 1 then a new week starts
+     * on monday, not sunday. */
+    sunday += 24 * 3600 * config_weekstart_offset + config_daystart_offset;
 
-	return sunday;
+    return sunday;
 }
 
-static time_t
-get_month (time_t last)
+static time_t get_month(time_t last)
 {
-	struct tm lt;
-	time_t first;
+    struct tm lt;
+    time_t first;
 
-	if (0 >= last)
-	{
-		last = time(0);
-	}
+    if (0 >= last)
+    {
+        last = time(0);
+    }
 
-	memcpy (&lt, localtime (&last), sizeof (struct tm));
-	lt.tm_sec = 0;
-	lt.tm_min = 0;
-	lt.tm_hour = 0;
-	lt.tm_mday = 1;
-	first = mktime (&lt);
+    memcpy(&lt, localtime(&last), sizeof(struct tm));
+    lt.tm_sec = 0;
+    lt.tm_min = 0;
+    lt.tm_hour = 0;
+    lt.tm_mday = 1;
+    first = mktime(&lt);
 
-	first += config_daystart_offset;
-	return first;
+    first += config_daystart_offset;
+    return first;
 }
 
-static time_t
-get_newyear (time_t last)
+static time_t get_newyear(time_t last)
 {
-	struct tm lt;
-	time_t newyear;
+    struct tm lt;
+    time_t newyear;
 
-	if (0 >= last)
-	{
-		last = time(0);
-	}
+    if (0 >= last)
+    {
+        last = time(0);
+    }
 
-	memcpy (&lt, localtime (&last), sizeof (struct tm));
-	lt.tm_sec = 0;
-	lt.tm_min = 0;
-	lt.tm_hour = 0;
-	lt.tm_mday -= lt.tm_yday;
-	newyear = mktime (&lt);
+    memcpy(&lt, localtime(&last), sizeof(struct tm));
+    lt.tm_sec = 0;
+    lt.tm_min = 0;
+    lt.tm_hour = 0;
+    lt.tm_mday -= lt.tm_yday;
+    newyear = mktime(&lt);
 
-	newyear += config_daystart_offset;
-	return newyear;
+    newyear += config_daystart_offset;
+    return newyear;
 }
 
-void
-gtt_project_compat_set_secs (GttProject *proj, int sever, int sday, time_t last)
+void gtt_project_compat_set_secs(GttProject *proj, int sever, int sday, time_t last)
 {
-	time_t midnight;
-	GttTask *tsk;
-	GttInterval *ivl;
+    time_t midnight;
+    GttTask *tsk;
+    GttInterval *ivl;
 
-	/* Get the midnight of the last update */
-	midnight = get_midnight (last);
+    /* Get the midnight of the last update */
+    midnight = get_midnight(last);
 
-	/* Old GTT data will just be one big interval
-	 * lumped under one task */
-	tsk = gtt_task_new ();
-	gtt_task_set_memo (tsk, _("Old GTT Tasks"));
+    /* Old GTT data will just be one big interval
+     * lumped under one task */
+    tsk = gtt_task_new();
+    gtt_task_set_memo(tsk, _("Old GTT Tasks"));
 
-	ivl = gtt_interval_new();
-	ivl->stop = midnight - 1;
-	ivl->start = midnight - 1 - sever + sday;
-	gtt_task_add_interval (tsk, ivl);
+    ivl = gtt_interval_new();
+    ivl->stop = midnight - 1;
+    ivl->start = midnight - 1 - sever + sday;
+    gtt_task_add_interval(tsk, ivl);
 
-	if (0 < sday)
-	{
-		ivl = gtt_interval_new();
-		ivl->start = midnight +1;
-		ivl->stop = midnight + sday + 1;
-		gtt_task_add_interval (tsk, ivl);
-	}
+    if (0 < sday)
+    {
+        ivl = gtt_interval_new();
+        ivl->start = midnight + 1;
+        ivl->stop = midnight + sday + 1;
+        gtt_task_add_interval(tsk, ivl);
+    }
 
-	gtt_project_append_task (proj, tsk);
+    gtt_project_append_task(proj, tsk);
 
-	/* All new data will get its own task */
-	tsk = gtt_task_new ();
-	gtt_task_set_memo (tsk, _("New Diary Entry"));
-	gtt_project_append_task (proj, tsk);
+    /* All new data will get its own task */
+    tsk = gtt_task_new();
+    gtt_task_set_memo(tsk, _("New Diary Entry"));
+    gtt_project_append_task(proj, tsk);
 
-	proj_refresh_time (proj);
+    proj_refresh_time(proj);
 }
 
 /* =========================================================== */
 /* add subprojects, tasks */
 
-void
-gtt_project_append_project (GttProject *proj, GttProject *child)
+void gtt_project_append_project(GttProject *proj, GttProject *child)
 {
-	if (!child) return;
-	gtt_project_remove(child);
-	if (!proj)
-	{
-		/* if no parent specified, put in top-level list */
-		gtt_project_list_append (global_plist, child);
-		return;
-	}
+    if (!child)
+        return;
+    gtt_project_remove(child);
+    if (!proj)
+    {
+        /* if no parent specified, put in top-level list */
+        gtt_project_list_append(global_plist, child);
+        return;
+    }
 
-	proj->sub_projects = g_list_append (proj->sub_projects, child);
-	child->parent = proj;
+    proj->sub_projects = g_list_append(proj->sub_projects, child);
+    child->parent = proj;
 }
 
-void
-gtt_project_insert_before(GttProject *p, GttProject *before_me)
+void gtt_project_insert_before(GttProject *p, GttProject *before_me)
 {
-	gint pos;
+    gint pos;
 
-	if (!p) return;
-	gtt_project_remove(p);
+    if (!p)
+        return;
+    gtt_project_remove(p);
 
-	/* no before ?? then append to master list */
-	if (!before_me)
-	{
-		global_plist->prj_list = g_list_append (global_plist->prj_list, p);
-		p->parent = NULL;
-		return;
-	}
-	else
-	{
-		if (!before_me->parent)
-		{
-			/* if before_me has no parent, then its in the
-			 * master list */
-			pos  = g_list_index (global_plist->prj_list, before_me);
+    /* no before ?? then append to master list */
+    if (!before_me)
+    {
+        global_plist->prj_list = g_list_append(global_plist->prj_list, p);
+        p->parent = NULL;
+        return;
+    }
+    else
+    {
+        if (!before_me->parent)
+        {
+            /* if before_me has no parent, then its in the
+             * master list */
+            pos = g_list_index(global_plist->prj_list, before_me);
 
-			/* this shouldn't happen ....node should be found */
-			if (0 > pos)
-			{
-				global_plist->prj_list = g_list_append (global_plist->prj_list, p);
-				p->parent = NULL;
-				return;
-			}
-			global_plist->prj_list = g_list_insert (global_plist->prj_list, p, pos);
-			p->parent = NULL;
-			return;
-		}
-		else
-		{
-			GList *sub;
-			sub = before_me->parent->sub_projects;
-			pos  = g_list_index (sub, before_me);
+            /* this shouldn't happen ....node should be found */
+            if (0 > pos)
+            {
+                global_plist->prj_list = g_list_append(global_plist->prj_list, p);
+                p->parent = NULL;
+                return;
+            }
+            global_plist->prj_list = g_list_insert(global_plist->prj_list, p, pos);
+            p->parent = NULL;
+            return;
+        }
+        else
+        {
+            GList *sub;
+            sub = before_me->parent->sub_projects;
+            pos = g_list_index(sub, before_me);
 
-			/* this shouldn't happen ....node should be found */
-			if (0 > pos)
-			{
-				sub = g_list_append (sub, p);
-				before_me->parent->sub_projects = sub;
-				p->parent = before_me->parent;
-				return;
-			}
-			sub = g_list_insert (sub, p, pos);
-			before_me->parent->sub_projects = sub;
-			p->parent = before_me->parent;
-			return;
-		}
-	}
+            /* this shouldn't happen ....node should be found */
+            if (0 > pos)
+            {
+                sub = g_list_append(sub, p);
+                before_me->parent->sub_projects = sub;
+                p->parent = before_me->parent;
+                return;
+            }
+            sub = g_list_insert(sub, p, pos);
+            before_me->parent->sub_projects = sub;
+            p->parent = before_me->parent;
+            return;
+        }
+    }
 }
 
-void
-gtt_project_insert_after(GttProject *p, GttProject *after_me)
+void gtt_project_insert_after(GttProject *p, GttProject *after_me)
 {
-	gint pos;
+    gint pos;
 
-	if (!p) return;
-	gtt_project_remove(p);
+    if (!p)
+        return;
+    gtt_project_remove(p);
 
-	/* no after ?? then prepend to master list */
-	if (!after_me)
-	{
-		global_plist->prj_list = g_list_prepend (global_plist->prj_list, p);
-		p->parent = NULL;
-		return;
-	}
-	else
-	{
-		if (!after_me->parent)
-		{
-			/* if after_me has no parent, then its in the
-			 * master list */
-			pos  = g_list_index (global_plist->prj_list, after_me);
+    /* no after ?? then prepend to master list */
+    if (!after_me)
+    {
+        global_plist->prj_list = g_list_prepend(global_plist->prj_list, p);
+        p->parent = NULL;
+        return;
+    }
+    else
+    {
+        if (!after_me->parent)
+        {
+            /* if after_me has no parent, then its in the
+             * master list */
+            pos = g_list_index(global_plist->prj_list, after_me);
 
-			/* this shouldn't happen ....node should be found */
-			if (0 > pos)
-			{
-				global_plist->prj_list = g_list_prepend (global_plist->prj_list, p);
-				p->parent = NULL;
-				return;
-			}
-			pos ++;
-			global_plist->prj_list = g_list_insert (global_plist->prj_list, p, pos);
-			p->parent = NULL;
-			return;
-		}
-		else
-		{
-			GList *sub;
-			sub = after_me->parent->sub_projects;
-			pos  = g_list_index (sub, after_me);
+            /* this shouldn't happen ....node should be found */
+            if (0 > pos)
+            {
+                global_plist->prj_list = g_list_prepend(global_plist->prj_list, p);
+                p->parent = NULL;
+                return;
+            }
+            pos++;
+            global_plist->prj_list = g_list_insert(global_plist->prj_list, p, pos);
+            p->parent = NULL;
+            return;
+        }
+        else
+        {
+            GList *sub;
+            sub = after_me->parent->sub_projects;
+            pos = g_list_index(sub, after_me);
 
-			/* this shouldn't happen ....node should be found */
-			if (0 > pos)
-			{
-				sub = g_list_prepend (sub, p);
-				after_me->parent->sub_projects = sub;
-				p->parent = after_me->parent;
-				return;
-			}
-			pos ++;
-			sub = g_list_insert (sub, p, pos);
-			after_me->parent->sub_projects = sub;
-			p->parent = after_me->parent;
-			return;
-		}
-	}
+            /* this shouldn't happen ....node should be found */
+            if (0 > pos)
+            {
+                sub = g_list_prepend(sub, p);
+                after_me->parent->sub_projects = sub;
+                p->parent = after_me->parent;
+                return;
+            }
+            pos++;
+            sub = g_list_insert(sub, p, pos);
+            after_me->parent->sub_projects = sub;
+            p->parent = after_me->parent;
+            return;
+        }
+    }
 }
 
-void
-gtt_project_reparent (GttProject *proj, GttProject *parent, int position)
+void gtt_project_reparent(GttProject *proj, GttProject *parent, int position)
 {
-	GList **new_list = NULL;
-	GList **old_list = NULL;
-	if (parent)
-	{
-		new_list = &parent->sub_projects;
-	}
-	else
-	{
-		new_list = &global_plist->prj_list;
-	}
+    GList **new_list = NULL;
+    GList **old_list = NULL;
+    if (parent)
+    {
+        new_list = &parent->sub_projects;
+    }
+    else
+    {
+        new_list = &global_plist->prj_list;
+    }
 
-	if (proj->parent)
-	{
-		old_list = &proj->parent->sub_projects;
-	}
-	else
-	{
-		old_list = &global_plist->prj_list;
-	}
+    if (proj->parent)
+    {
+        old_list = &proj->parent->sub_projects;
+    }
+    else
+    {
+        old_list = &global_plist->prj_list;
+    }
 
-	*old_list = g_list_remove (*old_list, proj);
-	*new_list = g_list_insert (*new_list, proj, position);
-	proj->parent = parent;
-
+    *old_list = g_list_remove(*old_list, proj);
+    *new_list = g_list_insert(*new_list, proj, position);
+    proj->parent = parent;
 }
 
-
-void
-gtt_project_append_task (GttProject *proj, GttTask *task)
+void gtt_project_append_task(GttProject *proj, GttTask *task)
 {
-	if (!proj || !task) return;
+    if (!proj || !task)
+        return;
 
-	/* if task has a different parent, then reparent */
-	if (task->parent)
-	{
-		task->parent->task_list =
-			g_list_remove (task->parent->task_list, task);
-		proj_refresh_time(task->parent);
-	}
+    /* if task has a different parent, then reparent */
+    if (task->parent)
+    {
+        task->parent->task_list = g_list_remove(task->parent->task_list, task);
+        proj_refresh_time(task->parent);
+    }
 
-	proj->task_list = g_list_append (proj->task_list, task);
-	task->parent = proj;
-	proj_refresh_time(proj);
+    proj->task_list = g_list_append(proj->task_list, task);
+    task->parent = proj;
+    proj_refresh_time(proj);
 }
 
-void
-gtt_project_prepend_task (GttProject *proj, GttTask *task)
+void gtt_project_prepend_task(GttProject *proj, GttTask *task)
 {
-	int is_running = FALSE;
-	if (!proj || !task) return;
+    int is_running = FALSE;
+    if (!proj || !task)
+        return;
 
-	/* if task has a different parent, then reparent */
-	if (task->parent)
-	{
-		task->parent->task_list =
-			g_list_remove (task->parent->task_list, task);
-		proj_refresh_time(task->parent);
-	}
+    /* if task has a different parent, then reparent */
+    if (task->parent)
+    {
+        task->parent->task_list = g_list_remove(task->parent->task_list, task);
+        proj_refresh_time(task->parent);
+    }
 
-	/* avoid misplaced running intervals, stop the task */
-	if (proj->task_list)
-	{
-		GttTask *leadtask = proj->task_list->data;
-		is_running = task_suspend (leadtask);
-	}
+    /* avoid misplaced running intervals, stop the task */
+    if (proj->task_list)
+    {
+        GttTask *leadtask = proj->task_list->data;
+        is_running = task_suspend(leadtask);
+    }
 
-	proj->task_list = g_list_prepend (proj->task_list, task);
-	proj->current_task = task;
-	task->parent = proj;
+    proj->task_list = g_list_prepend(proj->task_list, task);
+    proj->current_task = task;
+    task->parent = proj;
 
-	if (is_running) gtt_project_timer_start (proj);
-	proj_refresh_time(proj);
+    if (is_running)
+        gtt_project_timer_start(proj);
+    proj_refresh_time(proj);
 }
 
-
-GList *
-gtt_project_get_children (GttProject *proj)
+GList *gtt_project_get_children(GttProject *proj)
 {
-	if (!proj) return NULL;
-	return proj->sub_projects;
+    if (!proj)
+        return NULL;
+    return proj->sub_projects;
 }
 
-GttProject *
-gtt_project_get_parent (GttProject *proj)
+GttProject *gtt_project_get_parent(GttProject *proj)
 {
-	if (!proj) return NULL;
-	return proj->parent;
+    if (!proj)
+        return NULL;
+    return proj->parent;
 }
 
-
-GList *
-gtt_project_get_tasks (GttProject *proj)
+GList *gtt_project_get_tasks(GttProject *proj)
 {
-	if (!proj) return NULL;
-	return proj->task_list;
+    if (!proj)
+        return NULL;
+    return proj->task_list;
 }
 
-GttTask *
-gtt_project_get_first_task (GttProject *proj)
+GttTask *gtt_project_get_first_task(GttProject *proj)
 {
-	if (!proj) return NULL;
-	if (!proj->task_list) return NULL;
-	return (proj->task_list->data);
+    if (!proj)
+        return NULL;
+    if (!proj->task_list)
+        return NULL;
+    return (proj->task_list->data);
 }
 
-GttTask *
-gtt_project_get_current_task (GttProject *proj)
+GttTask *gtt_project_get_current_task(GttProject *proj)
 {
-	if (!proj) return NULL;
-	if (!proj->current_task)
-		return gtt_project_get_first_task(proj);
+    if (!proj)
+        return NULL;
+    if (!proj->current_task)
+        return gtt_project_get_first_task(proj);
 
-	return (proj->current_task);
+    return (proj->current_task);
 }
 
-void
-gtt_project_set_current_task (GttProject *proj, GttTask *newCurrentTask)
+void gtt_project_set_current_task(GttProject *proj, GttTask *newCurrentTask)
 {
-	int is_running = 0;
+    int is_running = 0;
 
-	if (!proj || !newCurrentTask) return;
+    if (!proj || !newCurrentTask)
+        return;
 
-	if (proj->current_task)
-		is_running = task_suspend(proj->current_task);
-	proj->current_task = newCurrentTask;
-	if (is_running) gtt_project_timer_start(proj);
-	proj_refresh_time(proj);
+    if (proj->current_task)
+        is_running = task_suspend(proj->current_task);
+    proj->current_task = newCurrentTask;
+    if (is_running)
+        gtt_project_timer_start(proj);
+    proj_refresh_time(proj);
 }
 
-GttInterval *
-gtt_project_get_first_interval (GttProject *proj)
+GttInterval *gtt_project_get_first_interval(GttProject *proj)
 {
-	GttTask *tsk;
-	if (!proj) return NULL;
-	if (!proj->task_list) return NULL;
-	tsk = proj->task_list->data;
-	if (!tsk) return NULL;
-	if (!tsk->interval_list) return NULL;
-	return (tsk->interval_list->data);
+    GttTask *tsk;
+    if (!proj)
+        return NULL;
+    if (!proj->task_list)
+        return NULL;
+    tsk = proj->task_list->data;
+    if (!tsk)
+        return NULL;
+    if (!tsk->interval_list)
+        return NULL;
+    return (tsk->interval_list->data);
 }
 
 /* =========================================================== */
 /* get totals */
 
-
-int
-gtt_project_foreach (GttProject *prj, GttProjectCB cb, gpointer data)
+int gtt_project_foreach(GttProject *prj, GttProjectCB cb, gpointer data)
 {
-	int rc;
-	GList *node;
-	if (!prj || !cb) return 0;
+    int rc;
+    GList *node;
+    if (!prj || !cb)
+        return 0;
 
-	rc = cb (prj, data);
-	if (0 == rc) return 0;
+    rc = cb(prj, data);
+    if (0 == rc)
+        return 0;
 
-	for (node=prj->sub_projects; node; node=node->next)
-	{
-		GttProject *subprj = node->data;
-		if (!subprj) continue;  /* this can't really happen */
-		rc = gtt_project_foreach (subprj, cb, data);
-		if (0 == rc) return 0;
-	}
-	return rc;
+    for (node = prj->sub_projects; node; node = node->next)
+    {
+        GttProject *subprj = node->data;
+        if (!subprj)
+            continue; /* this can't really happen */
+        rc = gtt_project_foreach(subprj, cb, data);
+        if (0 == rc)
+            return 0;
+    }
+    return rc;
 }
 
-static int
-prj_total_secs_day (GttProject *prj, gpointer data)
+static int prj_total_secs_day(GttProject *prj, gpointer data)
 {
-	*((int *) data) += prj->secs_day;
-	return 1;
+    *((int *) data) += prj->secs_day;
+    return 1;
 }
 
-static int
-prj_total_secs_yesterday (GttProject *prj, gpointer data)
+static int prj_total_secs_yesterday(GttProject *prj, gpointer data)
 {
-	*((int *) data) += prj->secs_yesterday;
-	return 1;
+    *((int *) data) += prj->secs_yesterday;
+    return 1;
 }
 
-static int
-prj_total_secs_week (GttProject *prj, gpointer data)
+static int prj_total_secs_week(GttProject *prj, gpointer data)
 {
-	*((int *) data) += prj->secs_week;
-	return 1;
+    *((int *) data) += prj->secs_week;
+    return 1;
 }
 
-static int
-prj_total_secs_lastweek (GttProject *prj, gpointer data)
+static int prj_total_secs_lastweek(GttProject *prj, gpointer data)
 {
-	*((int *) data) += prj->secs_lastweek;
-	return 1;
+    *((int *) data) += prj->secs_lastweek;
+    return 1;
 }
 
-static int
-prj_total_secs_month (GttProject *prj, gpointer data)
+static int prj_total_secs_month(GttProject *prj, gpointer data)
 {
-	*((int *) data) += prj->secs_month;
-	return 1;
+    *((int *) data) += prj->secs_month;
+    return 1;
 }
 
-static int
-prj_total_secs_year (GttProject *prj, gpointer data)
+static int prj_total_secs_year(GttProject *prj, gpointer data)
 {
-	*((int *) data) += prj->secs_year;
-	return 1;
+    *((int *) data) += prj->secs_year;
+    return 1;
 }
 
-static int
-prj_total_secs_ever (GttProject *prj, gpointer data)
+static int prj_total_secs_ever(GttProject *prj, gpointer data)
 {
-	*((int *) data) += prj->secs_ever;
-	return 1;
+    *((int *) data) += prj->secs_ever;
+    return 1;
 }
 
-static int
-prj_total_secs_current (GttProject *prj, gpointer data)
+static int prj_total_secs_current(GttProject *prj, gpointer data)
 {
-	*((int *) data) += gtt_project_get_secs_current (prj);
-	return 1;
+    *((int *) data) += gtt_project_get_secs_current(prj);
+    return 1;
 }
 
 /* this routine adds up total day-secs for this project, and its sub-projects */
-int
-gtt_project_total_secs_day (GttProject *proj)
+int gtt_project_total_secs_day(GttProject *proj)
 {
-	int total = 0;
-	if (!proj) return 0;
-	gtt_project_foreach (proj, prj_total_secs_day, &total);
-	return total;
+    int total = 0;
+    if (!proj)
+        return 0;
+    gtt_project_foreach(proj, prj_total_secs_day, &total);
+    return total;
 }
 
-int
-gtt_project_total_secs_yesterday (GttProject *proj)
+int gtt_project_total_secs_yesterday(GttProject *proj)
 {
-	int total = 0;
-	if (!proj) return 0;
-	gtt_project_foreach (proj, prj_total_secs_yesterday, &total);
-	return total;
+    int total = 0;
+    if (!proj)
+        return 0;
+    gtt_project_foreach(proj, prj_total_secs_yesterday, &total);
+    return total;
 }
 
-int
-gtt_project_total_secs_week (GttProject *proj)
+int gtt_project_total_secs_week(GttProject *proj)
 {
-	int total = 0;
-	if (!proj) return 0;
-	gtt_project_foreach (proj, prj_total_secs_week, &total);
-	return total;
+    int total = 0;
+    if (!proj)
+        return 0;
+    gtt_project_foreach(proj, prj_total_secs_week, &total);
+    return total;
 }
 
-int
-gtt_project_total_secs_lastweek (GttProject *proj)
+int gtt_project_total_secs_lastweek(GttProject *proj)
 {
-	int total = 0;
-	if (!proj) return 0;
-	gtt_project_foreach (proj, prj_total_secs_lastweek, &total);
-	return total;
+    int total = 0;
+    if (!proj)
+        return 0;
+    gtt_project_foreach(proj, prj_total_secs_lastweek, &total);
+    return total;
 }
 
-int
-gtt_project_total_secs_month (GttProject *proj)
+int gtt_project_total_secs_month(GttProject *proj)
 {
-	int total = 0;
-	if (!proj) return 0;
-	gtt_project_foreach (proj, prj_total_secs_month, &total);
-	return total;
+    int total = 0;
+    if (!proj)
+        return 0;
+    gtt_project_foreach(proj, prj_total_secs_month, &total);
+    return total;
 }
 
-int
-gtt_project_total_secs_year (GttProject *proj)
+int gtt_project_total_secs_year(GttProject *proj)
 {
-	int total = 0;
-	if (!proj) return 0;
-	gtt_project_foreach (proj, prj_total_secs_year, &total);
-	return total;
+    int total = 0;
+    if (!proj)
+        return 0;
+    gtt_project_foreach(proj, prj_total_secs_year, &total);
+    return total;
 }
 
-int
-gtt_project_total_secs_ever (GttProject *proj)
+int gtt_project_total_secs_ever(GttProject *proj)
 {
-	int total = 0;
-	if (!proj) return 0;
-	gtt_project_foreach (proj, prj_total_secs_ever, &total);
-	return total;
+    int total = 0;
+    if (!proj)
+        return 0;
+    gtt_project_foreach(proj, prj_total_secs_ever, &total);
+    return total;
 }
 
-int
-gtt_project_total_secs_current (GttProject *proj)
+int gtt_project_total_secs_current(GttProject *proj)
 {
-	int total = 0;
-	if (!proj) return 0;
-	gtt_project_foreach (proj, prj_total_secs_current, &total);
-	return total;
+    int total = 0;
+    if (!proj)
+        return 0;
+    gtt_project_foreach(proj, prj_total_secs_current, &total);
+    return total;
 }
 
-int
-gtt_project_get_secs_day (GttProject *proj)
+int gtt_project_get_secs_day(GttProject *proj)
 {
-	if (!proj) return 0;
-	return proj->secs_day;
+    if (!proj)
+        return 0;
+    return proj->secs_day;
 }
 
-int
-gtt_project_get_secs_yesterday (GttProject *proj)
+int gtt_project_get_secs_yesterday(GttProject *proj)
 {
-	if (!proj) return 0;
-	return proj->secs_yesterday;
+    if (!proj)
+        return 0;
+    return proj->secs_yesterday;
 }
 
-int
-gtt_project_get_secs_week (GttProject *proj)
+int gtt_project_get_secs_week(GttProject *proj)
 {
-	if (!proj) return 0;
-	return proj->secs_week;
+    if (!proj)
+        return 0;
+    return proj->secs_week;
 }
 
-int
-gtt_project_get_secs_lastweek (GttProject *proj)
+int gtt_project_get_secs_lastweek(GttProject *proj)
 {
-	if (!proj) return 0;
-	return proj->secs_lastweek;
+    if (!proj)
+        return 0;
+    return proj->secs_lastweek;
 }
 
-int
-gtt_project_get_secs_month (GttProject *proj)
+int gtt_project_get_secs_month(GttProject *proj)
 {
-	if (!proj) return 0;
-	return proj->secs_month;
+    if (!proj)
+        return 0;
+    return proj->secs_month;
 }
 
-int
-gtt_project_get_secs_year (GttProject *proj)
+int gtt_project_get_secs_year(GttProject *proj)
 {
-	if (!proj) return 0;
-	return proj->secs_year;
+    if (!proj)
+        return 0;
+    return proj->secs_year;
 }
 
-int
-gtt_project_get_secs_ever (GttProject *proj)
+int gtt_project_get_secs_ever(GttProject *proj)
 {
-	if (!proj) return 0;
-	return proj->secs_ever;
+    if (!proj)
+        return 0;
+    return proj->secs_ever;
 }
 
-int
-gtt_project_get_secs_current (GttProject *proj)
+int gtt_project_get_secs_current(GttProject *proj)
 {
-	GttTask *tsk;
-	if (!proj) return 0;
-	if (!proj->task_list) return 0;
-	tsk = gtt_project_get_current_task (proj);
+    GttTask *tsk;
+    if (!proj)
+        return 0;
+    if (!proj->task_list)
+        return 0;
+    tsk = gtt_project_get_current_task(proj);
 
-	return gtt_task_get_secs_ever(tsk);
+    return gtt_task_get_secs_ever(tsk);
 }
 
 /* This routine adds up total number of projects, and sub-projects */
-static int
-prj_total (GttProject *prj, gpointer data)
+static int prj_total(GttProject *prj, gpointer data)
 {
-	*((int *) data) += 1;  /* just count one */
-	return 1;
+    *((int *) data) += 1; /* just count one */
+    return 1;
 }
 
-int
-gtt_project_total (GttProject *proj)
+int gtt_project_total(GttProject *proj)
 {
-	int total = 0;
-	if (!proj) return 0;
-	gtt_project_foreach (proj, prj_total, &total);
-	return total;
+    int total = 0;
+    if (!proj)
+        return 0;
+    gtt_project_foreach(proj, prj_total, &total);
+    return total;
 }
 
 /* =========================================================== */
 
-int
-gtt_project_list_total_secs_day (void)
+int gtt_project_list_total_secs_day(void)
 {
-	GList *node;
-	int total = 0;
-	if (!global_plist->prj_list) return 0;
+    GList *node;
+    int total = 0;
+    if (!global_plist->prj_list)
+        return 0;
 
-	for (node=global_plist->prj_list; node; node=node->next)
-	{
-		GttProject *proj = node->data;
-		total += gtt_project_total_secs_day (proj);
-	}
-	return total;
+    for (node = global_plist->prj_list; node; node = node->next)
+    {
+        GttProject *proj = node->data;
+        total += gtt_project_total_secs_day(proj);
+    }
+    return total;
 }
 
-int
-gtt_project_list_total_secs_yesterday (void)
+int gtt_project_list_total_secs_yesterday(void)
 {
-	GList *node;
-	int total = 0;
-	if (!global_plist->prj_list) return 0;
+    GList *node;
+    int total = 0;
+    if (!global_plist->prj_list)
+        return 0;
 
-	for (node=global_plist->prj_list; node; node=node->next)
-	{
-		GttProject *proj = node->data;
-		total += gtt_project_total_secs_yesterday (proj);
-	}
-	return total;
+    for (node = global_plist->prj_list; node; node = node->next)
+    {
+        GttProject *proj = node->data;
+        total += gtt_project_total_secs_yesterday(proj);
+    }
+    return total;
 }
 
-int
-gtt_project_list_total (void)
+int gtt_project_list_total(void)
 {
-	GList *node;
-	int total = 0;
-	if (!global_plist->prj_list) return 0;
+    GList *node;
+    int total = 0;
+    if (!global_plist->prj_list)
+        return 0;
 
-	for (node=global_plist->prj_list; node; node=node->next)
-	{
-		GttProject *proj = node->data;
-		total += gtt_project_total (proj);
-	}
-	return total;
+    for (node = global_plist->prj_list; node; node = node->next)
+    {
+        GttProject *proj = node->data;
+        total += gtt_project_total(proj);
+    }
+    return total;
 }
 
 /* =========================================================== */
@@ -1325,1435 +1321,1473 @@ gtt_project_list_total (void)
  *     (but only do this if the nearest is in the same day).
  */
 
-static GttInterval *
-get_closest (GList *node)
+static GttInterval *get_closest(GList *node)
 {
-	if (node->next) return node->next->data;
-	if (node->prev) return node->prev->data;
-	return NULL;
+    if (node->next)
+        return node->next->data;
+    if (node->prev)
+        return node->prev->data;
+    return NULL;
 }
 
-static GttInterval *
-scrub_intervals (GttTask *tsk, GttInterval *handle)
+static GttInterval *scrub_intervals(GttTask *tsk, GttInterval *handle)
 {
-	GttProject *prj;
-	GList *node;
-	int mini, merge, mgap;
-	int not_done = TRUE;
-	int save_freeze;
+    GttProject *prj;
+    GList *node;
+    int mini, merge, mgap;
+    int not_done = TRUE;
+    int save_freeze;
 
-	/* Prevent recursion */
-	prj = tsk->parent;
-	g_return_val_if_fail (prj, FALSE);
-	save_freeze = prj->frozen;
-	prj->frozen = TRUE;
+    /* Prevent recursion */
+    prj = tsk->parent;
+    g_return_val_if_fail(prj, FALSE);
+    save_freeze = prj->frozen;
+    prj->frozen = TRUE;
 
-	/* First, eliminate very short intervals */
-	mini = prj->min_interval;
-	while (not_done)
-	{
-		not_done = FALSE;
-		for (node = tsk->interval_list; node; node=node->next)
-		{
-			GttInterval *ivl = node->data;
-			int len = ivl->stop - ivl->start;
+    /* First, eliminate very short intervals */
+    mini = prj->min_interval;
+    while (not_done)
+    {
+        not_done = FALSE;
+        for (node = tsk->interval_list; node; node = node->next)
+        {
+            GttInterval *ivl = node->data;
+            int len = ivl->stop - ivl->start;
 
-			/* Should never see negative intervals */
-			g_return_val_if_fail ((0 <= len), handle);
-			if ((FALSE == ivl->running) &&
-			    (len <= mini) &&
-			    (0 != ivl->start))  /* don't whack new ivls */
-			{
-				if (handle == ivl) handle = get_closest (node);
-				tsk->interval_list = g_list_remove (tsk->interval_list, ivl);
-				ivl->parent = NULL;
-				g_free (ivl);
-				not_done = TRUE;
-				break;
-			}
-		}
-	}
+            /* Should never see negative intervals */
+            g_return_val_if_fail((0 <= len), handle);
+            if ((FALSE == ivl->running) && (len <= mini)
+                && (0 != ivl->start)) /* don't whack new ivls */
+            {
+                if (handle == ivl)
+                    handle = get_closest(node);
+                tsk->interval_list = g_list_remove(tsk->interval_list, ivl);
+                ivl->parent = NULL;
+                g_free(ivl);
+                not_done = TRUE;
+                break;
+            }
+        }
+    }
 
-	/* Merge intervals with small gaps between them */
-	mgap = prj->auto_merge_gap;
-	not_done = TRUE;
-	while (not_done)
-	{
-		not_done = FALSE;
-		for (node = tsk->interval_list; node; node=node->next)
-		{
-			GttInterval *ivl = node->data;
-			GttInterval *nivl;
-			int gap;
+    /* Merge intervals with small gaps between them */
+    mgap = prj->auto_merge_gap;
+    not_done = TRUE;
+    while (not_done)
+    {
+        not_done = FALSE;
+        for (node = tsk->interval_list; node; node = node->next)
+        {
+            GttInterval *ivl = node->data;
+            GttInterval *nivl;
+            int gap;
 
-			if (ivl->running) continue;
-			if (!node->next) break;
-			nivl = node->next->data;
-			gap = ivl->start - nivl->stop;
-			if (0 > gap) continue;  /* out of order ivls */
-			if ((mgap > gap) ||
-			    (ivl->fuzz > gap) ||
-			    (nivl->fuzz > gap))
-			{
-				GttInterval *rc = gtt_interval_merge_down (ivl);
-				if (handle == ivl) handle = rc;
-				not_done = TRUE;
-				break;
-			}
-		}
-	}
+            if (ivl->running)
+                continue;
+            if (!node->next)
+                break;
+            nivl = node->next->data;
+            gap = ivl->start - nivl->stop;
+            if (0 > gap)
+                continue; /* out of order ivls */
+            if ((mgap > gap) || (ivl->fuzz > gap) || (nivl->fuzz > gap))
+            {
+                GttInterval *rc = gtt_interval_merge_down(ivl);
+                if (handle == ivl)
+                    handle = rc;
+                not_done = TRUE;
+                break;
+            }
+        }
+    }
 
-	/* Merge short intervals into neighbors */
-	merge = prj->auto_merge_interval;
-	not_done = TRUE;
-	while (not_done)
-	{
-		not_done = FALSE;
-		for (node = tsk->interval_list; node; node=node->next)
-		{
-			GttInterval *ivl = node->data;
-			int gap_up=1000000000;
-			int gap_down=1000000000;
-			int do_merge = FALSE;
-			int len;
+    /* Merge short intervals into neighbors */
+    merge = prj->auto_merge_interval;
+    not_done = TRUE;
+    while (not_done)
+    {
+        not_done = FALSE;
+        for (node = tsk->interval_list; node; node = node->next)
+        {
+            GttInterval *ivl = node->data;
+            int gap_up = 1000000000;
+            int gap_down = 1000000000;
+            int do_merge = FALSE;
+            int len;
 
-			if (ivl->running) continue;
-			if (0 == ivl->start) continue;  /* brand-new ivl */
-			len = ivl->stop - ivl->start;
-			if (len > merge) continue;
-			if (node->next)
-			{
-				GttInterval *nivl = node->next->data;
+            if (ivl->running)
+                continue;
+            if (0 == ivl->start)
+                continue; /* brand-new ivl */
+            len = ivl->stop - ivl->start;
+            if (len > merge)
+                continue;
+            if (node->next)
+            {
+                GttInterval *nivl = node->next->data;
 
-				/* Merge only if the intervals are in the same day */
-				if (get_midnight (ivl->start) == get_midnight (nivl->stop))
-				{
-					gap_down = ivl->start - nivl->stop;
-					do_merge = TRUE;
-				}
-			}
-			if (node->prev)
-			{
-				GttInterval *nivl = node->prev->data;
+                /* Merge only if the intervals are in the same day */
+                if (get_midnight(ivl->start) == get_midnight(nivl->stop))
+                {
+                    gap_down = ivl->start - nivl->stop;
+                    do_merge = TRUE;
+                }
+            }
+            if (node->prev)
+            {
+                GttInterval *nivl = node->prev->data;
 
-				/* Merge only if the intervals are in the same day */
-				if (get_midnight (nivl->start) == get_midnight (ivl->stop))
-				{
-					gap_up = nivl->start - ivl->stop;
-					do_merge = TRUE;
-				}
-			}
-			if (!do_merge) continue;
-			if (gap_up < gap_down)
-			{
-				GttInterval *rc = gtt_interval_merge_up (ivl);
-				if (handle == ivl) handle = rc;
-			}
-			else
-			{
-				GttInterval *rc = gtt_interval_merge_down (ivl);
-				if (handle == ivl) handle = rc;
-			}
-			not_done = TRUE;
-			break;
-		}
-	}
+                /* Merge only if the intervals are in the same day */
+                if (get_midnight(nivl->start) == get_midnight(ivl->stop))
+                {
+                    gap_up = nivl->start - ivl->stop;
+                    do_merge = TRUE;
+                }
+            }
+            if (!do_merge)
+                continue;
+            if (gap_up < gap_down)
+            {
+                GttInterval *rc = gtt_interval_merge_up(ivl);
+                if (handle == ivl)
+                    handle = rc;
+            }
+            else
+            {
+                GttInterval *rc = gtt_interval_merge_down(ivl);
+                if (handle == ivl)
+                    handle = rc;
+            }
+            not_done = TRUE;
+            break;
+        }
+    }
 
-	prj->frozen = save_freeze;
-	return handle;
+    prj->frozen = save_freeze;
+    return handle;
 }
 
-static void
-project_compute_secs (GttProject *proj)
+static void project_compute_secs(GttProject *proj)
 {
-	int total_ever = 0;
-	int total_day = 0;
-	int total_yesterday = 0;
-	int total_week = 0;
-	int total_lastweek = 0;
-	int total_month = 0;
-	int total_year = 0;
-	time_t midnight, sunday, month, newyear;
-	GList *tsk_node, *ivl_node, *prj_node;
+    int total_ever = 0;
+    int total_day = 0;
+    int total_yesterday = 0;
+    int total_week = 0;
+    int total_lastweek = 0;
+    int total_month = 0;
+    int total_year = 0;
+    time_t midnight, sunday, month, newyear;
+    GList *tsk_node, *ivl_node, *prj_node;
 
-	if (!proj) return;
+    if (!proj)
+        return;
 
-	/* Total up the subprojects first */
-	for (prj_node= proj->sub_projects; prj_node; prj_node=prj_node->next)
-	{
-		GttProject * prj = prj_node->data;
-		project_compute_secs (prj);
-	}
+    /* Total up the subprojects first */
+    for (prj_node = proj->sub_projects; prj_node; prj_node = prj_node->next)
+    {
+        GttProject *prj = prj_node->data;
+        project_compute_secs(prj);
+    }
 
-	midnight = get_midnight (-1);
-	sunday = get_sunday (-1);
-	month = get_month (-1);
-	newyear = get_newyear (-1);
+    midnight = get_midnight(-1);
+    sunday = get_sunday(-1);
+    month = get_month(-1);
+    newyear = get_newyear(-1);
 
-	/* Total up time spent in various tasks.
-	 * XXX None of these total handle daylight savings correctly.
-	 */
-	for (tsk_node= proj->task_list; tsk_node; tsk_node=tsk_node->next)
-	{
-		GttTask * task = tsk_node->data;
-		scrub_intervals (task , NULL);
-		for (ivl_node= task->interval_list; ivl_node; ivl_node=ivl_node->next)
-		{
-			GttInterval *ivl = ivl_node->data;
-			total_ever += ivl->stop - ivl->start;
+    /* Total up time spent in various tasks.
+     * XXX None of these total handle daylight savings correctly.
+     */
+    for (tsk_node = proj->task_list; tsk_node; tsk_node = tsk_node->next)
+    {
+        GttTask *task = tsk_node->data;
+        scrub_intervals(task, NULL);
+        for (ivl_node = task->interval_list; ivl_node; ivl_node = ivl_node->next)
+        {
+            GttInterval *ivl = ivl_node->data;
+            total_ever += ivl->stop - ivl->start;
 
-			/* Accum time today. */
-			if (ivl->start >= midnight)
-			{
-				total_day += ivl->stop - ivl->start;
-			}
-			else if (ivl->stop > midnight)
-			{
-				total_day += ivl->stop - midnight;
-			}
+            /* Accum time today. */
+            if (ivl->start >= midnight)
+            {
+                total_day += ivl->stop - ivl->start;
+            }
+            else if (ivl->stop > midnight)
+            {
+                total_day += ivl->stop - midnight;
+            }
 
-			/* Accum time yesterday. */
-			if (ivl->start < midnight)
-			{
-				if (ivl->start >= midnight-24*3600)
-				{
-					if (ivl->stop <= midnight)
-					{
-						total_yesterday += ivl->stop - ivl->start;
-					}
-					else
-					{
-						total_yesterday += midnight - ivl->start;
-					}
-				}
-				else  /* else .. it started before midnight yesterday */
-				if (ivl->stop > midnight-24*3600)
-				{
-					if (ivl->stop <= midnight)
-					{
-						total_yesterday += ivl->stop - (midnight-24*3600);
-					}
-					else
-					{
-						total_yesterday += 24*3600;
-					}
-				}
-			}
+            /* Accum time yesterday. */
+            if (ivl->start < midnight)
+            {
+                if (ivl->start >= midnight - 24 * 3600)
+                {
+                    if (ivl->stop <= midnight)
+                    {
+                        total_yesterday += ivl->stop - ivl->start;
+                    }
+                    else
+                    {
+                        total_yesterday += midnight - ivl->start;
+                    }
+                }
+                else /* else .. it started before midnight yesterday */
+                    if (ivl->stop > midnight - 24 * 3600)
+                    {
+                        if (ivl->stop <= midnight)
+                        {
+                            total_yesterday += ivl->stop - (midnight - 24 * 3600);
+                        }
+                        else
+                        {
+                            total_yesterday += 24 * 3600;
+                        }
+                    }
+            }
 
-			/* Accum time this week. */
-			if (ivl->start >= sunday)
-			{
-				total_week += ivl->stop - ivl->start;
-			}
-			else if (ivl->stop > sunday)
-			{
-				total_week += ivl->stop - sunday;
-			}
+            /* Accum time this week. */
+            if (ivl->start >= sunday)
+            {
+                total_week += ivl->stop - ivl->start;
+            }
+            else if (ivl->stop > sunday)
+            {
+                total_week += ivl->stop - sunday;
+            }
 
-			/* Accum time last week. */
-			if (ivl->start < sunday)
-			{
-				if (ivl->start >= sunday-7*24*3600)
-				{
-					if (ivl->stop <= sunday)
-					{
-						total_lastweek += ivl->stop - ivl->start;
-					}
-					else
-					{
-						total_lastweek += sunday - ivl->start;
-					}
-				}
-				else  /* else .. it started before sunday last week */
-				if (ivl->stop > sunday-7*24*3600)
-				{
-					if (ivl->stop <= sunday)
-					{
-						total_lastweek += ivl->stop - (sunday-7*24*3600);
-					}
-					else
-					{
-						total_lastweek += 7*24*3600;
-					}
-				}
-			}
+            /* Accum time last week. */
+            if (ivl->start < sunday)
+            {
+                if (ivl->start >= sunday - 7 * 24 * 3600)
+                {
+                    if (ivl->stop <= sunday)
+                    {
+                        total_lastweek += ivl->stop - ivl->start;
+                    }
+                    else
+                    {
+                        total_lastweek += sunday - ivl->start;
+                    }
+                }
+                else /* else .. it started before sunday last week */
+                    if (ivl->stop > sunday - 7 * 24 * 3600)
+                    {
+                        if (ivl->stop <= sunday)
+                        {
+                            total_lastweek += ivl->stop - (sunday - 7 * 24 * 3600);
+                        }
+                        else
+                        {
+                            total_lastweek += 7 * 24 * 3600;
+                        }
+                    }
+            }
 
-			/* Accum time this month */
-			if (ivl->start >= month)
-			{
-				total_month += ivl->stop - ivl->start;
-			}
-			else if (ivl->stop > month)
-			{
-				total_month += ivl->stop - month;
-			}
-			if (ivl->start >= newyear)
-			{
-				total_year += ivl->stop - ivl->start;
-			}
-			else if (ivl->stop > newyear)
-			{
-				total_year += ivl->stop - newyear;
-			}
-		}
-	}
+            /* Accum time this month */
+            if (ivl->start >= month)
+            {
+                total_month += ivl->stop - ivl->start;
+            }
+            else if (ivl->stop > month)
+            {
+                total_month += ivl->stop - month;
+            }
+            if (ivl->start >= newyear)
+            {
+                total_year += ivl->stop - ivl->start;
+            }
+            else if (ivl->stop > newyear)
+            {
+                total_year += ivl->stop - newyear;
+            }
+        }
+    }
 
-	proj->secs_ever = total_ever;
-	proj->secs_day = total_day;
-	proj->secs_yesterday = total_yesterday;
-	proj->secs_week = total_week;
-	proj->secs_lastweek = total_lastweek;
-	proj->secs_month = total_month;
-	proj->secs_year = total_year;
-	proj->dirty_time = FALSE;
+    proj->secs_ever = total_ever;
+    proj->secs_day = total_day;
+    proj->secs_yesterday = total_yesterday;
+    proj->secs_week = total_week;
+    proj->secs_lastweek = total_lastweek;
+    proj->secs_month = total_month;
+    proj->secs_year = total_year;
+    proj->dirty_time = FALSE;
 }
 
-static void
-children_modified (GttProject *prj)
+static void children_modified(GttProject *prj)
 {
-	GList *node;
-	if (!prj) return;
-	for (node= prj->sub_projects; node; node=node->next)
-	{
-		GttProject * subprj = node->data;
-		children_modified (subprj);
-	}
-	proj_modified (prj);
+    GList *node;
+    if (!prj)
+        return;
+    for (node = prj->sub_projects; node; node = node->next)
+    {
+        GttProject *subprj = node->data;
+        children_modified(subprj);
+    }
+    proj_modified(prj);
 }
 
-void
-gtt_project_list_compute_secs (void)
+void gtt_project_list_compute_secs(void)
 {
-	GList *node;
-	for (node= global_plist->prj_list; node; node=node->next)
-	{
-		GttProject * prj = node->data;
-		proj_refresh_time (prj);
-		children_modified (prj);
-	}
+    GList *node;
+    for (node = global_plist->prj_list; node; node = node->next)
+    {
+        GttProject *prj = node->data;
+        proj_refresh_time(prj);
+        children_modified(prj);
+    }
 }
 
 /* =========================================================== */
 /* even notification subsystem */
 
-void
-gtt_project_add_notifier (GttProject *prj,
-                       GttProjectChanged cb,
-                       gpointer user_stuff)
+void gtt_project_add_notifier(GttProject *prj, GttProjectChanged cb, gpointer user_stuff)
 {
-	Notifier * ntf;
+    Notifier *ntf;
 
-	if (!prj || !cb) return;
+    if (!prj || !cb)
+        return;
 
-	ntf = g_new0 (Notifier, 1);
-	ntf->func = cb;
-	ntf->user_data = user_stuff;
-	prj->listeners = g_list_append (prj->listeners, ntf);
+    ntf = g_new0(Notifier, 1);
+    ntf->func = cb;
+    ntf->user_data = user_stuff;
+    prj->listeners = g_list_append(prj->listeners, ntf);
 }
 
-void
-gtt_project_remove_notifier (GttProject *prj,
-                       GttProjectChanged cb,
-                       gpointer user_stuff)
+void gtt_project_remove_notifier(GttProject *prj, GttProjectChanged cb, gpointer user_stuff)
 {
-	Notifier * ntf;
-	GList *node;
+    Notifier *ntf;
+    GList *node;
 
-	if (!prj || !cb) return;
+    if (!prj || !cb)
+        return;
 
-	for (node = prj->listeners; node; node=node->next)
-	{
-		ntf = node->data;
-		if ((ntf->func == cb) && (ntf->user_data == user_stuff)) break;
-	}
+    for (node = prj->listeners; node; node = node->next)
+    {
+        ntf = node->data;
+        if ((ntf->func == cb) && (ntf->user_data == user_stuff))
+            break;
+    }
 
-	if (node)
-	{
-		prj->listeners = g_list_remove (prj->listeners, ntf);
-		g_free (ntf);
-	}
+    if (node)
+    {
+        prj->listeners = g_list_remove(prj->listeners, ntf);
+        g_free(ntf);
+    }
 }
 
-void
-gtt_project_freeze (GttProject *prj)
+void gtt_project_freeze(GttProject *prj)
 {
-	if (!prj) return;
-	prj->frozen = TRUE;
+    if (!prj)
+        return;
+    prj->frozen = TRUE;
 }
 
-void
-gtt_project_thaw (GttProject *prj)
+void gtt_project_thaw(GttProject *prj)
 {
-	if (!prj) return;
-	prj->frozen = FALSE;
-	proj_refresh_time (prj);
+    if (!prj)
+        return;
+    prj->frozen = FALSE;
+    proj_refresh_time(prj);
 }
 
-void
-gtt_task_freeze (GttTask *tsk)
+void gtt_task_freeze(GttTask *tsk)
 {
-	if (!tsk ||!tsk->parent) return;
-	tsk->parent->frozen = TRUE;
+    if (!tsk || !tsk->parent)
+        return;
+    tsk->parent->frozen = TRUE;
 }
 
-void
-gtt_task_thaw (GttTask *tsk)
+void gtt_task_thaw(GttTask *tsk)
 {
-	if (!tsk ||!tsk->parent) return;
-	tsk->parent->frozen = FALSE;
-	proj_refresh_time (tsk->parent);
+    if (!tsk || !tsk->parent)
+        return;
+    tsk->parent->frozen = FALSE;
+    proj_refresh_time(tsk->parent);
 }
 
-void
-gtt_interval_freeze (GttInterval *ivl)
+void gtt_interval_freeze(GttInterval *ivl)
 {
-	if (!ivl ||!ivl->parent || !ivl->parent->parent) return;
-	ivl->parent->parent->frozen = TRUE;
+    if (!ivl || !ivl->parent || !ivl->parent->parent)
+        return;
+    ivl->parent->parent->frozen = TRUE;
 }
 
-GttInterval *
-gtt_interval_thaw (GttInterval *ivl)
+GttInterval *gtt_interval_thaw(GttInterval *ivl)
 {
-	if (!ivl ||!ivl->parent || !ivl->parent->parent) return ivl;
-	ivl->parent->parent->frozen = FALSE;
-	ivl = scrub_intervals (ivl->parent, ivl);
-	proj_refresh_time (ivl->parent->parent);
-	return ivl;
+    if (!ivl || !ivl->parent || !ivl->parent->parent)
+        return ivl;
+    ivl->parent->parent->frozen = FALSE;
+    ivl = scrub_intervals(ivl->parent, ivl);
+    proj_refresh_time(ivl->parent->parent);
+    return ivl;
 }
 
-static void
-proj_refresh_time (GttProject *proj)
+static void proj_refresh_time(GttProject *proj)
 {
-	GList *node;
+    GList *node;
 
-	if (!proj) return;
-	if (proj->being_destroyed) return;
-	proj->dirty_time = TRUE;
-	if (proj->frozen) return;
-	project_compute_secs (proj);
+    if (!proj)
+        return;
+    if (proj->being_destroyed)
+        return;
+    proj->dirty_time = TRUE;
+    if (proj->frozen)
+        return;
+    project_compute_secs(proj);
 
-	/* let listeners know that the times have changed */
-	for (node=proj->listeners; node; node=node->next)
-	{
-		Notifier *ntf = node->data;
-		(ntf->func) (proj, ntf->user_data);
-	}
+    /* let listeners know that the times have changed */
+    for (node = proj->listeners; node; node = node->next)
+    {
+        Notifier *ntf = node->data;
+        (ntf->func)(proj, ntf->user_data);
+    }
 }
 
-static void
-proj_modified (GttProject *proj)
+static void proj_modified(GttProject *proj)
 {
-	GList *node;
+    GList *node;
 
-	if (!proj) return;
-	if (proj->being_destroyed) return;
-	if (proj->frozen) return;
+    if (!proj)
+        return;
+    if (proj->being_destroyed)
+        return;
+    if (proj->frozen)
+        return;
 
-	/* let listeners know that the times have changed */
-	for (node=proj->listeners; node; node=node->next)
-	{
-		Notifier *ntf = node->data;
-		(ntf->func) (proj, ntf->user_data);
-	}
-}
-
-/* =========================================================== */
-
-void
-gtt_clear_daily_counter (GttProject *proj)
-{
-	time_t midnight;
-	int not_done = TRUE;
-	GList *tsk_node, *in;
-	int is_running;
-
-	if (!proj) return;
-	if (!proj->task_list) return;
-
-	is_running = task_suspend ((GttTask *) proj->task_list->data);
-
-	gtt_project_freeze (proj);
-	midnight = get_midnight (-1);
-
-	/* loop over tasks */
-	for (tsk_node= proj->task_list; tsk_node; tsk_node=tsk_node->next)
-	{
-		GttTask * task = tsk_node->data;
-
-		not_done = TRUE;
-		while (not_done)
-		{
-			not_done = FALSE;
-			for (in= task->interval_list; in; in=in->next)
-			{
-				GttInterval *ivl = in->data;
-
-				/* only nuke the ones that started after midnight.
-			 	 * The ones that started before midnight remain */
-				if (ivl->start >= midnight)
-				{
-					task->interval_list =
-					     g_list_remove (task->interval_list, ivl);
-					g_free (ivl);
-					not_done = TRUE;
-					break;
-				}
-			}
-		}
-	}
-	gtt_project_thaw (proj);
-	if (is_running) gtt_project_timer_start (proj);
+    /* let listeners know that the times have changed */
+    for (node = proj->listeners; node; node = node->next)
+    {
+        Notifier *ntf = node->data;
+        (ntf->func)(proj, ntf->user_data);
+    }
 }
 
 /* =========================================================== */
 
-void
-gtt_project_timer_start (GttProject *proj)
+void gtt_clear_daily_counter(GttProject *proj)
 {
-	GttTask *task;
-	GttInterval *ival;
-	time_t now;
+    time_t midnight;
+    int not_done = TRUE;
+    GList *tsk_node, *in;
+    int is_running;
 
-	if (!proj) return;
+    if (!proj)
+        return;
+    if (!proj->task_list)
+        return;
 
-	/* By definition, the current task is not anymore the one at the head
-	 * of the list, but rather the one denoted by GttProject->current_task
-	 * and the current interval is  at the head
-	 * of the task */
-	if (NULL == proj->task_list)
-	{
-		task = gtt_task_new();
-		gtt_task_set_memo (task, _("New Diary Entry"));
-		proj->current_task = task;
-	}
-	else
-	{
-		if (NULL == proj->current_task)
-		{
-			task = proj->task_list->data;
-			proj->current_task = task;
-		}
-		else
-		{
-			task = proj->current_task;
-		}
+    is_running = task_suspend((GttTask *) proj->task_list->data);
 
-		g_return_if_fail (task);
-	}
+    gtt_project_freeze(proj);
+    midnight = get_midnight(-1);
 
-	now = time(0);
+    /* loop over tasks */
+    for (tsk_node = proj->task_list; tsk_node; tsk_node = tsk_node->next)
+    {
+        GttTask *task = tsk_node->data;
 
-	/* only add a new interval if there's been a bit of a gap,
-	 * otherwise, reuse the most recent running interval.  */
-	if (task->interval_list)
-	{
-		int delta;
-		ival = task->interval_list->data;
-		delta = now - ival->stop;
+        not_done = TRUE;
+        while (not_done)
+        {
+            not_done = FALSE;
+            for (in = task->interval_list; in; in = in->next)
+            {
+                GttInterval *ivl = in->data;
 
-		if (delta <= proj->auto_merge_gap)
-		{
-
-			ival->start += delta;
-			ival->fuzz += delta;
-			ival->stop = now;
-			ival->running = TRUE;
-			return;
-		}
-	}
-
-	ival = g_new0 (GttInterval, 1);
-	ival->start = now;
-	ival->stop = ival->start;
-	ival->running = TRUE;
-	task->interval_list = g_list_prepend (task->interval_list, ival);
-	ival->parent = task;
-
-	/* don't add the task until after we've done above */
-	if (NULL == proj->task_list)
-	{
-		gtt_project_append_task (proj, task);
-	}
-}
-
-void
-gtt_project_timer_update (GttProject *proj)
-{
-	GttTask *task;
-	GttInterval *ival;
-	time_t prev_update, now, diff;
-
-	if (!proj) return;
-	g_return_if_fail (proj->task_list);
-	g_return_if_fail (proj->current_task);
-
-	/* By definition, the current task is not anymore the one at the head
-	 * of the list, but rather the one denoted by GttProject->current_task
-	 * and the current interval is  at the head
-	 * of the task */
-	task = proj->current_task;
-	g_return_if_fail (task);
-
-	/* Its possible that there are no intervals (which implies
-	 * that the timer isn't running). */
-	if (NULL == task->interval_list) return;
-	ival = task->interval_list->data;
-	g_return_if_fail (ival);
-
-	/* If timer isn't running, do nothing.  Normally,
-	 * this function should never be called when timer is stopped,
-	 * but there are a few rare cases (e.g. clear daily counter).
-	 * where it is.
-	 */
-	if (FALSE == ival->running) return;
-
-	/* compute the delta change, update cached data */
-	now = time(0);
-
-	/* hack alert -- why aren't we checking a midnight rollover? */
-	prev_update = ival->stop;
-	ival->stop = now;
-	diff = now - prev_update;
-	proj->secs_ever += diff;
-	proj->secs_day += diff;
-	proj->secs_week += diff;
-	proj->secs_month += diff;
-	proj->secs_year += diff;
-}
-
-void
-gtt_project_timer_stop (GttProject *proj)
-{
-	GttTask *task;
-	GttInterval *ival;
-
-	if (!proj) return;
-	if (!proj->current_task) return;
-
-	gtt_project_timer_update (proj);
-
-	/* Also note that the timer really has stopped. */
-	task = proj->current_task;
-	g_return_if_fail (task);
-
-	/* its 'legal' to have no intervals, which implies
-	 * that the timer isn't running anyway. */
-	if (task->interval_list)
-	{
-		ival = task->interval_list->data;
-		g_return_if_fail (ival);
-		ival->running = FALSE;
-	}
-
-	/* When we stop the timer, call proj_refresh_time(),
-	 * as this will do several things: first, it will
-	 * scrub away short intervals and/or short gaps,
-	 * and, secondly, it will force redraws of affected
-	 * windows so that the old data doesn't show.
-	 */
-	proj_refresh_time (proj);
+                /* only nuke the ones that started after midnight.
+                 * The ones that started before midnight remain */
+                if (ivl->start >= midnight)
+                {
+                    task->interval_list = g_list_remove(task->interval_list, ivl);
+                    g_free(ivl);
+                    not_done = TRUE;
+                    break;
+                }
+            }
+        }
+    }
+    gtt_project_thaw(proj);
+    if (is_running)
+        gtt_project_timer_start(proj);
 }
 
 /* =========================================================== */
 
-static void
-prj_obj_foreach_helper (GList *prjlist, QofEntityForeachCB cb, gpointer data)
+void gtt_project_timer_start(GttProject *proj)
 {
-	GList *node;
+    GttTask *task;
+    GttInterval *ival;
+    time_t now;
 
-	for (node=prjlist; node; node=node->next)
-	{
-		GttProject *prj = node->data;
-		cb ((QofEntity *) prj, data);
-		prj_obj_foreach_helper (prj->sub_projects, cb, data);
-	}
+    if (!proj)
+        return;
+
+    /* By definition, the current task is not anymore the one at the head
+     * of the list, but rather the one denoted by GttProject->current_task
+     * and the current interval is  at the head
+     * of the task */
+    if (NULL == proj->task_list)
+    {
+        task = gtt_task_new();
+        gtt_task_set_memo(task, _("New Diary Entry"));
+        proj->current_task = task;
+    }
+    else
+    {
+        if (NULL == proj->current_task)
+        {
+            task = proj->task_list->data;
+            proj->current_task = task;
+        }
+        else
+        {
+            task = proj->current_task;
+        }
+
+        g_return_if_fail(task);
+    }
+
+    now = time(0);
+
+    /* only add a new interval if there's been a bit of a gap,
+     * otherwise, reuse the most recent running interval.  */
+    if (task->interval_list)
+    {
+        int delta;
+        ival = task->interval_list->data;
+        delta = now - ival->stop;
+
+        if (delta <= proj->auto_merge_gap)
+        {
+
+            ival->start += delta;
+            ival->fuzz += delta;
+            ival->stop = now;
+            ival->running = TRUE;
+            return;
+        }
+    }
+
+    ival = g_new0(GttInterval, 1);
+    ival->start = now;
+    ival->stop = ival->start;
+    ival->running = TRUE;
+    task->interval_list = g_list_prepend(task->interval_list, ival);
+    ival->parent = task;
+
+    /* don't add the task until after we've done above */
+    if (NULL == proj->task_list)
+    {
+        gtt_project_append_task(proj, task);
+    }
 }
 
-void
-gtt_project_obj_foreach (QofCollection *coll, QofEntityForeachCB cb, gpointer data)
+void gtt_project_timer_update(GttProject *proj)
 {
-	prj_obj_foreach_helper (global_plist->prj_list, cb, data);
+    GttTask *task;
+    GttInterval *ival;
+    time_t prev_update, now, diff;
+
+    if (!proj)
+        return;
+    g_return_if_fail(proj->task_list);
+    g_return_if_fail(proj->current_task);
+
+    /* By definition, the current task is not anymore the one at the head
+     * of the list, but rather the one denoted by GttProject->current_task
+     * and the current interval is  at the head
+     * of the task */
+    task = proj->current_task;
+    g_return_if_fail(task);
+
+    /* Its possible that there are no intervals (which implies
+     * that the timer isn't running). */
+    if (NULL == task->interval_list)
+        return;
+    ival = task->interval_list->data;
+    g_return_if_fail(ival);
+
+    /* If timer isn't running, do nothing.  Normally,
+     * this function should never be called when timer is stopped,
+     * but there are a few rare cases (e.g. clear daily counter).
+     * where it is.
+     */
+    if (FALSE == ival->running)
+        return;
+
+    /* compute the delta change, update cached data */
+    now = time(0);
+
+    /* hack alert -- why aren't we checking a midnight rollover? */
+    prev_update = ival->stop;
+    ival->stop = now;
+    diff = now - prev_update;
+    proj->secs_ever += diff;
+    proj->secs_day += diff;
+    proj->secs_week += diff;
+    proj->secs_month += diff;
+    proj->secs_year += diff;
 }
 
-static int
-prj_obj_order (GttProject *a, GttProject *b)
+void gtt_project_timer_stop(GttProject *proj)
 {
-	return 0;
+    GttTask *task;
+    GttInterval *ival;
+
+    if (!proj)
+        return;
+    if (!proj->current_task)
+        return;
+
+    gtt_project_timer_update(proj);
+
+    /* Also note that the timer really has stopped. */
+    task = proj->current_task;
+    g_return_if_fail(task);
+
+    /* its 'legal' to have no intervals, which implies
+     * that the timer isn't running anyway. */
+    if (task->interval_list)
+    {
+        ival = task->interval_list->data;
+        g_return_if_fail(ival);
+        ival->running = FALSE;
+    }
+
+    /* When we stop the timer, call proj_refresh_time(),
+     * as this will do several things: first, it will
+     * scrub away short intervals and/or short gaps,
+     * and, secondly, it will force redraws of affected
+     * windows so that the old data doesn't show.
+     */
+    proj_refresh_time(proj);
 }
 
-static QofObject prj_object_def =
+/* =========================================================== */
+
+static void prj_obj_foreach_helper(GList *prjlist, QofEntityForeachCB cb, gpointer data)
 {
-interface_version: QOF_OBJECT_VERSION,
-e_type:            GTT_PROJECT_ID,
-type_label:        GTT_PROJECT_ID,
-create:            NULL,
-book_begin:        NULL,
-book_end:          NULL,
-is_dirty:          NULL,
-mark_clean:        NULL,
-foreach:           gtt_project_obj_foreach,
-printable:         NULL,
+    GList *node;
+
+    for (node = prjlist; node; node = node->next)
+    {
+        GttProject *prj = node->data;
+        cb((QofEntity *) prj, data);
+        prj_obj_foreach_helper(prj->sub_projects, cb, data);
+    }
+}
+
+void gtt_project_obj_foreach(QofCollection *coll, QofEntityForeachCB cb, gpointer data)
+{
+    prj_obj_foreach_helper(global_plist->prj_list, cb, data);
+}
+
+static int prj_obj_order(GttProject *a, GttProject *b)
+{
+    return 0;
+}
+
+static QofObject prj_object_def = {
+    interface_version : QOF_OBJECT_VERSION,
+    e_type : GTT_PROJECT_ID,
+    type_label : GTT_PROJECT_ID,
+    create : NULL,
+    book_begin : NULL,
+    book_end : NULL,
+    is_dirty : NULL,
+    mark_clean : NULL,
+    foreach : gtt_project_obj_foreach,
+    printable : NULL,
 };
 
 /* =========================================================== */
 /* bogus wrappers */
-static QofTime *
-prj_obj_get_earliest (GttProject *prj, QofParam *qpm)
+static QofTime *prj_obj_get_earliest(GttProject *prj, QofParam *qpm)
 {
-	// static time return, not thread safe, but a hack that will do for now.
-	static QofTime *qt = NULL;
-	if (NULL == qt) qt = qof_time_new();
-	time_t gt = gtt_project_get_earliest_start (prj, TRUE);
-	qof_time_set_secs (qt, gt);
-	return qt;
+    // static time return, not thread safe, but a hack that will do for now.
+    static QofTime *qt = NULL;
+    if (NULL == qt)
+        qt = qof_time_new();
+    time_t gt = gtt_project_get_earliest_start(prj, TRUE);
+    qof_time_set_secs(qt, gt);
+    return qt;
 }
 
-static QofTime *
-prj_obj_get_latest (GttProject *prj, QofParam *qpm)
+static QofTime *prj_obj_get_latest(GttProject *prj, QofParam *qpm)
 {
-	static QofTime *qt = NULL;
-	if (NULL == qt) qt = qof_time_new();
-	time_t gt = gtt_project_get_latest_stop (prj, TRUE);
-	qof_time_set_secs (qt, gt);
-	return qt;
+    static QofTime *qt = NULL;
+    if (NULL == qt)
+        qt = qof_time_new();
+    time_t gt = gtt_project_get_latest_stop(prj, TRUE);
+    qof_time_set_secs(qt, gt);
+    return qt;
 }
 
-gboolean
-gtt_project_obj_register (void)
+gboolean gtt_project_obj_register(void)
 {
-	global_book = qof_book_new();
+    global_book = qof_book_new();
 
-/* Associate an ASCII name to each getter, as well as the return type */
-static QofParam params[] = {
-		{ GTT_PROJECT_EARLIEST, QOF_TYPE_TIME, (QofAccessFunc)prj_obj_get_earliest, NULL},
-		{ GTT_PROJECT_LATEST, QOF_TYPE_TIME, (QofAccessFunc)prj_obj_get_latest, NULL},
-		{ NULL },
-	};
+    /* Associate an ASCII name to each getter, as well as the return type */
+    static QofParam params[] = {
+        { GTT_PROJECT_EARLIEST, QOF_TYPE_TIME, (QofAccessFunc) prj_obj_get_earliest, NULL },
+        { GTT_PROJECT_LATEST, QOF_TYPE_TIME, (QofAccessFunc) prj_obj_get_latest, NULL },
+        { NULL },
+    };
 
-	qof_class_register (GTT_PROJECT_ID, (QofSortFunc)prj_obj_order, params);
-	return qof_object_register (&prj_object_def);
-}
-
-/* =========================================================== */
-
-GttTask *
-gtt_task_new (void)
-{
-	GttTask *task;
-
-	task = g_new0(GttTask, 1);
-	task->parent = NULL;
-	task->memo = g_strdup (_("New Diary Entry"));
-	task->notes = g_strdup ("");
-	task->billable = GTT_BILLABLE;
-	task->billrate = GTT_REGULAR;
-	task->billstatus = GTT_BILL,
-	task->bill_unit = 900;
-	task->interval_list = NULL;
-
-	qof_instance_init (&task->inst, GTT_TASK_ID, global_book);
-	return task;
-}
-
-GttTask *
-gtt_task_copy (GttTask *old)
-{
-	GttTask *task;
-
-	if (!old) return gtt_task_new();
-
-	task = g_new0(GttTask, 1);
-	task->parent = NULL;
-	task->memo = g_strdup (old->memo);
-	task->notes = g_strdup (old->notes);
-
-	/* inherit the properties ... important for user */
-	task->billable = old->billable;
-	task->billrate = old->billrate;
-	task->billstatus = old->billstatus;
-	task->bill_unit = old->bill_unit;
-	task->interval_list = NULL;
-
-	qof_instance_init (&task->inst, GTT_TASK_ID, global_book);
-	return task;
-}
-
-static int
-task_suspend (GttTask *tsk)
-{
-	int is_running = 0;
-
-	/* avoid misplaced running intervals, stop the task */
-	if (tsk->interval_list)
-	{
-		GttInterval *first_ivl;
-		first_ivl = (GttInterval *) (tsk->interval_list->data);
-		is_running = first_ivl -> running;
-		if (is_running)
-		{
-			/* don't call stop here, avoid dispatching redraw events */
-			gtt_project_timer_update (tsk->parent);
-			first_ivl->running = FALSE;
-		}
-	}
-	return is_running;
-}
-
-
-void
-gtt_task_destroy (GttTask *task)
-{
-	int is_running;
-	if (!task) return;
-
-	is_running = task_suspend (task);
-	if (task->parent)
-	{
-		task->parent->task_list =
-			g_list_remove (task->parent->task_list, task);
-		if (is_running) gtt_project_timer_start (task->parent);
-		proj_refresh_time (task->parent);
-		task->parent = NULL;
-	}
-
-	if (task->memo) g_free(task->memo);
-	task->memo = NULL;
-	if (task->notes) g_free(task->notes);
-	task->notes = NULL;
-	if (task->interval_list)
-	{
-		GList *node;
-		for (node = task->interval_list; node; node=node->next)
-		{
-			/* free the individual intervals */
-			g_free (node->data);
-		}
-		g_list_free (task->interval_list);
-		task->interval_list = NULL;
-	}
-}
-
-void
-gtt_task_remove (GttTask *task)
-{
-	int is_running;
-	if (!task) return;
-
-	is_running = task_suspend (task);
-
-	GttProject *project = task->parent;
-
-	if (project)
-	{
-		project->task_list =
-			g_list_remove (project->task_list, task);
-		gtt_project_set_current_task(project,
-				gtt_project_get_first_task(project));
-		if (is_running) gtt_project_timer_start (project);
-		proj_refresh_time (project);
-		task->parent = NULL;
-	}
-}
-
-
-void
-gtt_task_insert (GttTask *where, GttTask *insertee)
-{
-	GttProject *prj;
-	int idx;
-	int is_running = 0;
-
-	if (!where || !insertee) return;
-
-	prj = where->parent;
-	if (!prj) return;
-
-	gtt_task_remove (insertee);
-	is_running = task_suspend (where);
-
-	insertee->parent = prj;
-	idx = g_list_index (prj->task_list, where);
-	prj->task_list = g_list_insert (prj->task_list, insertee, idx);
-
-	if (is_running) gtt_project_timer_start (prj);
-	proj_refresh_time (prj);
-}
-
-GttTask *
-gtt_task_new_insert (GttTask *old)
-{
-	int is_running = 0;
-	GttProject *prj;
-	GttTask *task;
-	int idx;
-
-	if (!old) return NULL;
-
-	task = gtt_task_new();
-
-	/* Inherit the properties ... important for user */
-	task->billable = old->billable;
-	task->billrate = old->billrate;
-	task->billstatus = old->billstatus;
-	task->bill_unit = old->bill_unit;
-	task->interval_list = NULL;
-
-	/* chain into place */
-	prj = old->parent;
-	task->parent = prj;
-	if (!prj) return task;
-
-	/* avoid misplaced running intervals, stop the task */
-	is_running = task_suspend (old);
-
-	idx = g_list_index (prj->task_list, old);
-	prj->task_list = g_list_insert (prj->task_list, task, idx);
-	prj->current_task = task;
-
-	if (is_running) gtt_project_timer_start (prj);
-	proj_refresh_time (prj);
-	return task;
-}
-
-void
-gtt_task_set_guid (GttTask *tsk, const GUID *guid)
-{
-	qof_entity_set_guid (&tsk->inst.entity, guid);
-}
-
-const GUID *
-gtt_task_get_guid (GttTask *tsk)
-{
-	return qof_entity_get_guid (&tsk->inst.entity);
-}
-
-void
-gtt_task_add_interval (GttTask *tsk, GttInterval *ival)
-{
-	if (!tsk || !ival) return;
-	gtt_interval_unhook (ival);
-	tsk->interval_list = g_list_prepend (tsk->interval_list, ival);
-	ival->parent = tsk;
-	proj_refresh_time (tsk->parent);
-}
-
-void
-gtt_task_append_interval (GttTask *tsk, GttInterval *ival)
-{
-	if (!tsk || !ival) return;
-	gtt_interval_unhook (ival);
-	tsk->interval_list = g_list_append (tsk->interval_list, ival);
-	ival->parent = tsk;
-	proj_refresh_time (tsk->parent);
-}
-
-void
-gtt_task_set_memo(GttTask *tsk, const char *m)
-{
-	if (!tsk) return;
-	if (tsk->memo) g_free(tsk->memo);
-	if (!m)
-	{
-		tsk->memo = g_strdup ("");
-		return;
-	}
-	tsk->memo = g_strdup(m);
-	proj_modified (tsk->parent);
-}
-
-void
-gtt_task_set_notes(GttTask *tsk, const char *m)
-{
-	if (!tsk) return;
-	if (tsk->notes) g_free(tsk->notes);
-	if (!m)
-	{
-		tsk->notes = g_strdup ("");
-		return;
-	}
-	tsk->notes = g_strdup(m);
-	proj_modified (tsk->parent);
-}
-
-const char *
-gtt_task_get_memo (GttTask *tsk)
-{
-	if (!tsk) return NULL;
-	return tsk->memo;
-}
-
-const char *
-gtt_task_get_notes (GttTask *tsk)
-{
-	if (!tsk) return NULL;
-	return tsk->notes;
-}
-
-void
-gtt_task_set_billable (GttTask *tsk, GttBillable b)
-{
-	if (!tsk) return;
-	tsk->billable = b;
-	proj_modified (tsk->parent);
-}
-
-GttBillable
-gtt_task_get_billable (GttTask *tsk)
-{
-	if (!tsk) return GTT_NOT_BILLABLE;
-	return tsk->billable;
-}
-
-void
-gtt_task_set_billrate (GttTask *tsk, GttBillRate b)
-{
-	if (!tsk) return;
-	tsk->billrate = b;
-	proj_modified (tsk->parent);
-}
-
-GttBillRate
-gtt_task_get_billrate (GttTask *tsk)
-{
-	if (!tsk) return GTT_REGULAR;
-	return tsk->billrate;
-}
-
-void
-gtt_task_set_billstatus (GttTask *tsk, GttBillStatus b)
-{
-	if (!tsk) return;
-	tsk->billstatus = b;
-	proj_modified (tsk->parent);
-}
-
-GttBillStatus
-gtt_task_get_billstatus (GttTask *tsk)
-{
-	if (!tsk) return GTT_HOLD;
-	return tsk->billstatus;
-}
-
-void
-gtt_task_set_bill_unit (GttTask *tsk, int b)
-{
-	if (!tsk) return;
-	tsk->bill_unit = b;
-	proj_modified (tsk->parent);
-}
-
-int
-gtt_task_get_bill_unit (GttTask *tsk)
-{
-	if (!tsk) return GTT_REGULAR;
-	return tsk->bill_unit;
-}
-
-GList *
-gtt_task_get_intervals (GttTask *tsk)
-{
-	if (!tsk) return NULL;
-	return tsk->interval_list;
-}
-
-gboolean
-gtt_task_is_first_task (GttTask *tsk)
-{
-	if (!tsk || !tsk->parent || !tsk->parent->task_list) return TRUE;
-
-	if ((GttTask *) tsk->parent->task_list->data == tsk) return TRUE;
-	return FALSE;
-}
-
-gboolean
-gtt_task_is_last_task (GttTask *tsk)
-{
-	if (!tsk || !tsk->parent || !tsk->parent->task_list) return TRUE;
-
-	GList *last = g_list_last (tsk->parent->task_list);
-	if ((GttTask *) last->data == tsk) return TRUE;
-	return FALSE;
-}
-
-GttProject *
-gtt_task_get_parent (GttTask *tsk)
-{
-	if (!tsk) return NULL;
-	return tsk->parent;
+    qof_class_register(GTT_PROJECT_ID, (QofSortFunc) prj_obj_order, params);
+    return qof_object_register(&prj_object_def);
 }
 
 /* =========================================================== */
 
-void
-gtt_task_merge_up (GttTask *tsk)
+GttTask *gtt_task_new(void)
 {
-	GttTask *mtask;
-	GList * node;
-	GttProject *prj;
-	if (!tsk) return;
+    GttTask *task;
 
-	prj = tsk->parent;
-	if (!prj || !prj->task_list) return;
+    task = g_new0(GttTask, 1);
+    task->parent = NULL;
+    task->memo = g_strdup(_("New Diary Entry"));
+    task->notes = g_strdup("");
+    task->billable = GTT_BILLABLE;
+    task->billrate = GTT_REGULAR;
+    task->billstatus = GTT_BILL, task->bill_unit = 900;
+    task->interval_list = NULL;
 
-	node = g_list_find (prj->task_list, tsk);
-	if (!node) return;
+    qof_instance_init(&task->inst, GTT_TASK_ID, global_book);
+    return task;
+}
 
-	node = node->prev;
-	if (!node) return;
+GttTask *gtt_task_copy(GttTask *old)
+{
+    GttTask *task;
 
-	mtask = node->data;
+    if (!old)
+        return gtt_task_new();
 
-	for (node=tsk->interval_list; node; node=node->next)
-	{
-		GttInterval *ivl = node->data;
-		ivl->parent = mtask;
-	}
-	mtask->interval_list = g_list_concat (mtask->interval_list, tsk->interval_list);
-	tsk->interval_list = NULL;
+    task = g_new0(GttTask, 1);
+    task->parent = NULL;
+    task->memo = g_strdup(old->memo);
+    task->notes = g_strdup(old->notes);
+
+    /* inherit the properties ... important for user */
+    task->billable = old->billable;
+    task->billrate = old->billrate;
+    task->billstatus = old->billstatus;
+    task->bill_unit = old->bill_unit;
+    task->interval_list = NULL;
+
+    qof_instance_init(&task->inst, GTT_TASK_ID, global_book);
+    return task;
+}
+
+static int task_suspend(GttTask *tsk)
+{
+    int is_running = 0;
+
+    /* avoid misplaced running intervals, stop the task */
+    if (tsk->interval_list)
+    {
+        GttInterval *first_ivl;
+        first_ivl = (GttInterval *) (tsk->interval_list->data);
+        is_running = first_ivl->running;
+        if (is_running)
+        {
+            /* don't call stop here, avoid dispatching redraw events */
+            gtt_project_timer_update(tsk->parent);
+            first_ivl->running = FALSE;
+        }
+    }
+    return is_running;
+}
+
+void gtt_task_destroy(GttTask *task)
+{
+    int is_running;
+    if (!task)
+        return;
+
+    is_running = task_suspend(task);
+    if (task->parent)
+    {
+        task->parent->task_list = g_list_remove(task->parent->task_list, task);
+        if (is_running)
+            gtt_project_timer_start(task->parent);
+        proj_refresh_time(task->parent);
+        task->parent = NULL;
+    }
+
+    if (task->memo)
+        g_free(task->memo);
+    task->memo = NULL;
+    if (task->notes)
+        g_free(task->notes);
+    task->notes = NULL;
+    if (task->interval_list)
+    {
+        GList *node;
+        for (node = task->interval_list; node; node = node->next)
+        {
+            /* free the individual intervals */
+            g_free(node->data);
+        }
+        g_list_free(task->interval_list);
+        task->interval_list = NULL;
+    }
+}
+
+void gtt_task_remove(GttTask *task)
+{
+    int is_running;
+    if (!task)
+        return;
+
+    is_running = task_suspend(task);
+
+    GttProject *project = task->parent;
+
+    if (project)
+    {
+        project->task_list = g_list_remove(project->task_list, task);
+        gtt_project_set_current_task(project, gtt_project_get_first_task(project));
+        if (is_running)
+            gtt_project_timer_start(project);
+        proj_refresh_time(project);
+        task->parent = NULL;
+    }
+}
+
+void gtt_task_insert(GttTask *where, GttTask *insertee)
+{
+    GttProject *prj;
+    int idx;
+    int is_running = 0;
+
+    if (!where || !insertee)
+        return;
+
+    prj = where->parent;
+    if (!prj)
+        return;
+
+    gtt_task_remove(insertee);
+    is_running = task_suspend(where);
+
+    insertee->parent = prj;
+    idx = g_list_index(prj->task_list, where);
+    prj->task_list = g_list_insert(prj->task_list, insertee, idx);
+
+    if (is_running)
+        gtt_project_timer_start(prj);
+    proj_refresh_time(prj);
+}
+
+GttTask *gtt_task_new_insert(GttTask *old)
+{
+    int is_running = 0;
+    GttProject *prj;
+    GttTask *task;
+    int idx;
+
+    if (!old)
+        return NULL;
+
+    task = gtt_task_new();
+
+    /* Inherit the properties ... important for user */
+    task->billable = old->billable;
+    task->billrate = old->billrate;
+    task->billstatus = old->billstatus;
+    task->bill_unit = old->bill_unit;
+    task->interval_list = NULL;
+
+    /* chain into place */
+    prj = old->parent;
+    task->parent = prj;
+    if (!prj)
+        return task;
+
+    /* avoid misplaced running intervals, stop the task */
+    is_running = task_suspend(old);
+
+    idx = g_list_index(prj->task_list, old);
+    prj->task_list = g_list_insert(prj->task_list, task, idx);
+    prj->current_task = task;
+
+    if (is_running)
+        gtt_project_timer_start(prj);
+    proj_refresh_time(prj);
+    return task;
+}
+
+void gtt_task_set_guid(GttTask *tsk, const GUID *guid)
+{
+    qof_entity_set_guid(&tsk->inst.entity, guid);
+}
+
+const GUID *gtt_task_get_guid(GttTask *tsk)
+{
+    return qof_entity_get_guid(&tsk->inst.entity);
+}
+
+void gtt_task_add_interval(GttTask *tsk, GttInterval *ival)
+{
+    if (!tsk || !ival)
+        return;
+    gtt_interval_unhook(ival);
+    tsk->interval_list = g_list_prepend(tsk->interval_list, ival);
+    ival->parent = tsk;
+    proj_refresh_time(tsk->parent);
+}
+
+void gtt_task_append_interval(GttTask *tsk, GttInterval *ival)
+{
+    if (!tsk || !ival)
+        return;
+    gtt_interval_unhook(ival);
+    tsk->interval_list = g_list_append(tsk->interval_list, ival);
+    ival->parent = tsk;
+    proj_refresh_time(tsk->parent);
+}
+
+void gtt_task_set_memo(GttTask *tsk, const char *m)
+{
+    if (!tsk)
+        return;
+    if (tsk->memo)
+        g_free(tsk->memo);
+    if (!m)
+    {
+        tsk->memo = g_strdup("");
+        return;
+    }
+    tsk->memo = g_strdup(m);
+    proj_modified(tsk->parent);
+}
+
+void gtt_task_set_notes(GttTask *tsk, const char *m)
+{
+    if (!tsk)
+        return;
+    if (tsk->notes)
+        g_free(tsk->notes);
+    if (!m)
+    {
+        tsk->notes = g_strdup("");
+        return;
+    }
+    tsk->notes = g_strdup(m);
+    proj_modified(tsk->parent);
+}
+
+const char *gtt_task_get_memo(GttTask *tsk)
+{
+    if (!tsk)
+        return NULL;
+    return tsk->memo;
+}
+
+const char *gtt_task_get_notes(GttTask *tsk)
+{
+    if (!tsk)
+        return NULL;
+    return tsk->notes;
+}
+
+void gtt_task_set_billable(GttTask *tsk, GttBillable b)
+{
+    if (!tsk)
+        return;
+    tsk->billable = b;
+    proj_modified(tsk->parent);
+}
+
+GttBillable gtt_task_get_billable(GttTask *tsk)
+{
+    if (!tsk)
+        return GTT_NOT_BILLABLE;
+    return tsk->billable;
+}
+
+void gtt_task_set_billrate(GttTask *tsk, GttBillRate b)
+{
+    if (!tsk)
+        return;
+    tsk->billrate = b;
+    proj_modified(tsk->parent);
+}
+
+GttBillRate gtt_task_get_billrate(GttTask *tsk)
+{
+    if (!tsk)
+        return GTT_REGULAR;
+    return tsk->billrate;
+}
+
+void gtt_task_set_billstatus(GttTask *tsk, GttBillStatus b)
+{
+    if (!tsk)
+        return;
+    tsk->billstatus = b;
+    proj_modified(tsk->parent);
+}
+
+GttBillStatus gtt_task_get_billstatus(GttTask *tsk)
+{
+    if (!tsk)
+        return GTT_HOLD;
+    return tsk->billstatus;
+}
+
+void gtt_task_set_bill_unit(GttTask *tsk, int b)
+{
+    if (!tsk)
+        return;
+    tsk->bill_unit = b;
+    proj_modified(tsk->parent);
+}
+
+int gtt_task_get_bill_unit(GttTask *tsk)
+{
+    if (!tsk)
+        return GTT_REGULAR;
+    return tsk->bill_unit;
+}
+
+GList *gtt_task_get_intervals(GttTask *tsk)
+{
+    if (!tsk)
+        return NULL;
+    return tsk->interval_list;
+}
+
+gboolean gtt_task_is_first_task(GttTask *tsk)
+{
+    if (!tsk || !tsk->parent || !tsk->parent->task_list)
+        return TRUE;
+
+    if ((GttTask *) tsk->parent->task_list->data == tsk)
+        return TRUE;
+    return FALSE;
+}
+
+gboolean gtt_task_is_last_task(GttTask *tsk)
+{
+    if (!tsk || !tsk->parent || !tsk->parent->task_list)
+        return TRUE;
+
+    GList *last = g_list_last(tsk->parent->task_list);
+    if ((GttTask *) last->data == tsk)
+        return TRUE;
+    return FALSE;
+}
+
+GttProject *gtt_task_get_parent(GttTask *tsk)
+{
+    if (!tsk)
+        return NULL;
+    return tsk->parent;
 }
 
 /* =========================================================== */
 
-int
-gtt_task_get_secs_ever (GttTask *tsk)
+void gtt_task_merge_up(GttTask *tsk)
 {
-	GList *node;
-	int total = 0;
+    GttTask *mtask;
+    GList *node;
+    GttProject *prj;
+    if (!tsk)
+        return;
 
-	for (node=tsk->interval_list; node; node=node->next)
-	{
-		GttInterval * ivl = node->data;
-		total += ivl->stop - ivl->start;
-	}
-	return total;
-}
+    prj = tsk->parent;
+    if (!prj || !prj->task_list)
+        return;
 
-time_t
-gtt_task_get_secs_earliest (GttTask *tsk)
-{
-	GList *node;
-	if (NULL == tsk->interval_list) return 0;
+    node = g_list_find(prj->task_list, tsk);
+    if (!node)
+        return;
 
-	time_t earliest = INT_MAX;
+    node = node->prev;
+    if (!node)
+        return;
 
-	for (node=tsk->interval_list; node; node=node->next)
-	{
-		GttInterval * ivl = node->data;
-		if (ivl->start < earliest) earliest = ivl->start;
-	}
-	return earliest;
-}
+    mtask = node->data;
 
-time_t
-gtt_task_get_secs_latest (GttTask *tsk)
-{
-	GList *node;
-	if (NULL == tsk->interval_list) return 0;
-
-	time_t latest = INT_MIN;
-
-	for (node=tsk->interval_list; node; node=node->next)
-	{
-		GttInterval * ivl = node->data;
-		if (ivl->stop > latest) latest = ivl->stop;
-	}
-	return latest;
+    for (node = tsk->interval_list; node; node = node->next)
+    {
+        GttInterval *ivl = node->data;
+        ivl->parent = mtask;
+    }
+    mtask->interval_list = g_list_concat(mtask->interval_list, tsk->interval_list);
+    tsk->interval_list = NULL;
 }
 
 /* =========================================================== */
 
-GttInterval *
-gtt_interval_new (void)
+int gtt_task_get_secs_ever(GttTask *tsk)
 {
-	GttInterval * ivl;
-	ivl = g_new0 (GttInterval, 1);
-	ivl->parent = NULL;
-	ivl->start = 0;
-	ivl->stop = 0;
-	ivl->running = FALSE;
-	ivl->fuzz = 0;
-	return ivl;
+    GList *node;
+    int total = 0;
+
+    for (node = tsk->interval_list; node; node = node->next)
+    {
+        GttInterval *ivl = node->data;
+        total += ivl->stop - ivl->start;
+    }
+    return total;
 }
 
-void
-gtt_interval_destroy (GttInterval * ivl)
+time_t gtt_task_get_secs_earliest(GttTask *tsk)
 {
-	if (!ivl) return;
-	gtt_interval_unhook (ivl);
-	g_free (ivl);
+    GList *node;
+    if (NULL == tsk->interval_list)
+        return 0;
+
+    time_t earliest = INT_MAX;
+
+    for (node = tsk->interval_list; node; node = node->next)
+    {
+        GttInterval *ivl = node->data;
+        if (ivl->start < earliest)
+            earliest = ivl->start;
+    }
+    return earliest;
 }
 
-static void
-gtt_interval_unhook (GttInterval * ivl)
+time_t gtt_task_get_secs_latest(GttTask *tsk)
 {
-	if (NULL == ivl->parent) return;
+    GList *node;
+    if (NULL == tsk->interval_list)
+        return 0;
 
-	/* Unhook myself from the chain */
-	ivl->parent->interval_list =
-		g_list_remove (ivl->parent->interval_list, ivl);
-	proj_refresh_time (ivl->parent->parent);
-	ivl->parent = NULL;
+    time_t latest = INT_MIN;
+
+    for (node = tsk->interval_list; node; node = node->next)
+    {
+        GttInterval *ivl = node->data;
+        if (ivl->stop > latest)
+            latest = ivl->stop;
+    }
+    return latest;
 }
 
-void
-gtt_interval_set_start (GttInterval *ivl, time_t st)
+/* =========================================================== */
+
+GttInterval *gtt_interval_new(void)
 {
-	if (!ivl) return;
-	ivl->start = st;
-	if (st > ivl->stop) ivl->stop = st;
-	if (ivl->parent) proj_refresh_time (ivl->parent->parent);
+    GttInterval *ivl;
+    ivl = g_new0(GttInterval, 1);
+    ivl->parent = NULL;
+    ivl->start = 0;
+    ivl->stop = 0;
+    ivl->running = FALSE;
+    ivl->fuzz = 0;
+    return ivl;
 }
 
-void
-gtt_interval_set_stop (GttInterval *ivl, time_t st)
+void gtt_interval_destroy(GttInterval *ivl)
 {
-	if (!ivl) return;
-	ivl->stop = st;
-	if (st < ivl->start) ivl->start = st;
-	if (ivl->parent) proj_refresh_time (ivl->parent->parent);
+    if (!ivl)
+        return;
+    gtt_interval_unhook(ivl);
+    g_free(ivl);
 }
 
-void
-gtt_interval_set_fuzz (GttInterval *ivl, int st)
+static void gtt_interval_unhook(GttInterval *ivl)
 {
-	if (!ivl) return;
-	ivl->fuzz = st;
-	if (ivl->parent) proj_modified (ivl->parent->parent);
+    if (NULL == ivl->parent)
+        return;
+
+    /* Unhook myself from the chain */
+    ivl->parent->interval_list = g_list_remove(ivl->parent->interval_list, ivl);
+    proj_refresh_time(ivl->parent->parent);
+    ivl->parent = NULL;
 }
 
-void
-gtt_interval_set_running (GttInterval *ivl, gboolean st)
+void gtt_interval_set_start(GttInterval *ivl, time_t st)
 {
-	if (!ivl) return;
-	ivl->running = st;
-	if (ivl->parent) proj_modified (ivl->parent->parent);
+    if (!ivl)
+        return;
+    ivl->start = st;
+    if (st > ivl->stop)
+        ivl->stop = st;
+    if (ivl->parent)
+        proj_refresh_time(ivl->parent->parent);
 }
 
-time_t
-gtt_interval_get_start (GttInterval * ivl)
+void gtt_interval_set_stop(GttInterval *ivl, time_t st)
 {
-	if (!ivl) return 0;
-	return ivl->start;
+    if (!ivl)
+        return;
+    ivl->stop = st;
+    if (st < ivl->start)
+        ivl->start = st;
+    if (ivl->parent)
+        proj_refresh_time(ivl->parent->parent);
 }
 
-time_t
-gtt_interval_get_stop (GttInterval * ivl)
+void gtt_interval_set_fuzz(GttInterval *ivl, int st)
 {
-	if (!ivl) return 0;
-	return ivl->stop;
+    if (!ivl)
+        return;
+    ivl->fuzz = st;
+    if (ivl->parent)
+        proj_modified(ivl->parent->parent);
 }
 
-int
-gtt_interval_get_fuzz (GttInterval * ivl)
+void gtt_interval_set_running(GttInterval *ivl, gboolean st)
 {
-	if (!ivl) return 0;
-	return ivl->fuzz;
+    if (!ivl)
+        return;
+    ivl->running = st;
+    if (ivl->parent)
+        proj_modified(ivl->parent->parent);
 }
 
-gboolean
-gtt_interval_is_running (GttInterval * ivl)
+time_t gtt_interval_get_start(GttInterval *ivl)
 {
-	if (!ivl) return FALSE;
-	return (gboolean) ivl->running;
+    if (!ivl)
+        return 0;
+    return ivl->start;
 }
 
-GttTask *
-gtt_interval_get_parent (GttInterval * ivl)
+time_t gtt_interval_get_stop(GttInterval *ivl)
 {
-	if (!ivl) return NULL;
-	return ivl->parent;
+    if (!ivl)
+        return 0;
+    return ivl->stop;
 }
 
-gboolean
-gtt_interval_is_first_interval (GttInterval *ivl)
+int gtt_interval_get_fuzz(GttInterval *ivl)
 {
-	if (!ivl || !ivl->parent || !ivl->parent->interval_list) return TRUE;
-
-	if ((GttInterval *) ivl->parent->interval_list->data == ivl) return TRUE;
-	return FALSE;
+    if (!ivl)
+        return 0;
+    return ivl->fuzz;
 }
 
-gboolean
-gtt_interval_is_last_interval (GttInterval *ivl)
+gboolean gtt_interval_is_running(GttInterval *ivl)
 {
-	if (!ivl || !ivl->parent || !ivl->parent->interval_list) return TRUE;
+    if (!ivl)
+        return FALSE;
+    return (gboolean) ivl->running;
+}
 
-	if ((GttInterval *) ((g_list_last(ivl->parent->interval_list))->data) == ivl) return TRUE;
-	return FALSE;
+GttTask *gtt_interval_get_parent(GttInterval *ivl)
+{
+    if (!ivl)
+        return NULL;
+    return ivl->parent;
+}
+
+gboolean gtt_interval_is_first_interval(GttInterval *ivl)
+{
+    if (!ivl || !ivl->parent || !ivl->parent->interval_list)
+        return TRUE;
+
+    if ((GttInterval *) ivl->parent->interval_list->data == ivl)
+        return TRUE;
+    return FALSE;
+}
+
+gboolean gtt_interval_is_last_interval(GttInterval *ivl)
+{
+    if (!ivl || !ivl->parent || !ivl->parent->interval_list)
+        return TRUE;
+
+    if ((GttInterval *) ((g_list_last(ivl->parent->interval_list))->data) == ivl)
+        return TRUE;
+    return FALSE;
 }
 
 /* ============================================================= */
 
-GttInterval *
-gtt_interval_new_insert_after (GttInterval *where)
+GttInterval *gtt_interval_new_insert_after(GttInterval *where)
 {
-	GttInterval *ivl;
-	GttTask *tsk;
-	int idx;
+    GttInterval *ivl;
+    GttTask *tsk;
+    int idx;
 
-	if (!where) return NULL;
+    if (!where)
+        return NULL;
 
-	tsk = where->parent;
-	if (!tsk) return NULL;
+    tsk = where->parent;
+    if (!tsk)
+        return NULL;
 
-	/* clone the other interval */
-	ivl = g_new0 (GttInterval, 1);
-	ivl->parent = tsk;
-	ivl->start = where->start;
-	ivl->stop = where->stop;
-	ivl->running = FALSE;
-	ivl->fuzz = where->fuzz;
+    /* clone the other interval */
+    ivl = g_new0(GttInterval, 1);
+    ivl->parent = tsk;
+    ivl->start = where->start;
+    ivl->stop = where->stop;
+    ivl->running = FALSE;
+    ivl->fuzz = where->fuzz;
 
-	idx = g_list_index (tsk->interval_list, where);
-	tsk->interval_list = g_list_insert (tsk->interval_list, ivl, idx);
+    idx = g_list_index(tsk->interval_list, where);
+    tsk->interval_list = g_list_insert(tsk->interval_list, ivl, idx);
 
-	/* Don't do a refresh, since the refresh will probably
-	 * cull this interval for being to short, or merge it,
-	 * or something.  Refresh only after some edit has occurred.
-	 */
-	/* proj_refresh_time (tsk->parent); */
+    /* Don't do a refresh, since the refresh will probably
+     * cull this interval for being to short, or merge it,
+     * or something.  Refresh only after some edit has occurred.
+     */
+    /* proj_refresh_time (tsk->parent); */
 
-	return ivl;
+    return ivl;
 }
 
-
-GttInterval *
-gtt_interval_merge_up (GttInterval *ivl)
+GttInterval *gtt_interval_merge_up(GttInterval *ivl)
 {
-	int more_fuzz;
-	int ivl_len;
-	GList *node;
-	GttInterval *merge;
-	GttTask *prnt;
+    int more_fuzz;
+    int ivl_len;
+    GList *node;
+    GttInterval *merge;
+    GttTask *prnt;
 
-	if (!ivl) return NULL;
-	prnt = ivl->parent;
-	if (!prnt) return NULL;
+    if (!ivl)
+        return NULL;
+    prnt = ivl->parent;
+    if (!prnt)
+        return NULL;
 
-	for (node=prnt->interval_list; node; node=node->next)
-	{
-		if (ivl == node->data) break;
-	}
-	if (!node) return NULL;
-	node = node->prev;
-	if (!node) return NULL;
+    for (node = prnt->interval_list; node; node = node->next)
+    {
+        if (ivl == node->data)
+            break;
+    }
+    if (!node)
+        return NULL;
+    node = node->prev;
+    if (!node)
+        return NULL;
 
-	merge = node->data;
-	if (!merge) return NULL;
+    merge = node->data;
+    if (!merge)
+        return NULL;
 
-	/* the fuzz is the gap between stop and start times */
-	more_fuzz = merge->start - ivl->stop;
-	ivl_len = ivl->stop - ivl->start;
-	if (more_fuzz > ivl_len) more_fuzz = ivl_len;
+    /* the fuzz is the gap between stop and start times */
+    more_fuzz = merge->start - ivl->stop;
+    ivl_len = ivl->stop - ivl->start;
+    if (more_fuzz > ivl_len)
+        more_fuzz = ivl_len;
 
-	merge->start -= ivl_len;
-	if (ivl->fuzz > merge->fuzz) merge->fuzz = ivl->fuzz;
-	if (more_fuzz > merge->fuzz) merge->fuzz = more_fuzz;
+    merge->start -= ivl_len;
+    if (ivl->fuzz > merge->fuzz)
+        merge->fuzz = ivl->fuzz;
+    if (more_fuzz > merge->fuzz)
+        merge->fuzz = more_fuzz;
 
-	gtt_interval_destroy (ivl);
+    gtt_interval_destroy(ivl);
 
-	proj_refresh_time (prnt->parent);
-	return merge;
+    proj_refresh_time(prnt->parent);
+    return merge;
 }
 
-
-GttInterval *
-gtt_interval_merge_down (GttInterval *ivl)
+GttInterval *gtt_interval_merge_down(GttInterval *ivl)
 {
-	int more_fuzz;
-	int ivl_len;
-	GList *node;
-	GttInterval *merge;
-	GttTask *prnt;
+    int more_fuzz;
+    int ivl_len;
+    GList *node;
+    GttInterval *merge;
+    GttTask *prnt;
 
-	if (!ivl) return NULL;
-	prnt = ivl->parent;
-	if (!prnt) return NULL;
+    if (!ivl)
+        return NULL;
+    prnt = ivl->parent;
+    if (!prnt)
+        return NULL;
 
-	for (node=prnt->interval_list; node; node=node->next)
-	{
-		if (ivl == node->data) break;
-	}
-	if (!node) return NULL;
-	node = node->next;
-	if (!node) return NULL;
+    for (node = prnt->interval_list; node; node = node->next)
+    {
+        if (ivl == node->data)
+            break;
+    }
+    if (!node)
+        return NULL;
+    node = node->next;
+    if (!node)
+        return NULL;
 
-	merge = node->data;
-	if (!merge) return NULL;
+    merge = node->data;
+    if (!merge)
+        return NULL;
 
-	/* the fuzz is the gap between stop and start times */
-	more_fuzz = ivl->start - merge->stop;
-	ivl_len = ivl->stop - ivl->start;
-	if (more_fuzz > ivl_len) more_fuzz = ivl_len;
+    /* the fuzz is the gap between stop and start times */
+    more_fuzz = ivl->start - merge->stop;
+    ivl_len = ivl->stop - ivl->start;
+    if (more_fuzz > ivl_len)
+        more_fuzz = ivl_len;
 
-	merge->stop += ivl_len;
-	if (ivl->fuzz > merge->fuzz) merge->fuzz = ivl->fuzz;
-	if (more_fuzz > merge->fuzz) merge->fuzz = more_fuzz;
-	gtt_interval_destroy (ivl);
+    merge->stop += ivl_len;
+    if (ivl->fuzz > merge->fuzz)
+        merge->fuzz = ivl->fuzz;
+    if (more_fuzz > merge->fuzz)
+        merge->fuzz = more_fuzz;
+    gtt_interval_destroy(ivl);
 
-	proj_refresh_time (prnt->parent);
-	return merge;
+    proj_refresh_time(prnt->parent);
+    return merge;
 }
 
-void
-gtt_interval_split (GttInterval *ivl, GttTask *newtask)
+void gtt_interval_split(GttInterval *ivl, GttTask *newtask)
 {
-	int is_running = 0;
-	gint idx;
-	GttProject *prj;
-	GttTask *prnt;
-	GList *node;
-	GttInterval *first_ivl;
+    int is_running = 0;
+    gint idx;
+    GttProject *prj;
+    GttTask *prnt;
+    GList *node;
+    GttInterval *first_ivl;
 
-	if (!ivl || !newtask) return;
-	prnt = ivl->parent;
-	if (!prnt) return;
-	prj = prnt->parent;
-	if (!prj) return;
-	node = g_list_find (prnt->interval_list, ivl);
-	if (!node) return;
+    if (!ivl || !newtask)
+        return;
+    prnt = ivl->parent;
+    if (!prnt)
+        return;
+    prj = prnt->parent;
+    if (!prj)
+        return;
+    node = g_list_find(prnt->interval_list, ivl);
+    if (!node)
+        return;
 
-	gtt_task_remove (newtask);
+    gtt_task_remove(newtask);
 
-	/* avoid misplaced running intervals, stop the task */
-	first_ivl = (GttInterval *) (prnt->interval_list->data);
-	is_running = first_ivl -> running;
-	if (is_running)
-	{
-		/* don't call stop here, avoid dispatching redraw events */
-		gtt_project_timer_update (prj);
-		first_ivl->running = FALSE;
-	}
+    /* avoid misplaced running intervals, stop the task */
+    first_ivl = (GttInterval *) (prnt->interval_list->data);
+    is_running = first_ivl->running;
+    if (is_running)
+    {
+        /* don't call stop here, avoid dispatching redraw events */
+        gtt_project_timer_update(prj);
+        first_ivl->running = FALSE;
+    }
 
-	/* chain the new task into proper order in the parent project */
-	idx = g_list_index (prj->task_list, prnt);
-	idx ++;
-	prj->task_list = g_list_insert (prj->task_list, newtask, idx);
-	newtask->parent = prj;
+    /* chain the new task into proper order in the parent project */
+    idx = g_list_index(prj->task_list, prnt);
+    idx++;
+    prj->task_list = g_list_insert(prj->task_list, newtask, idx);
+    newtask->parent = prj;
 
-	/* Rechain the intervals.  We do this by hand, since it
-	 * seems that glib doesn't provide this function. */
-	if (node->prev)
-	{
-		node->prev->next = NULL;
-		node->prev = NULL;
-	}
-	else
-	{
-		prnt->interval_list = NULL;
-	}
+    /* Rechain the intervals.  We do this by hand, since it
+     * seems that glib doesn't provide this function. */
+    if (node->prev)
+    {
+        node->prev->next = NULL;
+        node->prev = NULL;
+    }
+    else
+    {
+        prnt->interval_list = NULL;
+    }
 
-	newtask->interval_list = node;
+    newtask->interval_list = node;
 
-	for (; node; node=node->next)
-	{
-		GttInterval *nivl = node->data;
-		nivl->parent = newtask;
-	}
+    for (; node; node = node->next)
+    {
+        GttInterval *nivl = node->data;
+        nivl->parent = newtask;
+    }
 
-	if (is_running) gtt_project_timer_start (prj);
+    if (is_running)
+        gtt_project_timer_start(prj);
 
-	proj_refresh_time (prnt->parent);
+    proj_refresh_time(prnt->parent);
 }
 
 /* ============================================================= */
@@ -2761,361 +2795,319 @@ gtt_interval_split (GttInterval *ivl, GttTask *newtask)
 /* hack alert -- this list should probably be replaced with a
  * GNode tree ... */
 
-
-GttProjectList *
-gtt_project_list_new (void)
+GttProjectList *gtt_project_list_new(void)
 {
-	GttProjectList *gpl;
-	gpl = g_new0(GttProjectList, 1);
-	gpl->prj_list = NULL;
-	global_plist = gpl;   /* XXX one of many nasty hacks */
-	return gpl;
+    GttProjectList *gpl;
+    gpl = g_new0(GttProjectList, 1);
+    gpl->prj_list = NULL;
+    global_plist = gpl; /* XXX one of many nasty hacks */
+    return gpl;
 }
 
-GList *
-gtt_project_list_get_list (GttProjectList *gpl)
+GList *gtt_project_list_get_list(GttProjectList *gpl)
 {
-	return gpl->prj_list;
+    return gpl->prj_list;
 }
 
-void
-gtt_project_list_append(GttProjectList *gpl, GttProject *p)
+void gtt_project_list_append(GttProjectList *gpl, GttProject *p)
 {
-	gtt_project_insert_before (p, NULL);
+    gtt_project_insert_before(p, NULL);
 }
 
-
-void
-gtt_project_list_destroy(GttProjectList *gpl)
+void gtt_project_list_destroy(GttProjectList *gpl)
 {
-	while (gpl->prj_list)
-	{
-		/* destroying a project pops the plist ... */
-		gtt_project_destroy(gpl->prj_list->data);
-	}
+    while (gpl->prj_list)
+    {
+        /* destroying a project pops the plist ... */
+        gtt_project_destroy(gpl->prj_list->data);
+    }
 
-	g_free (gpl);
+    g_free(gpl);
 }
 
-static GList *
-project_list_sort(GList *prjs, int (cmp)(const void *, const void *))
+static GList *project_list_sort(GList *prjs, int(cmp)(const void *, const void *))
 {
-	GList *node;
-	prjs = g_list_sort (prjs, cmp);
-	for (node = prjs; node; node=node->next)
-	{
-		GttProject *prj = node->data;
-		if (prj->sub_projects)
-		{
-			prj->sub_projects = project_list_sort (prj->sub_projects, cmp);
-		}
-	}
-	return prjs;
+    GList *node;
+    prjs = g_list_sort(prjs, cmp);
+    for (node = prjs; node; node = node->next)
+    {
+        GttProject *prj = node->data;
+        if (prj->sub_projects)
+        {
+            prj->sub_projects = project_list_sort(prj->sub_projects, cmp);
+        }
+    }
+    return prjs;
 }
 
 /* -------------------- */
 /* given id, walk the tree of projects till we find it. */
 
-static GttProject *
-locate_from_id (GList *prj_list, int prj_id)
+static GttProject *locate_from_id(GList *prj_list, int prj_id)
 {
-	GList *node;
-	for (node = prj_list; node; node=node->next)
-	{
-		GttProject *prj = node->data;
-		if (prj_id == prj->id) return prj;
+    GList *node;
+    for (node = prj_list; node; node = node->next)
+    {
+        GttProject *prj = node->data;
+        if (prj_id == prj->id)
+            return prj;
 
-		/* recurse to handle sub-projects */
-		if (prj->sub_projects)
-		{
-			prj = locate_from_id (prj->sub_projects, prj_id);
-			if (prj) return prj;
-		}
-	}
-	return NULL;  /* not found */
+        /* recurse to handle sub-projects */
+        if (prj->sub_projects)
+        {
+            prj = locate_from_id(prj->sub_projects, prj_id);
+            if (prj)
+                return prj;
+        }
+    }
+    return NULL; /* not found */
 }
 
-GttProject *
-gtt_project_locate_from_id (int prj_id)
+GttProject *gtt_project_locate_from_id(int prj_id)
 {
-	return locate_from_id (global_plist->prj_list, prj_id);
+    return locate_from_id(global_plist->prj_list, prj_id);
 }
 
 /* ==================================================================== */
 /* sort funcs */
 
-
-static int
-cmp_day(const void *aa, const void *bb)
+static int cmp_day(const void *aa, const void *bb)
 {
-	GttProject *a = (GttProject *)aa;
-	GttProject *b = (GttProject *)bb;
-	return (gtt_project_total_secs_day(b) - gtt_project_total_secs_day(a));
+    GttProject *a = (GttProject *) aa;
+    GttProject *b = (GttProject *) bb;
+    return (gtt_project_total_secs_day(b) - gtt_project_total_secs_day(a));
 }
 
-static int
-cmp_yesterday(const void *aa, const void *bb)
+static int cmp_yesterday(const void *aa, const void *bb)
 {
-	GttProject *a = (GttProject *)aa;
-	GttProject *b = (GttProject *)bb;
-	return (gtt_project_total_secs_yesterday(b) - gtt_project_total_secs_yesterday(a));
+    GttProject *a = (GttProject *) aa;
+    GttProject *b = (GttProject *) bb;
+    return (gtt_project_total_secs_yesterday(b) - gtt_project_total_secs_yesterday(a));
 }
 
-static int
-cmp_week(const void *aa, const void *bb)
+static int cmp_week(const void *aa, const void *bb)
 {
-	GttProject *a = (GttProject *)aa;
-	GttProject *b = (GttProject *)bb;
-	return (gtt_project_total_secs_week(b) - gtt_project_total_secs_week(a));
+    GttProject *a = (GttProject *) aa;
+    GttProject *b = (GttProject *) bb;
+    return (gtt_project_total_secs_week(b) - gtt_project_total_secs_week(a));
 }
 
-static int
-cmp_lastweek(const void *aa, const void *bb)
+static int cmp_lastweek(const void *aa, const void *bb)
 {
-	GttProject *a = (GttProject *)aa;
-	GttProject *b = (GttProject *)bb;
-	return (gtt_project_total_secs_lastweek(b) - gtt_project_total_secs_lastweek(a));
+    GttProject *a = (GttProject *) aa;
+    GttProject *b = (GttProject *) bb;
+    return (gtt_project_total_secs_lastweek(b) - gtt_project_total_secs_lastweek(a));
 }
 
-static int
-cmp_month(const void *aa, const void *bb)
+static int cmp_month(const void *aa, const void *bb)
 {
-	GttProject *a = (GttProject *)aa;
-	GttProject *b = (GttProject *)bb;
-	return (gtt_project_total_secs_month(b) - gtt_project_total_secs_month(a));
+    GttProject *a = (GttProject *) aa;
+    GttProject *b = (GttProject *) bb;
+    return (gtt_project_total_secs_month(b) - gtt_project_total_secs_month(a));
 }
 
-static int
-cmp_year(const void *aa, const void *bb)
+static int cmp_year(const void *aa, const void *bb)
 {
-	GttProject *a = (GttProject *)aa;
-	GttProject *b = (GttProject *)bb;
-	return (gtt_project_total_secs_year(b) - gtt_project_total_secs_year(a));
+    GttProject *a = (GttProject *) aa;
+    GttProject *b = (GttProject *) bb;
+    return (gtt_project_total_secs_year(b) - gtt_project_total_secs_year(a));
 }
 
-static int
-cmp_ever(const void *aa, const void *bb)
+static int cmp_ever(const void *aa, const void *bb)
 {
-	GttProject *a = (GttProject *)aa;
-	GttProject *b = (GttProject *)bb;
-	return (gtt_project_total_secs_ever(b) - gtt_project_total_secs_ever(a));
+    GttProject *a = (GttProject *) aa;
+    GttProject *b = (GttProject *) bb;
+    return (gtt_project_total_secs_ever(b) - gtt_project_total_secs_ever(a));
 }
 
-static int
-cmp_current(const void *aa, const void *bb)
+static int cmp_current(const void *aa, const void *bb)
 {
-	GttProject *a = (GttProject *)aa;
-	GttProject *b = (GttProject *)bb;
-	return (gtt_project_total_secs_current(b) - gtt_project_total_secs_current(a));
+    GttProject *a = (GttProject *) aa;
+    GttProject *b = (GttProject *) bb;
+    return (gtt_project_total_secs_current(b) - gtt_project_total_secs_current(a));
 }
 
-
-static int
-cmp_title(const void *aa, const void *bb)
+static int cmp_title(const void *aa, const void *bb)
 {
-	const GttProject *a = aa;
-	const GttProject *b = bb;
-	return strcmp(a->title, b->title);
+    const GttProject *a = aa;
+    const GttProject *b = bb;
+    return strcmp(a->title, b->title);
 }
 
-static int
-cmp_desc(const void *aa, const void *bb)
+static int cmp_desc(const void *aa, const void *bb)
 {
-	const GttProject *a = aa;
-	const GttProject *b = bb;
-	if (!a->desc) {
-		return (b->desc == NULL)? 0 : 1;
-	}
-	if (!b->desc) {
-		return -1;
-	}
-	return strcmp(a->desc, b->desc);
+    const GttProject *a = aa;
+    const GttProject *b = bb;
+    if (!a->desc)
+    {
+        return (b->desc == NULL) ? 0 : 1;
+    }
+    if (!b->desc)
+    {
+        return -1;
+    }
+    return strcmp(a->desc, b->desc);
 }
 
-static int
-cmp_start(const void *aa, const void *bb)
+static int cmp_start(const void *aa, const void *bb)
 {
-	const GttProject *a = aa;
-	const GttProject *b = bb;
-	return (b->estimated_start - a->estimated_start);
+    const GttProject *a = aa;
+    const GttProject *b = bb;
+    return (b->estimated_start - a->estimated_start);
 }
 
-static int
-cmp_end(const void *aa, const void *bb)
+static int cmp_end(const void *aa, const void *bb)
 {
-	const GttProject *a = aa;
-	const GttProject *b = bb;
-	return (b->estimated_end - a->estimated_end);
+    const GttProject *a = aa;
+    const GttProject *b = bb;
+    return (b->estimated_end - a->estimated_end);
 }
 
-
-static int
-cmp_due(const void *aa, const void *bb)
+static int cmp_due(const void *aa, const void *bb)
 {
-	const GttProject *a = aa;
-	const GttProject *b = bb;
-	return (b->due_date - a->due_date);
+    const GttProject *a = aa;
+    const GttProject *b = bb;
+    return (b->due_date - a->due_date);
 }
 
-
-static int
-cmp_sizing(const void *aa, const void *bb)
+static int cmp_sizing(const void *aa, const void *bb)
 {
-	const GttProject *a = aa;
-	const GttProject *b = bb;
-	return (b->sizing - a->sizing);
+    const GttProject *a = aa;
+    const GttProject *b = bb;
+    return (b->sizing - a->sizing);
 }
 
-static int
-cmp_percent(const void *aa, const void *bb)
+static int cmp_percent(const void *aa, const void *bb)
 {
-	const GttProject *a = aa;
-	const GttProject *b = bb;
-	return (b->percent_complete - a->percent_complete);
+    const GttProject *a = aa;
+    const GttProject *b = bb;
+    return (b->percent_complete - a->percent_complete);
 }
 
-static int
-cmp_urgency(const void *aa, const void *bb)
+static int cmp_urgency(const void *aa, const void *bb)
 {
-	const GttProject *a = aa;
-	const GttProject *b = bb;
-	return (b->urgency - a->urgency);
+    const GttProject *a = aa;
+    const GttProject *b = bb;
+    return (b->urgency - a->urgency);
 }
 
-static int
-cmp_importance(const void *aa, const void *bb)
+static int cmp_importance(const void *aa, const void *bb)
 {
-	const GttProject *a = aa;
-	const GttProject *b = bb;
-	return (b->importance - a->importance);
+    const GttProject *a = aa;
+    const GttProject *b = bb;
+    return (b->importance - a->importance);
 }
 
-static int
-cmp_status(const void *aa, const void *bb)
+static int cmp_status(const void *aa, const void *bb)
 {
-	const GttProject *a = aa;
-	const GttProject *b = bb;
-	return (b->status - a->status);
+    const GttProject *a = aa;
+    const GttProject *b = bb;
+    return (b->status - a->status);
 }
 
-#define DO_SORT(CMP_FUNC)                                   \
-	gboolean is_top = FALSE;                                 \
-	GttProject *parent;                                      \
-	GList *prjs = gps->prj_list;                             \
-	if (!prjs) return;                                       \
-	if (prjs == gps->prj_list) is_top = TRUE;                \
-	parent = ((GttProject *) (prjs->data))->parent;          \
-	prjs = project_list_sort(prjs, CMP_FUNC);                \
-	if (is_top) gps->prj_list = prjs;                        \
-	else if (parent) parent->sub_projects = prjs;            \
+#define DO_SORT(CMP_FUNC)                           \
+    gboolean is_top = FALSE;                        \
+    GttProject *parent;                             \
+    GList *prjs = gps->prj_list;                    \
+    if (!prjs)                                      \
+        return;                                     \
+    if (prjs == gps->prj_list)                      \
+        is_top = TRUE;                              \
+    parent = ((GttProject *) (prjs->data))->parent; \
+    prjs = project_list_sort(prjs, CMP_FUNC);       \
+    if (is_top)                                     \
+        gps->prj_list = prjs;                       \
+    else if (parent)                                \
+        parent->sub_projects = prjs;
 
-
-void
-project_list_sort_day(GttProjectList *gps)
+void project_list_sort_day(GttProjectList *gps)
 {
-	DO_SORT(cmp_day);
+    DO_SORT(cmp_day);
 }
 
-void
-project_list_sort_yesterday(GttProjectList *gps)
+void project_list_sort_yesterday(GttProjectList *gps)
 {
-	DO_SORT(cmp_yesterday);
+    DO_SORT(cmp_yesterday);
 }
 
-void
-project_list_sort_week(GttProjectList *gps)
+void project_list_sort_week(GttProjectList *gps)
 {
-	DO_SORT(cmp_week);
+    DO_SORT(cmp_week);
 }
 
-void
-project_list_sort_lastweek(GttProjectList *gps)
+void project_list_sort_lastweek(GttProjectList *gps)
 {
-	DO_SORT(cmp_lastweek);
+    DO_SORT(cmp_lastweek);
 }
 
-void
-project_list_sort_month(GttProjectList *gps)
+void project_list_sort_month(GttProjectList *gps)
 {
-	DO_SORT(cmp_month);
+    DO_SORT(cmp_month);
 }
 
-void
-project_list_sort_year(GttProjectList *gps)
+void project_list_sort_year(GttProjectList *gps)
 {
-	DO_SORT(cmp_year);
+    DO_SORT(cmp_year);
 }
 
-void
-project_list_sort_ever(GttProjectList *gps)
+void project_list_sort_ever(GttProjectList *gps)
 {
-	DO_SORT(cmp_ever);
+    DO_SORT(cmp_ever);
 }
 
-void
-project_list_sort_current(GttProjectList *gps)
+void project_list_sort_current(GttProjectList *gps)
 {
-	DO_SORT(cmp_current);
+    DO_SORT(cmp_current);
 }
 
-void
-project_list_sort_title(GttProjectList *gps)
+void project_list_sort_title(GttProjectList *gps)
 {
-	DO_SORT(cmp_title);
+    DO_SORT(cmp_title);
 }
 
-void
-project_list_sort_desc(GttProjectList *gps)
+void project_list_sort_desc(GttProjectList *gps)
 {
-	DO_SORT(cmp_desc);
+    DO_SORT(cmp_desc);
 }
 
-void
-project_list_sort_start(GttProjectList *gps)
+void project_list_sort_start(GttProjectList *gps)
 {
-	DO_SORT(cmp_start);
+    DO_SORT(cmp_start);
 }
 
-void
-project_list_sort_end(GttProjectList *gps)
+void project_list_sort_end(GttProjectList *gps)
 {
-	DO_SORT(cmp_end);
+    DO_SORT(cmp_end);
 }
 
-void
-project_list_sort_due(GttProjectList *gps)
+void project_list_sort_due(GttProjectList *gps)
 {
-	DO_SORT(cmp_due);
+    DO_SORT(cmp_due);
 }
 
-void
-project_list_sort_sizing(GttProjectList *gps)
+void project_list_sort_sizing(GttProjectList *gps)
 {
-	DO_SORT(cmp_sizing);
+    DO_SORT(cmp_sizing);
 }
 
-void
-project_list_sort_percent(GttProjectList *gps)
+void project_list_sort_percent(GttProjectList *gps)
 {
-	DO_SORT(cmp_percent);
+    DO_SORT(cmp_percent);
 }
 
-void
-project_list_sort_urgency(GttProjectList *gps)
+void project_list_sort_urgency(GttProjectList *gps)
 {
-	DO_SORT(cmp_urgency);
+    DO_SORT(cmp_urgency);
 }
 
-void
-project_list_sort_importance(GttProjectList *gps)
+void project_list_sort_importance(GttProjectList *gps)
 {
-	DO_SORT(cmp_importance);
+    DO_SORT(cmp_importance);
 }
 
-void
-project_list_sort_status(GttProjectList *gps)
+void project_list_sort_status(GttProjectList *gps)
 {
-	DO_SORT(cmp_status);
+    DO_SORT(cmp_status);
 }
 
 /* =========================== END OF FILE ========================= */

--- a/src/proj.h
+++ b/src/proj.h
@@ -28,7 +28,6 @@
  * only through the setters and getters defined in this file.
  */
 
-
 #ifdef TIME_WITH_SYS_TIME
 #include <sys/time.h>
 #include <time.h>
@@ -39,61 +38,59 @@
 #include <time.h>
 #endif /* TIME_WITH_SYS_TIME */
 
-
 /* hack alert -- these are hard-coded enums; they should
  * probably be replaced by a system of user-defined
  * enumerated values, especially for GttProjectStatus
  */
 
-
 typedef enum
 {
-	GTT_BILLABLE = 1,   /* billable time */
-	GTT_NOT_BILLABLE,   /* not billable to customer, internal only */
-	GTT_NO_CHARGE       /* shows on invoice as 'no charge/free' */
+    GTT_BILLABLE = 1, /* billable time */
+    GTT_NOT_BILLABLE, /* not billable to customer, internal only */
+    GTT_NO_CHARGE     /* shows on invoice as 'no charge/free' */
 } GttBillable;
 
 typedef enum
 {
-	GTT_REGULAR = 0,
-	GTT_OVERTIME,
-	GTT_OVEROVER,
-	GTT_FLAT_FEE
+    GTT_REGULAR = 0,
+    GTT_OVERTIME,
+    GTT_OVEROVER,
+    GTT_FLAT_FEE
 } GttBillRate;
 
 typedef enum
 {
-	GTT_HOLD = 0,	 /* needs review, will not appear on invoice */
-	GTT_BILL = 1,    /* print this on invoice, its done, ready */
-	GTT_PAID         /* its been paid; do not print on invoice any more */
+    GTT_HOLD = 0, /* needs review, will not appear on invoice */
+    GTT_BILL = 1, /* print this on invoice, its done, ready */
+    GTT_PAID      /* its been paid; do not print on invoice any more */
 } GttBillStatus;
 
 typedef enum
 {
-	GTT_UNDEFINED = 0,
-	GTT_LOW = 1,
-	GTT_MEDIUM,
-	GTT_HIGH
+    GTT_UNDEFINED = 0,
+    GTT_LOW = 1,
+    GTT_MEDIUM,
+    GTT_HIGH
 } GttRank;
 
 typedef enum
 {
-	GTT_NO_STATUS = 0,
-	GTT_NOT_STARTED = 1,  /* hack alert-- we should allow */
-	GTT_IN_PROGRESS,      /* user-defined status states */
-	GTT_ON_HOLD,          /* wating for something */
-	GTT_CANCELLED,
-	GTT_COMPLETED
+    GTT_NO_STATUS = 0,
+    GTT_NOT_STARTED = 1, /* hack alert-- we should allow */
+    GTT_IN_PROGRESS,     /* user-defined status states */
+    GTT_ON_HOLD,         /* wating for something */
+    GTT_CANCELLED,
+    GTT_COMPLETED
 } GttProjectStatus;
 
 /* -------------------------------------------------------- */
 /* Query related things -- under construction */
 
 #define GTT_PROJECT_ID "GttProjectId"
-#define GTT_TASK_ID    "GttTaskId"
+#define GTT_TASK_ID "GttTaskId"
 
 #define GTT_PROJECT_EARLIEST "GttProjectEarliest"
-#define GTT_PROJECT_LATEST   "GttProjectLatest"
+#define GTT_PROJECT_LATEST "GttProjectLatest"
 
 /* -------------------------------------------------------- */
 /* The four basic structures */
@@ -109,50 +106,50 @@ typedef struct gtt_project_s GttProject;
 typedef struct gtt_task_s GttTask;
 typedef struct gtt_interval_s GttInterval;
 
-typedef void (*GttProjectChanged) (GttProject *, gpointer);
-typedef int (*GttProjectCB) (GttProject *, gpointer);
-typedef int (*GttIntervalCB) (GttInterval *, gpointer);
+typedef void (*GttProjectChanged)(GttProject *, gpointer);
+typedef int (*GttProjectCB)(GttProject *, gpointer);
+typedef int (*GttIntervalCB)(GttInterval *, gpointer);
 
 /* -------------------------------------------------------- */
 /* system init */
-gboolean gtt_project_obj_register (void);
+gboolean gtt_project_obj_register(void);
 
 /* -------------------------------------------------------- */
 /* project data */
 
 /* create, destroy a new project */
-GttProject *	gtt_project_new(void);
-GttProject *	gtt_project_new_title_desc(const char *, const char *);
-void 		gtt_project_destroy(GttProject *);
+GttProject *gtt_project_new(void);
+GttProject *gtt_project_new_title_desc(const char *, const char *);
+void gtt_project_destroy(GttProject *);
 
 /* The gtt_project_dup() routine will make a copy of the indicated
  *    project. Note, it will copy the sub-projects, but it will *not*
  *    copy the tasks (I dunno, this is probably a bug, I think it should
  *    copy the tasks as well ....)
  */
-GttProject *	gtt_project_dup(GttProject *);
+GttProject *gtt_project_dup(GttProject *);
 
 /* The gtt_project_remove() routine will take the project out of
  *    either the master list, or out of any parents' list of
  *    sub-projects that it might below to.  As a result, this
  *    project will dangle there -- don't loose it
  */
-void 		gtt_project_remove(GttProject *p);
+void gtt_project_remove(GttProject *p);
 
-const GUID * gtt_project_get_guid (GttProject *);
+const GUID *gtt_project_get_guid(GttProject *);
 
-void 		gtt_project_set_title(GttProject *, const char *);
-void 		gtt_project_set_desc(GttProject *, const char *);
-void 		gtt_project_set_notes(GttProject *, const char *);
-void 		gtt_project_set_custid(GttProject *, const char *);
+void gtt_project_set_title(GttProject *, const char *);
+void gtt_project_set_desc(GttProject *, const char *);
+void gtt_project_set_notes(GttProject *, const char *);
+void gtt_project_set_custid(GttProject *, const char *);
 
 /* These two routines return the title & desc strings.
  * Do *not* free these strings when done.  Note that
  * are freed when project is deleted. */
-const char * 	gtt_project_get_title (GttProject *);
-const char * 	gtt_project_get_desc (GttProject *);
-const char * 	gtt_project_get_notes (GttProject *);
-const char * 	gtt_project_get_custid (GttProject *);
+const char *gtt_project_get_title(GttProject *);
+const char *gtt_project_get_desc(GttProject *);
+const char *gtt_project_get_notes(GttProject *);
+const char *gtt_project_get_custid(GttProject *);
 
 /* The gtt_project_compat_set_secs() routine provides a
  *    backwards-compatible routine for setting the total amount of
@@ -160,23 +157,23 @@ const char * 	gtt_project_get_custid (GttProject *);
  *    labelling it as 'old gtt data', and putting the time info
  *    into that task.  Depricated. Don't use in new code.
  */
-void		gtt_project_compat_set_secs (GttProject *proj,
-			int secs_ever, int secs_day, time_t last_update);
-
+void gtt_project_compat_set_secs(
+    GttProject *proj, int secs_ever, int secs_day, time_t last_update
+);
 
 /* The billrate is the currency amount to charge for an hour's work.
  *     overtime_rate is the over-time rate (usually 1.5x billrate)
  *     overover_rate is the double over-time rate (usually 2x billrate)
  *     flat_fee is charged, independent of the length of time.
  */
-void 		gtt_project_set_billrate (GttProject *, double);
-double 		gtt_project_get_billrate (GttProject *);
-void 		gtt_project_set_overtime_rate (GttProject *, double);
-double 		gtt_project_get_overtime_rate (GttProject *);
-void 		gtt_project_set_overover_rate (GttProject *, double);
-double 		gtt_project_get_overover_rate (GttProject *);
-void 		gtt_project_set_flat_fee (GttProject *, double);
-double 		gtt_project_get_flat_fee (GttProject *);
+void gtt_project_set_billrate(GttProject *, double);
+double gtt_project_get_billrate(GttProject *);
+void gtt_project_set_overtime_rate(GttProject *, double);
+double gtt_project_get_overtime_rate(GttProject *);
+void gtt_project_set_overover_rate(GttProject *, double);
+double gtt_project_get_overover_rate(GttProject *);
+void gtt_project_set_flat_fee(GttProject *, double);
+double gtt_project_get_flat_fee(GttProject *);
 
 /* The gtt_project_set_min_interval() routine sets the smallest
  *    time unit, below which work intervals will not be recorded
@@ -188,12 +185,12 @@ double 		gtt_project_get_flat_fee (GttProject *);
  *    prior work intervals rather than being counted as seperate.
  *    Default is 1 minute, but should be 5 minutes.
  */
-void		gtt_project_set_min_interval (GttProject *, int);
-int		gtt_project_get_min_interval (GttProject *);
-void		gtt_project_set_auto_merge_interval (GttProject *, int);
-int		gtt_project_get_auto_merge_interval (GttProject *);
-void		gtt_project_set_auto_merge_gap (GttProject *, int);
-int		gtt_project_get_auto_merge_gap (GttProject *);
+void gtt_project_set_min_interval(GttProject *, int);
+int gtt_project_get_min_interval(GttProject *);
+void gtt_project_set_auto_merge_interval(GttProject *, int);
+int gtt_project_get_auto_merge_interval(GttProject *);
+void gtt_project_set_auto_merge_gap(GttProject *, int);
+int gtt_project_get_auto_merge_gap(GttProject *);
 
 /* Todo-list management stuff.
  * The estimated start date is when we expect to first start working
@@ -218,30 +215,29 @@ int		gtt_project_get_auto_merge_gap (GttProject *);
  * could define multiple stages: e.g. 'testing', 'designing',
  * 'on-hold', 'waiting for response', etc.
  */
-void     gtt_project_set_estimated_start (GttProject *, time_t);
-time_t   gtt_project_get_estimated_start (GttProject *);
-void     gtt_project_set_estimated_end (GttProject *, time_t);
-time_t   gtt_project_get_estimated_end (GttProject *);
-void     gtt_project_set_due_date (GttProject *, time_t);
-time_t   gtt_project_get_due_date (GttProject *);
-void     gtt_project_set_sizing (GttProject *, int);
-int      gtt_project_get_sizing (GttProject *);
-void     gtt_project_set_percent_complete (GttProject *, int);
-int      gtt_project_get_percent_complete (GttProject *);
-void     gtt_project_set_urgency (GttProject *, GttRank);
-GttRank  gtt_project_get_urgency (GttProject *);
-void     gtt_project_set_importance (GttProject *, GttRank);
-GttRank  gtt_project_get_importance (GttProject *);
-void     gtt_project_set_status (GttProject *, GttProjectStatus);
-GttProjectStatus      gtt_project_get_status (GttProject *);
-
+void gtt_project_set_estimated_start(GttProject *, time_t);
+time_t gtt_project_get_estimated_start(GttProject *);
+void gtt_project_set_estimated_end(GttProject *, time_t);
+time_t gtt_project_get_estimated_end(GttProject *);
+void gtt_project_set_due_date(GttProject *, time_t);
+time_t gtt_project_get_due_date(GttProject *);
+void gtt_project_set_sizing(GttProject *, int);
+int gtt_project_get_sizing(GttProject *);
+void gtt_project_set_percent_complete(GttProject *, int);
+int gtt_project_get_percent_complete(GttProject *);
+void gtt_project_set_urgency(GttProject *, GttRank);
+GttRank gtt_project_get_urgency(GttProject *);
+void gtt_project_set_importance(GttProject *, GttRank);
+GttRank gtt_project_get_importance(GttProject *);
+void gtt_project_set_status(GttProject *, GttProjectStatus);
+GttProjectStatus gtt_project_get_status(GttProject *);
 
 /* The id is a simple id, handy for .. stuff */
-void 		gtt_project_set_id (GttProject *, int id);
-int  		gtt_project_get_id (GttProject *);
+void gtt_project_set_id(GttProject *, int id);
+int gtt_project_get_id(GttProject *);
 
 /* return a project, given only its id; NULL if not found */
-GttProject * 	gtt_project_locate_from_id (int prj_id);
+GttProject *gtt_project_locate_from_id(int prj_id);
 
 /* The gtt_project_add_notifier() routine allows anoter component
  *    (e.g. a GUI) to add a signal that will be called whenever the
@@ -263,23 +259,21 @@ GttProject * 	gtt_project_locate_from_id (int prj_id);
  *    interval.
  */
 
-void		gtt_project_freeze (GttProject *prj);
-void		gtt_project_thaw (GttProject *prj);
-void		gtt_task_freeze (GttTask *tsk);
-void		gtt_task_thaw (GttTask *tsk);
-void		gtt_interval_freeze (GttInterval *ivl);
-GttInterval * gtt_interval_thaw (GttInterval *ivl);
+void gtt_project_freeze(GttProject *prj);
+void gtt_project_thaw(GttProject *prj);
+void gtt_task_freeze(GttTask *tsk);
+void gtt_task_thaw(GttTask *tsk);
+void gtt_interval_freeze(GttInterval *ivl);
+GttInterval *gtt_interval_thaw(GttInterval *ivl);
 
-void		gtt_project_add_notifier (GttProject *,
-			GttProjectChanged, gpointer);
-void		gtt_project_remove_notifier (GttProject *,
-			GttProjectChanged, gpointer);
+void gtt_project_add_notifier(GttProject *, GttProjectChanged, gpointer);
+void gtt_project_remove_notifier(GttProject *, GttProjectChanged, gpointer);
 
 /* These functions provide a generic place to hang arbitrary data
  *     on the project (used by the GUI).
  */
-gpointer gtt_project_get_private_data (GttProject *);
-void     gtt_project_set_private_data (GttProject *, gpointer);
+gpointer gtt_project_get_private_data(GttProject *);
+void gtt_project_set_private_data(GttProject *, gpointer);
 
 /* The gtt_project_foreach() routine calls the indicated function
  *    on the project and each of the sub-projects.  The recursion is
@@ -299,10 +293,9 @@ void     gtt_project_set_private_data (GttProject *, gpointer);
  *    visits the subprojects of the project.
  *
  */
-int      gtt_project_foreach (GttProject *,  GttProjectCB, gpointer);
-int      gtt_project_foreach_interval (GttProject *, GttIntervalCB, gpointer);
-int      gtt_project_foreach_subproject_interval (GttProject *, GttIntervalCB, gpointer);
-
+int gtt_project_foreach(GttProject *, GttProjectCB, gpointer);
+int gtt_project_foreach_interval(GttProject *, GttIntervalCB, gpointer);
+int gtt_project_foreach_subproject_interval(GttProject *, GttIntervalCB, gpointer);
 
 /* -------------------------------------------------------- */
 /* Project Manipulation */
@@ -312,10 +305,9 @@ int      gtt_project_foreach_subproject_interval (GttProject *, GttIntervalCB, g
  * The project_timer_update() routine updates the end-time
  *    for a task interval.
  */
-void 		gtt_project_timer_start (GttProject *);
-void 		gtt_project_timer_update (GttProject *);
-void 		gtt_project_timer_stop (GttProject *);
-
+void gtt_project_timer_start(GttProject *);
+void gtt_project_timer_update(GttProject *);
+void gtt_project_timer_stop(GttProject *);
 
 /* The gtt_project_get_secs_day() routine returns the
  *    number of seconds spent on this project today,
@@ -337,32 +329,30 @@ void 		gtt_project_timer_stop (GttProject *);
  * by a generic query mechanism at some point.
  */
 
-int 		gtt_project_get_secs_current (GttProject *proj);
-int 		gtt_project_get_secs_day (GttProject *proj);
-int 		gtt_project_get_secs_yesterday (GttProject *proj);
-int 		gtt_project_get_secs_week (GttProject *proj);
-int 		gtt_project_get_secs_lastweek (GttProject *proj);
-int 		gtt_project_get_secs_month (GttProject *proj);
-int 		gtt_project_get_secs_year (GttProject *proj);
-int 		gtt_project_get_secs_ever (GttProject *proj);
+int gtt_project_get_secs_current(GttProject *proj);
+int gtt_project_get_secs_day(GttProject *proj);
+int gtt_project_get_secs_yesterday(GttProject *proj);
+int gtt_project_get_secs_week(GttProject *proj);
+int gtt_project_get_secs_lastweek(GttProject *proj);
+int gtt_project_get_secs_month(GttProject *proj);
+int gtt_project_get_secs_year(GttProject *proj);
+int gtt_project_get_secs_ever(GttProject *proj);
 
-int 		gtt_project_total_secs_current (GttProject *proj);
-int 		gtt_project_total_secs_day (GttProject *proj);
-int 		gtt_project_total_secs_yesterday (GttProject *proj);
-int 		gtt_project_total_secs_week (GttProject *proj);
-int 		gtt_project_total_secs_lastweek (GttProject *proj);
-int 		gtt_project_total_secs_month (GttProject *proj);
-int 		gtt_project_total_secs_year (GttProject *proj);
-int 		gtt_project_total_secs_ever (GttProject *proj);
+int gtt_project_total_secs_current(GttProject *proj);
+int gtt_project_total_secs_day(GttProject *proj);
+int gtt_project_total_secs_yesterday(GttProject *proj);
+int gtt_project_total_secs_week(GttProject *proj);
+int gtt_project_total_secs_lastweek(GttProject *proj);
+int gtt_project_total_secs_month(GttProject *proj);
+int gtt_project_total_secs_year(GttProject *proj);
+int gtt_project_total_secs_ever(GttProject *proj);
 
-
-void gtt_project_list_compute_secs (void);
+void gtt_project_list_compute_secs(void);
 
 /* The gtt_project_total() routine returns the total
  *   number of projects, including subprojects.
  */
-int      gtt_project_total (GttProject *);
-
+int gtt_project_total(GttProject *);
 
 /* The gtt_project_get_children() returns a list of the
  *    subprojects of this project
@@ -379,14 +369,14 @@ int      gtt_project_total (GttProject *);
  *    interval at the head of the active task (i.e. the currenly
  *    ticking interval, or the last interval to tick).
  */
-GList       * gtt_project_get_children (GttProject *);
-GList       * gtt_project_get_tasks (GttProject *);
-GttTask     * gtt_project_get_first_task (GttProject *);
-GttTask     * gtt_project_get_current_task (GttProject *);
-void          gtt_project_set_current_task (GttProject *proj, GttTask *tsk);
-GttInterval * gtt_project_get_first_interval (GttProject *);
+GList *gtt_project_get_children(GttProject *);
+GList *gtt_project_get_tasks(GttProject *);
+GttTask *gtt_project_get_first_task(GttProject *);
+GttTask *gtt_project_get_current_task(GttProject *);
+void gtt_project_set_current_task(GttProject *proj, GttTask *tsk);
+GttInterval *gtt_project_get_first_interval(GttProject *);
 
-GttProject * 	gtt_project_get_parent (GttProject *);
+GttProject *gtt_project_get_parent(GttProject *);
 
 /*
  * The following routines maintain a heirarchical tree of projects.
@@ -402,7 +392,7 @@ GttProject * 	gtt_project_get_parent (GttProject *);
  *    If 'parent' is NULL, then the child is appended to the
  *    top-level project list.
  */
-void	gtt_project_append_project (GttProject *parent, GttProject *child);
+void gtt_project_append_project(GttProject *parent, GttProject *child);
 
 /*
  * The gtt_project_insert_before() routine will insert 'proj' on the
@@ -417,13 +407,13 @@ void	gtt_project_append_project (GttProject *parent, GttProject *child);
  *     if 'after_me' is null, then the proj is prepended to the
  *     master list.
  */
-void	gtt_project_insert_before (GttProject *proj, GttProject *before_me);
-void	gtt_project_insert_after (GttProject *proj, GttProject *after_me);
+void gtt_project_insert_before(GttProject *proj, GttProject *before_me);
+void gtt_project_insert_after(GttProject *proj, GttProject *after_me);
 
-void    gtt_project_reparent (GttProject *proj, GttProject *parent, int position);
+void gtt_project_reparent(GttProject *proj, GttProject *parent, int position);
 
-void	gtt_project_append_task (GttProject *, GttTask *);
-void	gtt_project_prepend_task (GttProject *, GttTask *);
+void gtt_project_append_task(GttProject *, GttTask *);
+void gtt_project_prepend_task(GttProject *, GttTask *);
 
 /* The gtt_clear_daily_counter() will delete all intervals from
  *    the project that started after midnight.  Typically, this
@@ -432,7 +422,7 @@ void	gtt_project_prepend_task (GttProject *, GttTask *);
  *    on deck.
  */
 
-void gtt_clear_daily_counter (GttProject *proj);
+void gtt_clear_daily_counter(GttProject *proj);
 
 /* -------------------------------------------------------- */
 /* master project list */
@@ -440,14 +430,14 @@ void gtt_clear_daily_counter (GttProject *proj);
  * Right now its implemented as a global.
  */
 
-GttProjectList *gtt_project_list_new (void);
-void gtt_project_list_destroy (GttProjectList *);
+GttProjectList *gtt_project_list_new(void);
+void gtt_project_list_destroy(GttProjectList *);
 
 /* Return a list of all top-level projects */
-GList * 	gtt_project_list_get_list (GttProjectList *);
+GList *gtt_project_list_get_list(GttProjectList *);
 
 /* Append project to the project list */
-void 		gtt_project_list_append(GttProjectList *, GttProject *p);
+void gtt_project_list_append(GttProjectList *, GttProject *p);
 
 /* The 'sort' functions have a sort-of wacky interface.
  * They will sort the list of projects passed as an argument,
@@ -456,24 +446,24 @@ void 		gtt_project_list_append(GttProjectList *, GttProject *p);
  * it should be done in the display ("presentation") layer.
  * But this works for now.
  */
-void project_list_sort_current    (GttProjectList *);
-void project_list_sort_day        (GttProjectList *);
-void project_list_sort_yesterday  (GttProjectList *);
-void project_list_sort_week       (GttProjectList *);
-void project_list_sort_lastweek   (GttProjectList *);
-void project_list_sort_month      (GttProjectList *);
-void project_list_sort_year       (GttProjectList *);
-void project_list_sort_ever       (GttProjectList *);
-void project_list_sort_title      (GttProjectList *);
-void project_list_sort_desc       (GttProjectList *);
-void project_list_sort_start      (GttProjectList *);
-void project_list_sort_end        (GttProjectList *);
-void project_list_sort_due        (GttProjectList *);
-void project_list_sort_sizing     (GttProjectList *);
-void project_list_sort_percent    (GttProjectList *);
-void project_list_sort_urgency    (GttProjectList *);
-void project_list_sort_importance (GttProjectList *);
-void project_list_sort_status     (GttProjectList *);
+void project_list_sort_current(GttProjectList *);
+void project_list_sort_day(GttProjectList *);
+void project_list_sort_yesterday(GttProjectList *);
+void project_list_sort_week(GttProjectList *);
+void project_list_sort_lastweek(GttProjectList *);
+void project_list_sort_month(GttProjectList *);
+void project_list_sort_year(GttProjectList *);
+void project_list_sort_ever(GttProjectList *);
+void project_list_sort_title(GttProjectList *);
+void project_list_sort_desc(GttProjectList *);
+void project_list_sort_start(GttProjectList *);
+void project_list_sort_end(GttProjectList *);
+void project_list_sort_due(GttProjectList *);
+void project_list_sort_sizing(GttProjectList *);
+void project_list_sort_percent(GttProjectList *);
+void project_list_sort_urgency(GttProjectList *);
+void project_list_sort_importance(GttProjectList *);
+void project_list_sort_status(GttProjectList *);
 
 /* The gtt_project_list_total_secs_day() routine returns the
  *    total number of seconds spent on all projects today,
@@ -484,13 +474,13 @@ void project_list_sort_status     (GttProjectList *);
  *    including a total of all sub-projects.
  */
 
-int 		gtt_project_list_total_secs_day (void);
-int 		gtt_project_list_total_secs_ever (void);
+int gtt_project_list_total_secs_day(void);
+int gtt_project_list_total_secs_ever(void);
 
 /* The gtt_project_list_total() routine returns the total
  *   number of projects, including subprojects.
  */
-int      gtt_project_list_total (void);
+int gtt_project_list_total(void);
 
 /* -------------------------------------------------------- */
 /* Tasks */
@@ -503,30 +493,30 @@ int      gtt_project_list_total (void);
  *    intervals, nor the parent.
  */
 
-GttTask *	gtt_task_new (void);
-GttTask *	gtt_task_copy (GttTask *);
-void 		gtt_task_destroy (GttTask *);
+GttTask *gtt_task_new(void);
+GttTask *gtt_task_copy(GttTask *);
+void gtt_task_destroy(GttTask *);
 
-const GUID * gtt_task_get_guid (GttTask *);
+const GUID *gtt_task_get_guid(GttTask *);
 
-void		gtt_task_set_memo (GttTask *, const char *);
-const char *	gtt_task_get_memo (GttTask *);
-void		gtt_task_set_notes (GttTask *, const char *);
-const char *	gtt_task_get_notes (GttTask *);
+void gtt_task_set_memo(GttTask *, const char *);
+const char *gtt_task_get_memo(GttTask *);
+void gtt_task_set_notes(GttTask *, const char *);
+const char *gtt_task_get_notes(GttTask *);
 
-void		gtt_task_set_billable (GttTask *, GttBillable);
-GttBillable	gtt_task_get_billable (GttTask *);
-void		gtt_task_set_billrate (GttTask *, GttBillRate);
-GttBillRate	gtt_task_get_billrate (GttTask *);
-void		gtt_task_set_billstatus (GttTask *, GttBillStatus);
-GttBillStatus	gtt_task_get_billstatus (GttTask *);
+void gtt_task_set_billable(GttTask *, GttBillable);
+GttBillable gtt_task_get_billable(GttTask *);
+void gtt_task_set_billrate(GttTask *, GttBillRate);
+GttBillRate gtt_task_get_billrate(GttTask *);
+void gtt_task_set_billstatus(GttTask *, GttBillStatus);
+GttBillStatus gtt_task_get_billstatus(GttTask *);
 
 /* The bill_unit is the minimum billable unit of time.
  * Typically 15 minutes or an hour, it represents the smallest unit
  * of time that will appear on the invoice.
  */
-void		gtt_task_set_bill_unit (GttTask *, int);
-int		gtt_task_get_bill_unit (GttTask *);
+void gtt_task_set_bill_unit(GttTask *, int);
+int gtt_task_get_bill_unit(GttTask *);
 
 /* The gtt_task_remove() routine will remove the task from its parent
  *    project (presumably in preparation for reparenting).
@@ -548,29 +538,28 @@ int		gtt_task_get_bill_unit (GttTask *);
  * The gtt_task_is_last_task() routine returns True if this task
  *    is the last task of the project.
  */
-void         gtt_task_remove (GttTask *);
-GttTask *    gtt_task_new_insert (GttTask *);
-void         gtt_task_insert (GttTask *where, GttTask *insertee);
-void         gtt_task_merge_up (GttTask *);
-gboolean     gtt_task_is_first_task (GttTask *);
-gboolean     gtt_task_is_last_task (GttTask *);
-GttProject * gtt_task_get_parent (GttTask *);
+void gtt_task_remove(GttTask *);
+GttTask *gtt_task_new_insert(GttTask *);
+void gtt_task_insert(GttTask *where, GttTask *insertee);
+void gtt_task_merge_up(GttTask *);
+gboolean gtt_task_is_first_task(GttTask *);
+gboolean gtt_task_is_last_task(GttTask *);
+GttProject *gtt_task_get_parent(GttTask *);
 
-
-GList *  gtt_task_get_intervals (GttTask *);
-void		gtt_task_add_interval (GttTask *, GttInterval *);
-void		gtt_task_append_interval (GttTask *, GttInterval *);
+GList *gtt_task_get_intervals(GttTask *);
+void gtt_task_add_interval(GttTask *, GttInterval *);
+void gtt_task_append_interval(GttTask *, GttInterval *);
 
 /* gtt_task_get_secs_ever() adds up and returns the total number of
  * seconds in the intervals in this task. */
-int     gtt_task_get_secs_ever (GttTask *tsk);
+int gtt_task_get_secs_ever(GttTask *tsk);
 
 /* Get the earliest and the latest timestamps to occur in any
  * intervals associated with this task.  Return 0 if there
  * are  o intervals on this task.
  */
-time_t   gtt_task_get_secs_earliest (GttTask *tsk);
-time_t   gtt_task_get_secs_latest (GttTask *tsk);
+time_t gtt_task_get_secs_earliest(GttTask *tsk);
+time_t gtt_task_get_secs_latest(GttTask *tsk);
 
 /* intervals */
 /* The gtt_interval_set_start() and gtt_interval_set_stop() set the
@@ -601,17 +590,17 @@ time_t   gtt_task_get_secs_latest (GttTask *tsk);
  * The is_running flag indicates whether the timer is running on this
  * interval.
  */
-GttInterval *   gtt_interval_new (void);
-void      gtt_interval_destroy (GttInterval *);
+GttInterval *gtt_interval_new(void);
+void gtt_interval_destroy(GttInterval *);
 
-void      gtt_interval_set_start (GttInterval *, time_t);
-void      gtt_interval_set_stop (GttInterval *, time_t);
-void      gtt_interval_set_running (GttInterval *, gboolean);
-void      gtt_interval_set_fuzz (GttInterval *, int);
-time_t    gtt_interval_get_start (GttInterval *);
-time_t    gtt_interval_get_stop (GttInterval *);
-gboolean  gtt_interval_is_running (GttInterval *);
-int       gtt_interval_get_fuzz (GttInterval *);
+void gtt_interval_set_start(GttInterval *, time_t);
+void gtt_interval_set_stop(GttInterval *, time_t);
+void gtt_interval_set_running(GttInterval *, gboolean);
+void gtt_interval_set_fuzz(GttInterval *, int);
+time_t gtt_interval_get_start(GttInterval *);
+time_t gtt_interval_get_stop(GttInterval *);
+gboolean gtt_interval_is_running(GttInterval *);
+int gtt_interval_get_fuzz(GttInterval *);
 
 /* The gtt_interval_new_insert_after() routine creates a new interval
  *    and inserts it after the interval "where".  It returns the new
@@ -630,12 +619,12 @@ int       gtt_interval_get_fuzz (GttInterval *);
  *    into two pieces, with the indicated interval and everything
  *    following it going after the specified.
  */
-GttInterval *   gtt_interval_new_insert_after (GttInterval *where);
-GttInterval *   gtt_interval_merge_up (GttInterval *);
-GttInterval *   gtt_interval_merge_down (GttInterval *);
-void            gtt_interval_split (GttInterval *, GttTask *);
-GttTask *       gtt_interval_get_parent (GttInterval *);
-gboolean        gtt_interval_is_first_interval (GttInterval *);
-gboolean        gtt_interval_is_last_interval (GttInterval *);
+GttInterval *gtt_interval_new_insert_after(GttInterval *where);
+GttInterval *gtt_interval_merge_up(GttInterval *);
+GttInterval *gtt_interval_merge_down(GttInterval *);
+void gtt_interval_split(GttInterval *, GttTask *);
+GttTask *gtt_interval_get_parent(GttInterval *);
+gboolean gtt_interval_is_first_interval(GttInterval *);
+gboolean gtt_interval_is_last_interval(GttInterval *);
 
 #endif /* __GTT_PROJ_H__ */

--- a/src/proj_p.h
+++ b/src/proj_p.h
@@ -29,76 +29,75 @@
 
 struct gtt_project_list_s
 {
-	// XXX this should belong to a QOF book
-	GList *prj_list;
+    // XXX this should belong to a QOF book
+    GList *prj_list;
 };
 
 struct gtt_project_s
 {
-	QofInstance inst;
+    QofInstance inst;
 
-	/* State data, data that is saved/restored/transmitted */
-	/* 'protected' data, accessible through setters & getters */
-	/* This data defines the 'state' of the project. */
-	char *title;     /* short title */
-	char *desc;      /* breif description for invoice */
-	char *notes;     /* long description */
-	char *custid;    /* customer id (TBD -- index to addresbook) */
+    /* State data, data that is saved/restored/transmitted */
+    /* 'protected' data, accessible through setters & getters */
+    /* This data defines the 'state' of the project. */
+    char *title;  /* short title */
+    char *desc;   /* breif description for invoice */
+    char *notes;  /* long description */
+    char *custid; /* customer id (TBD -- index to addresbook) */
 
-	int min_interval;        /* smallest recorded interval */
-	int auto_merge_interval; /* merge intervals smaller than this */
-	int auto_merge_gap;      /* merge gaps smaller than this */
+    int min_interval;        /* smallest recorded interval */
+    int auto_merge_interval; /* merge intervals smaller than this */
+    int auto_merge_gap;      /* merge gaps smaller than this */
 
-	double billrate;       /* billing rate, in units of currency per hour */
-	double overtime_rate;  /*  in units of currency per hour */
-	double overover_rate;  /*  the good money is here ... */
-	double flat_fee;       /* flat price, in units of currency */
+    double billrate;      /* billing rate, in units of currency per hour */
+    double overtime_rate; /*  in units of currency per hour */
+    double overover_rate; /*  the good money is here ... */
+    double flat_fee;      /* flat price, in units of currency */
 
-	time_t estimated_start;  /* projected/planned start date */
-	time_t estimated_end;    /* projected/planned end date */
-	time_t due_date;         /* drop-dead date */
-	int sizing;  /* estimate amount of time to complete (seconds) */
-	short percent_complete;  /* estimate how much work left */
-	GttRank urgency;         /* does this have to get done quickly? */
-	GttRank importance;      /* is this important to get done? */
-	GttProjectStatus status; /* overall project status */
+    time_t estimated_start;  /* projected/planned start date */
+    time_t estimated_end;    /* projected/planned end date */
+    time_t due_date;         /* drop-dead date */
+    int sizing;              /* estimate amount of time to complete (seconds) */
+    short percent_complete;  /* estimate how much work left */
+    GttRank urgency;         /* does this have to get done quickly? */
+    GttRank importance;      /* is this important to get done? */
+    GttProjectStatus status; /* overall project status */
 
-	GList *task_list;      /* annotated chunks of time */
-	GttTask *current_task; /* a pointer to the currently active task */
+    GList *task_list;      /* annotated chunks of time */
+    GttTask *current_task; /* a pointer to the currently active task */
 
-	/* hack alert -- the project heriarachy should probably be
-	 * reimplemented as a GNode rather than a GList */
-	GList *sub_projects;   /* sub-projects */
-	GttProject *parent;    /* back pointer to parent project */
+    /* hack alert -- the project heriarachy should probably be
+     * reimplemented as a GNode rather than a GList */
+    GList *sub_projects; /* sub-projects */
+    GttProject *parent;  /* back pointer to parent project */
 
-	/* ------------------------------------------------ */
-	/* 'private' internal data caches & etc. Stores temp or
-	 * dynamically generated info, not save to file or transmitted.
-	 */
+    /* ------------------------------------------------ */
+    /* 'private' internal data caches & etc. Stores temp or
+     * dynamically generated info, not save to file or transmitted.
+     */
 
-	/* hack alert - come gnome-2.0, listeners should be replaced
-	 * by a GObject callback; once this whole struct is a GObject.
-	 */
-	GList *listeners;      /* listeners for change events */
+    /* hack alert - come gnome-2.0, listeners should be replaced
+     * by a GObject callback; once this whole struct is a GObject.
+     */
+    GList *listeners; /* listeners for change events */
 
-	/* miscellaneous -- used by GUI to display */
-	gpointer *private_data;
+    /* miscellaneous -- used by GUI to display */
+    gpointer *private_data;
 
-	int id;		/* simple id number */
+    int id; /* simple id number */
 
-	int being_destroyed : 1;  /* project is being destroyed */
-	int frozen : 1 ;          /* defer recomputes of time totals */
-	int dirty_time : 1 ;      /* the time totals are wrong */
+    int being_destroyed : 1; /* project is being destroyed */
+    int frozen : 1;          /* defer recomputes of time totals */
+    int dirty_time : 1;      /* the time totals are wrong */
 
-	int secs_ever;      /* seconds spend on this project */
-	int secs_year;      /* seconds spent on this project this year */
-	int secs_month;     /* seconds spent on this project this month */
-	int secs_week;      /* seconds spent on this project this week */
-	int secs_lastweek;  /* seconds spent on this project last week */
-	int secs_day;       /* seconds spent on this project today */
-	int secs_yesterday; /* seconds spent on this project yesterday */
+    int secs_ever;      /* seconds spend on this project */
+    int secs_year;      /* seconds spent on this project this year */
+    int secs_month;     /* seconds spent on this project this month */
+    int secs_week;      /* seconds spent on this project this week */
+    int secs_lastweek;  /* seconds spent on this project last week */
+    int secs_day;       /* seconds spent on this project today */
+    int secs_yesterday; /* seconds spent on this project yesterday */
 };
-
 
 /* A 'task' is a group of start-stops that have a common 'memo'
  * associated with them.   Note that by definition, the 'current',
@@ -106,32 +105,32 @@ struct gtt_project_s
  */
 struct gtt_task_s
 {
-	QofInstance inst;
+    QofInstance inst;
 
-	GttProject *parent;       /* parent project */
-	char * memo;              /* invoiceable memo (customer sees this) */
-	char * notes;             /* internal notes (office private) */
-	GttBillable   billable;   /* if fees can be collected for this task */
-	GttBillRate   billrate;   /* hourly rate at which to bill */
-	GttBillStatus billstatus; /* disposition of this item */
-	int	bill_unit;          /* billable unit, in seconds */
-	GList *interval_list;     /* collection of start-stop's */
+    GttProject *parent;       /* parent project */
+    char *memo;               /* invoiceable memo (customer sees this) */
+    char *notes;              /* internal notes (office private) */
+    GttBillable billable;     /* if fees can be collected for this task */
+    GttBillRate billrate;     /* hourly rate at which to bill */
+    GttBillStatus billstatus; /* disposition of this item */
+    int bill_unit;            /* billable unit, in seconds */
+    GList *interval_list;     /* collection of start-stop's */
 };
 
 /* one start-stop interval */
 struct gtt_interval_s
 {
-	GttTask *parent;      /* who I belong to */
-	time_t	start;       /* when the timer started */
-	time_t	stop;        /* if stopped, shows when timer stopped,
-	                       * if running, then the most recent log point */
-	int	fuzz;           /* how fuzzy the start time is.  In
-	                       * seconds, typically 300, 3600 or 1/2 day */
-	int	running : 1;    /* boolean: is the timer running? */
+    GttTask *parent; /* who I belong to */
+    time_t start;    /* when the timer started */
+    time_t stop;     /* if stopped, shows when timer stopped,
+                      * if running, then the most recent log point */
+    int fuzz;        /* how fuzzy the start time is.  In
+                      * seconds, typically 300, 3600 or 1/2 day */
+    int running : 1; /* boolean: is the timer running? */
 };
 
 /* Should not be used by outsiders; these are dangerous routines */
-void gtt_project_set_guid (GttProject *, const GUID *);
-void gtt_task_set_guid (GttTask *, const GUID *);
+void gtt_project_set_guid(GttProject *, const GUID *);
+void gtt_task_set_guid(GttTask *, const GUID *);
 
 #endif /* __GTT_PROJ_P_H__ */

--- a/src/projects-tree.c
+++ b/src/projects-tree.c
@@ -33,912 +33,945 @@
 #include "projects-tree.h"
 #include "timer.h"
 
-#define GTT_PROJECTS_TREE_GET_PRIVATE(obj) (G_TYPE_INSTANCE_GET_PRIVATE ((obj), GTT_TYPE_PROJECTS_TREE, GttProjectsTreePrivate))
+#define GTT_PROJECTS_TREE_GET_PRIVATE(obj) \
+    (G_TYPE_INSTANCE_GET_PRIVATE((obj), GTT_TYPE_PROJECTS_TREE, GttProjectsTreePrivate))
 
-static void gtt_projects_tree_finalize (GObject *obj);
+static void gtt_projects_tree_finalize(GObject *obj);
 
-
-typedef struct _ColumnDefinition {
-	gchar            *name;
-	gint             model_column;
-	GtkCellRenderer  *renderer;
-	gchar            *value_property_name;
-	gchar            *label;
-	gint             default_width;
+typedef struct _ColumnDefinition
+{
+    gchar *name;
+    gint model_column;
+    GtkCellRenderer *renderer;
+    gchar *value_property_name;
+    gchar *label;
+    gint default_width;
 } ColumnDefinition;
 
-typedef struct _ExpanderStateHelper {
-	GtkTreeView *view;
-	gchar *states;
-	int   *row;
+typedef struct _ExpanderStateHelper
+{
+    GtkTreeView *view;
+    gchar *states;
+    int *row;
 } ExpanderStateHelper;
 
 /* Columns for the model */
-typedef enum {
-	/* data columns */
-	TIME_EVER_COLUMN,
-	TIME_YEAR_COLUMN,
-	TIME_MONTH_COLUMN,
-	TIME_WEEK_COLUMN,
-	TIME_LASTWEEK_COLUMN,
-	TIME_YESTERDAY_COLUMN,
-	TIME_TODAY_COLUMN,
-	TIME_TASK_COLUMN,
-	TITLE_COLUMN,
-	DESCRIPTION_COLUMN,
-	TASK_COLUMN,
-	ESTIMATED_START_COLUMN,
-	ESTIMATED_END_COLUMN,
-	DUE_DATE_COLUMN,
-	SIZING_COLUMN,
-	PERCENT_COLUMN,
-	URGENCY_COLUMN,
-	IMPORTANCE_COLUMN,
-	STATUS_COLUMN,
-	/* row configuration colums */
-	BACKGROUND_COLOR_COLUMN,        /* Custom background color */
-	WEIGHT_COLUMN,
-	/* pointer to the project structure */
-	GTT_PROJECT_COLUMN,
-	/* total number of columns in model */
-	NCOLS
+typedef enum
+{
+    /* data columns */
+    TIME_EVER_COLUMN,
+    TIME_YEAR_COLUMN,
+    TIME_MONTH_COLUMN,
+    TIME_WEEK_COLUMN,
+    TIME_LASTWEEK_COLUMN,
+    TIME_YESTERDAY_COLUMN,
+    TIME_TODAY_COLUMN,
+    TIME_TASK_COLUMN,
+    TITLE_COLUMN,
+    DESCRIPTION_COLUMN,
+    TASK_COLUMN,
+    ESTIMATED_START_COLUMN,
+    ESTIMATED_END_COLUMN,
+    DUE_DATE_COLUMN,
+    SIZING_COLUMN,
+    PERCENT_COLUMN,
+    URGENCY_COLUMN,
+    IMPORTANCE_COLUMN,
+    STATUS_COLUMN,
+    /* row configuration colums */
+    BACKGROUND_COLOR_COLUMN, /* Custom background color */
+    WEIGHT_COLUMN,
+    /* pointer to the project structure */
+    GTT_PROJECT_COLUMN,
+    /* total number of columns in model */
+    NCOLS
 } ModelColumn;
 
-enum {
-	COLUMNS_SETUP_DONE,
-	LAST_SIGNAL
+enum
+{
+    COLUMNS_SETUP_DONE,
+    LAST_SIGNAL
 };
-
 
 #define N_VIEWABLE_COLS (NCOLS - 3)
 
 typedef struct _GttProjectsTreePrivate GttProjectsTreePrivate;
 
-
-
-struct _GttProjectsTreePrivate {
-	GtkCellRenderer  *text_renderer;
-	GtkCellRenderer  *date_renderer;
-	GtkCellRenderer  *time_renderer;
-	GtkCellRenderer  *progress_renderer;
-	gchar            *active_bgcolor;
-	gboolean         show_seconds;
-	gboolean         highlight_active;
-	ColumnDefinition column_definitions[N_VIEWABLE_COLS];
-	GTree            *row_references;
-	GTree            *column_references;
-	gulong            row_changed_handler;
-	char *expander_states;
+struct _GttProjectsTreePrivate
+{
+    GtkCellRenderer *text_renderer;
+    GtkCellRenderer *date_renderer;
+    GtkCellRenderer *time_renderer;
+    GtkCellRenderer *progress_renderer;
+    gchar *active_bgcolor;
+    gboolean show_seconds;
+    gboolean highlight_active;
+    ColumnDefinition column_definitions[N_VIEWABLE_COLS];
+    GTree *row_references;
+    GTree *column_references;
+    gulong row_changed_handler;
+    char *expander_states;
 };
 
-static guint projects_tree_signals[LAST_SIGNAL] = {0};
+static guint projects_tree_signals[LAST_SIGNAL] = { 0 };
 
-static void gtt_projects_tree_row_expand_collapse_callback (GtkTreeView *view, GtkTreeIter *iter, GtkTreePath *path, gpointer data);
+static void gtt_projects_tree_row_expand_collapse_callback(
+    GtkTreeView *view, GtkTreeIter *iter, GtkTreePath *path, gpointer data
+);
 
-static void gtt_projects_tree_model_row_changed_callback (GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer data);
+static void gtt_projects_tree_model_row_changed_callback(
+    GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer data
+);
 
-static void project_changed (GttProject *prj, gpointer user_data);
+static void project_changed(GttProject *prj, gpointer user_data);
 
-static void
-gtt_projects_tree_create_model (GttProjectsTree *gpt)
+static void gtt_projects_tree_create_model(GttProjectsTree *gpt)
 {
-	GtkTreeStore *tree_model;
-	GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE (gpt);
-	tree_model = gtk_tree_store_new (NCOLS,
-									 G_TYPE_STRING,      /* TIME_EVER_COLUMN */
-									 G_TYPE_STRING,      /* TIME_YEAR_COLUMN */
-									 G_TYPE_STRING,      /* TIME_MONTH_COLUMN */
-									 G_TYPE_STRING,      /* TIME_WEEK_COLUMN */
-									 G_TYPE_STRING,      /* TIME_LASTWEEK_COLUMN */
-									 G_TYPE_STRING,      /* TIME_YESTERDAY_COLUMN */
-									 G_TYPE_STRING,      /* TIME_TODAY_COLUMN */
-									 G_TYPE_STRING,      /* TIME_TASK_COLUMN */
-									 G_TYPE_STRING,      /* TITLE_COLUMN */
-									 G_TYPE_STRING,      /* DESCRIPTION_COLUMN */
-									 G_TYPE_STRING,      /* TASK_COLUMN */
-									 G_TYPE_STRING,      /* ESTIMATED_START_COLUMN */
-									 G_TYPE_STRING,      /* ESTIMATED_END_COLUMN */
-									 G_TYPE_STRING,      /* DUE_DATE_COLUMN */
-									 G_TYPE_INT,      /* SIZING_COLUMN */
-									 G_TYPE_INT,      /* PERCENT_COLUMN */
-									 G_TYPE_STRING,      /* URGENCY_COLUMN */
-									 G_TYPE_STRING,      /* IMPORTANCE_COLUMN */
-									 G_TYPE_STRING,      /* STATUS_COLUMN */
-									 G_TYPE_STRING,  /* BACKGROUND_COLOR_COLUMN */
-									 G_TYPE_INT,
-									 G_TYPE_POINTER   /* GTT_POINTER_COLUMN */
-		);
-	gtk_tree_view_set_model (GTK_TREE_VIEW (gpt), GTK_TREE_MODEL (tree_model));
+    GtkTreeStore *tree_model;
+    GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE(gpt);
+    tree_model = gtk_tree_store_new(
+        NCOLS, G_TYPE_STRING,      /* TIME_EVER_COLUMN */
+        G_TYPE_STRING,             /* TIME_YEAR_COLUMN */
+        G_TYPE_STRING,             /* TIME_MONTH_COLUMN */
+        G_TYPE_STRING,             /* TIME_WEEK_COLUMN */
+        G_TYPE_STRING,             /* TIME_LASTWEEK_COLUMN */
+        G_TYPE_STRING,             /* TIME_YESTERDAY_COLUMN */
+        G_TYPE_STRING,             /* TIME_TODAY_COLUMN */
+        G_TYPE_STRING,             /* TIME_TASK_COLUMN */
+        G_TYPE_STRING,             /* TITLE_COLUMN */
+        G_TYPE_STRING,             /* DESCRIPTION_COLUMN */
+        G_TYPE_STRING,             /* TASK_COLUMN */
+        G_TYPE_STRING,             /* ESTIMATED_START_COLUMN */
+        G_TYPE_STRING,             /* ESTIMATED_END_COLUMN */
+        G_TYPE_STRING,             /* DUE_DATE_COLUMN */
+        G_TYPE_INT,                /* SIZING_COLUMN */
+        G_TYPE_INT,                /* PERCENT_COLUMN */
+        G_TYPE_STRING,             /* URGENCY_COLUMN */
+        G_TYPE_STRING,             /* IMPORTANCE_COLUMN */
+        G_TYPE_STRING,             /* STATUS_COLUMN */
+        G_TYPE_STRING,             /* BACKGROUND_COLOR_COLUMN */
+        G_TYPE_INT, G_TYPE_POINTER /* GTT_POINTER_COLUMN */
+    );
+    gtk_tree_view_set_model(GTK_TREE_VIEW(gpt), GTK_TREE_MODEL(tree_model));
 
-	priv->row_changed_handler = g_signal_connect (GTK_TREE_MODEL(tree_model),
-												 "row-changed",
-												  G_CALLBACK (gtt_projects_tree_model_row_changed_callback),
-												 gpt);
-
+    priv->row_changed_handler = g_signal_connect(
+        GTK_TREE_MODEL(tree_model), "row-changed",
+        G_CALLBACK(gtt_projects_tree_model_row_changed_callback), gpt
+    );
 }
-
 
 G_DEFINE_TYPE(GttProjectsTree, gtt_projects_tree, GTK_TYPE_TREE_VIEW)
 
-
 /* GDataCompareFunc for use in the row_references GTree */
-static gint
-project_cmp (gconstpointer a, gconstpointer b, gpointer user_data)
+static gint project_cmp(gconstpointer a, gconstpointer b, gpointer user_data)
 {
-	GttProject *prj_a = (GttProject *) a;
-	GttProject *prj_b = (GttProject *) b;
-	return gtt_project_get_id (prj_a) - gtt_project_get_id (prj_b);
+    GttProject *prj_a = (GttProject *) a;
+    GttProject *prj_b = (GttProject *) b;
+    return gtt_project_get_id(prj_a) - gtt_project_get_id(prj_b);
 }
 
-static void
-gtt_projects_tree_init (GttProjectsTree* gpt)
+static void gtt_projects_tree_init(GttProjectsTree *gpt)
 {
 
-	GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE (gpt);
+    GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE(gpt);
 
+    /* default properties values */
+    priv->active_bgcolor = g_strdup("green");
+    priv->show_seconds = TRUE;
+    priv->highlight_active = TRUE;
 
-	/* default properties values */
-	priv->active_bgcolor = g_strdup("green");
-	priv->show_seconds = TRUE;
-	priv->highlight_active = TRUE;
+    /* references to the rows */
+    priv->row_references = g_tree_new_full(
+        project_cmp, NULL, NULL, (GDestroyNotify) gtk_tree_row_reference_free
+    );
 
-	/* references to the rows */
-	priv->row_references = g_tree_new_full (project_cmp, NULL, NULL, (GDestroyNotify) gtk_tree_row_reference_free);
+    /* cell renderers used to render the tree */
+    priv->text_renderer = gtk_cell_renderer_text_new();
+    g_object_ref(priv->text_renderer);
 
-	/* cell renderers used to render the tree */
-	priv->text_renderer = gtk_cell_renderer_text_new ();
-	g_object_ref (priv->text_renderer);
+    priv->date_renderer = gtk_cell_renderer_text_new();
+    g_object_set(priv->date_renderer, "xalign", 0.5, NULL);
+    g_object_ref(priv->date_renderer);
 
-	priv->date_renderer = gtk_cell_renderer_text_new ();
-	g_object_set (priv->date_renderer, "xalign", 0.5, NULL);
-	g_object_ref (priv->date_renderer);
+    priv->time_renderer = gtk_cell_renderer_text_new();
+    g_object_set(priv->time_renderer, "xalign", 0.5, NULL);
+    g_object_ref(priv->time_renderer);
 
-	priv->time_renderer = gtk_cell_renderer_text_new ();
-	g_object_set (priv->time_renderer, "xalign", 0.5, NULL);
-	g_object_ref (priv->time_renderer);
+    priv->progress_renderer = gtk_cell_renderer_progress_new();
+    g_object_ref(priv->progress_renderer);
 
-	priv->progress_renderer = gtk_cell_renderer_progress_new ();
-	g_object_ref (priv->progress_renderer);
+    /* Definition of the possible data columns to be displayed */
+    priv->column_definitions[0].name = "time_ever";
+    priv->column_definitions[0].model_column = TIME_EVER_COLUMN;
+    priv->column_definitions[0].renderer = priv->time_renderer;
+    priv->column_definitions[0].value_property_name = "text";
+    priv->column_definitions[0].label = _("Total");
+    priv->column_definitions[0].default_width = 72;
 
+    priv->column_definitions[1].name = "time_year";
+    priv->column_definitions[1].model_column = TIME_YEAR_COLUMN;
+    priv->column_definitions[1].renderer = priv->time_renderer;
+    priv->column_definitions[1].value_property_name = "text";
+    priv->column_definitions[1].label = _("Year");
+    priv->column_definitions[1].default_width = 72;
 
-	/* Definition of the possible data columns to be displayed */
-	priv->column_definitions[0].name = "time_ever";
-	priv->column_definitions[0].model_column = TIME_EVER_COLUMN;
-	priv->column_definitions[0].renderer = priv->time_renderer;
-	priv->column_definitions[0].value_property_name = "text";
-	priv->column_definitions[0].label = _("Total");
-	priv->column_definitions[0].default_width = 72;
+    priv->column_definitions[2].name = "time_month";
+    priv->column_definitions[2].model_column = TIME_MONTH_COLUMN;
+    priv->column_definitions[2].renderer = priv->time_renderer;
+    priv->column_definitions[2].value_property_name = "text";
+    priv->column_definitions[2].label = _("Month");
+    priv->column_definitions[2].default_width = 72;
 
-	priv->column_definitions[1].name = "time_year";
-	priv->column_definitions[1].model_column = TIME_YEAR_COLUMN;
-	priv->column_definitions[1].renderer = priv->time_renderer;
-	priv->column_definitions[1].value_property_name = "text";
-	priv->column_definitions[1].label = _("Year");
-	priv->column_definitions[1].default_width = 72;
+    priv->column_definitions[3].name = "time_week";
+    priv->column_definitions[3].model_column = TIME_WEEK_COLUMN;
+    priv->column_definitions[3].renderer = priv->time_renderer;
+    priv->column_definitions[3].value_property_name = "text";
+    priv->column_definitions[3].label = _("Week");
+    priv->column_definitions[3].default_width = 72;
 
-	priv->column_definitions[2].name = "time_month";
-	priv->column_definitions[2].model_column = TIME_MONTH_COLUMN;
-	priv->column_definitions[2].renderer = priv->time_renderer;
-	priv->column_definitions[2].value_property_name = "text";
-	priv->column_definitions[2].label = _("Month");
-	priv->column_definitions[2].default_width = 72;
+    priv->column_definitions[4].name = "time_lastweek";
+    priv->column_definitions[4].model_column = TIME_LASTWEEK_COLUMN;
+    priv->column_definitions[4].renderer = priv->time_renderer;
+    priv->column_definitions[4].value_property_name = "text";
+    priv->column_definitions[4].label = _("Last Week");
+    priv->column_definitions[4].default_width = 72;
 
-	priv->column_definitions[3].name = "time_week";
-	priv->column_definitions[3].model_column = TIME_WEEK_COLUMN;
-	priv->column_definitions[3].renderer = priv->time_renderer;
-	priv->column_definitions[3].value_property_name = "text";
-	priv->column_definitions[3].label = _("Week");
-	priv->column_definitions[3].default_width = 72;
+    priv->column_definitions[5].name = "time_yesterday";
+    priv->column_definitions[5].model_column = TIME_YESTERDAY_COLUMN;
+    priv->column_definitions[5].renderer = priv->time_renderer;
+    priv->column_definitions[5].value_property_name = "text";
+    priv->column_definitions[5].label = _("Yesterday");
+    priv->column_definitions[5].default_width = 72;
 
-	priv->column_definitions[4].name = "time_lastweek";
-	priv->column_definitions[4].model_column = TIME_LASTWEEK_COLUMN;
-	priv->column_definitions[4].renderer = priv->time_renderer;
-	priv->column_definitions[4].value_property_name = "text";
-	priv->column_definitions[4].label = _("Last Week");
-	priv->column_definitions[4].default_width = 72;
+    priv->column_definitions[6].name = "time_today";
+    priv->column_definitions[6].model_column = TIME_TODAY_COLUMN;
+    priv->column_definitions[6].renderer = priv->time_renderer;
+    priv->column_definitions[6].value_property_name = "text";
+    priv->column_definitions[6].label = _("Today");
+    priv->column_definitions[6].default_width = 72;
 
-	priv->column_definitions[5].name = "time_yesterday";
-	priv->column_definitions[5].model_column = TIME_YESTERDAY_COLUMN;
-	priv->column_definitions[5].renderer = priv->time_renderer;
-	priv->column_definitions[5].value_property_name = "text";
-	priv->column_definitions[5].label = _("Yesterday");
-	priv->column_definitions[5].default_width = 72;
+    priv->column_definitions[7].name = "time_task";
+    priv->column_definitions[7].model_column = TIME_TASK_COLUMN;
+    priv->column_definitions[7].renderer = priv->time_renderer;
+    priv->column_definitions[7].value_property_name = "text";
+    priv->column_definitions[7].label = _("Entry");
+    priv->column_definitions[7].default_width = 72;
 
-	priv->column_definitions[6].name = "time_today";
-	priv->column_definitions[6].model_column = TIME_TODAY_COLUMN;
-	priv->column_definitions[6].renderer = priv->time_renderer;
-	priv->column_definitions[6].value_property_name = "text";
-	priv->column_definitions[6].label = _("Today");
-	priv->column_definitions[6].default_width = 72;
+    priv->column_definitions[8].name = "title";
+    priv->column_definitions[8].model_column = TITLE_COLUMN;
+    priv->column_definitions[8].renderer = priv->text_renderer;
+    priv->column_definitions[8].value_property_name = "text";
+    priv->column_definitions[8].label = _("Title");
+    priv->column_definitions[8].default_width = 72;
 
-	priv->column_definitions[7].name = "time_task";
-	priv->column_definitions[7].model_column = TIME_TASK_COLUMN;
-	priv->column_definitions[7].renderer = priv->time_renderer;
-	priv->column_definitions[7].value_property_name = "text";
-	priv->column_definitions[7].label = _("Entry");
-	priv->column_definitions[7].default_width = 72;
+    priv->column_definitions[9].name = "description";
+    priv->column_definitions[9].model_column = DESCRIPTION_COLUMN;
+    priv->column_definitions[9].renderer = priv->text_renderer;
+    priv->column_definitions[9].value_property_name = "text";
+    priv->column_definitions[9].label = _("Description");
+    priv->column_definitions[9].default_width = 72;
 
-	priv->column_definitions[8].name = "title";
-	priv->column_definitions[8].model_column = TITLE_COLUMN;
-	priv->column_definitions[8].renderer = priv->text_renderer;
-	priv->column_definitions[8].value_property_name = "text";
-	priv->column_definitions[8].label = _("Title");
-	priv->column_definitions[8].default_width = 72;
+    priv->column_definitions[10].name = "task";
+    priv->column_definitions[10].model_column = TASK_COLUMN;
+    priv->column_definitions[10].renderer = priv->text_renderer;
+    priv->column_definitions[10].value_property_name = "text";
+    priv->column_definitions[10].label = _("Diary Entry");
+    priv->column_definitions[10].default_width = 72;
 
-	priv->column_definitions[9].name = "description";
-	priv->column_definitions[9].model_column = DESCRIPTION_COLUMN;
-	priv->column_definitions[9].renderer = priv->text_renderer;
-	priv->column_definitions[9].value_property_name = "text";
-	priv->column_definitions[9].label = _("Description");
-	priv->column_definitions[9].default_width = 72;
+    priv->column_definitions[11].name = "estimated_start";
+    priv->column_definitions[11].model_column = ESTIMATED_START_COLUMN;
+    priv->column_definitions[11].renderer = priv->date_renderer;
+    priv->column_definitions[11].value_property_name = "text";
+    priv->column_definitions[11].label = _("Start");
+    priv->column_definitions[11].default_width = 72;
 
-	priv->column_definitions[10].name = "task";
-	priv->column_definitions[10].model_column = TASK_COLUMN;
-	priv->column_definitions[10].renderer = priv->text_renderer;
-	priv->column_definitions[10].value_property_name = "text";
-	priv->column_definitions[10].label = _("Diary Entry");
-	priv->column_definitions[10].default_width = 72;
+    priv->column_definitions[12].name = "estimated_end";
+    priv->column_definitions[12].model_column = ESTIMATED_END_COLUMN;
+    priv->column_definitions[12].renderer = priv->date_renderer;
+    priv->column_definitions[12].value_property_name = "text";
+    priv->column_definitions[12].label = _("End");
+    priv->column_definitions[12].default_width = 72;
 
-	priv->column_definitions[11].name = "estimated_start";
-	priv->column_definitions[11].model_column = ESTIMATED_START_COLUMN;
-	priv->column_definitions[11].renderer = priv->date_renderer;
-	priv->column_definitions[11].value_property_name = "text";
-	priv->column_definitions[11].label = _("Start");
-	priv->column_definitions[11].default_width = 72;
+    priv->column_definitions[13].name = "due_date";
+    priv->column_definitions[13].model_column = DUE_DATE_COLUMN;
+    priv->column_definitions[13].renderer = priv->date_renderer;
+    priv->column_definitions[13].value_property_name = "text";
+    priv->column_definitions[13].label = _("Due");
+    priv->column_definitions[13].default_width = 72;
 
-	priv->column_definitions[12].name = "estimated_end";
-	priv->column_definitions[12].model_column = ESTIMATED_END_COLUMN;
-	priv->column_definitions[12].renderer = priv->date_renderer;
-	priv->column_definitions[12].value_property_name = "text";
-	priv->column_definitions[12].label = _("End");
-	priv->column_definitions[12].default_width = 72;
+    priv->column_definitions[14].name = "sizing";
+    priv->column_definitions[14].model_column = SIZING_COLUMN;
+    priv->column_definitions[14].renderer = priv->date_renderer;
+    priv->column_definitions[14].value_property_name = "text";
+    priv->column_definitions[14].label = _("Size");
+    priv->column_definitions[14].default_width = 72;
 
-	priv->column_definitions[13].name = "due_date";
-	priv->column_definitions[13].model_column = DUE_DATE_COLUMN;
-	priv->column_definitions[13].renderer = priv->date_renderer;
-	priv->column_definitions[13].value_property_name = "text";
-	priv->column_definitions[13].label = _("Due");
-	priv->column_definitions[13].default_width = 72;
+    priv->column_definitions[15].name = "percent_done";
+    priv->column_definitions[15].model_column = PERCENT_COLUMN;
+    priv->column_definitions[15].renderer = priv->progress_renderer;
+    priv->column_definitions[15].value_property_name = "value";
+    priv->column_definitions[15].label = _("Done");
+    priv->column_definitions[15].default_width = 72;
 
-	priv->column_definitions[14].name = "sizing";
-	priv->column_definitions[14].model_column = SIZING_COLUMN;
-	priv->column_definitions[14].renderer = priv->date_renderer;
-	priv->column_definitions[14].value_property_name = "text";
-	priv->column_definitions[14].label = _("Size");
-	priv->column_definitions[14].default_width = 72;
+    priv->column_definitions[16].name = "urgency";
+    priv->column_definitions[16].model_column = URGENCY_COLUMN;
+    priv->column_definitions[16].renderer = priv->text_renderer;
+    priv->column_definitions[16].value_property_name = "text";
+    priv->column_definitions[16].label = _("Urgency");
+    priv->column_definitions[16].default_width = 72;
 
-	priv->column_definitions[15].name = "percent_done";
-	priv->column_definitions[15].model_column = PERCENT_COLUMN;
-	priv->column_definitions[15].renderer = priv->progress_renderer;
-	priv->column_definitions[15].value_property_name = "value";
-	priv->column_definitions[15].label = _("Done");
-	priv->column_definitions[15].default_width = 72;
-	
-	priv->column_definitions[16].name = "urgency";
-	priv->column_definitions[16].model_column = URGENCY_COLUMN;
-	priv->column_definitions[16].renderer = priv->text_renderer;
-	priv->column_definitions[16].value_property_name = "text";
-	priv->column_definitions[16].label = _("Urgency");
-	priv->column_definitions[16].default_width = 72;
-	
-	priv->column_definitions[17].name = "importance";
-	priv->column_definitions[17].model_column = IMPORTANCE_COLUMN;
-	priv->column_definitions[17].renderer = priv->text_renderer;
-	priv->column_definitions[17].value_property_name = "text";
-	priv->column_definitions[17].label = _("Importance");
-	priv->column_definitions[17].default_width = 72;
-	
-	priv->column_definitions[18].name = "status";
-	priv->column_definitions[18].model_column = STATUS_COLUMN;
-	priv->column_definitions[18].renderer = priv->text_renderer;
-	priv->column_definitions[18].value_property_name = "text";
-	priv->column_definitions[18].label = _("Status");
-	priv->column_definitions[18].default_width = 72;
+    priv->column_definitions[17].name = "importance";
+    priv->column_definitions[17].model_column = IMPORTANCE_COLUMN;
+    priv->column_definitions[17].renderer = priv->text_renderer;
+    priv->column_definitions[17].value_property_name = "text";
+    priv->column_definitions[17].label = _("Importance");
+    priv->column_definitions[17].default_width = 72;
 
-	gtt_projects_tree_create_model (gpt);
-	gtt_projects_tree_set_visible_columns (gpt, NULL);
+    priv->column_definitions[18].name = "status";
+    priv->column_definitions[18].model_column = STATUS_COLUMN;
+    priv->column_definitions[18].renderer = priv->text_renderer;
+    priv->column_definitions[18].value_property_name = "text";
+    priv->column_definitions[18].label = _("Status");
+    priv->column_definitions[18].default_width = 72;
 
-	gtk_tree_view_set_headers_visible (GTK_TREE_VIEW (gpt), TRUE);
-	gtk_tree_view_set_headers_clickable (GTK_TREE_VIEW (gpt), TRUE);
-	gtk_tree_view_set_show_expanders (GTK_TREE_VIEW (gpt), TRUE);
-	gtk_tree_view_set_rules_hint (GTK_TREE_VIEW (gpt), TRUE);
-	gtk_tree_view_set_enable_tree_lines (GTK_TREE_VIEW (gpt), TRUE);
+    gtt_projects_tree_create_model(gpt);
+    gtt_projects_tree_set_visible_columns(gpt, NULL);
 
-	g_signal_connect (GTK_TREE_VIEW (gpt),
-					  "row-expanded",
-					  G_CALLBACK (gtt_projects_tree_row_expand_collapse_callback),
-					  NULL);
-	g_signal_connect (GTK_TREE_VIEW (gpt),
-					  "row-collapsed",
-					  G_CALLBACK (gtt_projects_tree_row_expand_collapse_callback),
-					  NULL);
+    gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(gpt), TRUE);
+    gtk_tree_view_set_headers_clickable(GTK_TREE_VIEW(gpt), TRUE);
+    gtk_tree_view_set_show_expanders(GTK_TREE_VIEW(gpt), TRUE);
+    gtk_tree_view_set_rules_hint(GTK_TREE_VIEW(gpt), TRUE);
+    gtk_tree_view_set_enable_tree_lines(GTK_TREE_VIEW(gpt), TRUE);
 
+    g_signal_connect(
+        GTK_TREE_VIEW(gpt), "row-expanded",
+        G_CALLBACK(gtt_projects_tree_row_expand_collapse_callback), NULL
+    );
+    g_signal_connect(
+        GTK_TREE_VIEW(gpt), "row-collapsed",
+        G_CALLBACK(gtt_projects_tree_row_expand_collapse_callback), NULL
+    );
 }
 
-static void
-gtt_projects_tree_finalize (GObject *obj)
+static void gtt_projects_tree_finalize(GObject *obj)
 {
-	GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE (obj);
-	g_object_unref (priv->text_renderer);
-	g_object_unref (priv->date_renderer);
-	g_object_unref (priv->time_renderer);
-	g_object_unref (priv->progress_renderer);
-	g_tree_destroy (priv->row_references);
-	g_tree_destroy (priv->column_references);
+    GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE(obj);
+    g_object_unref(priv->text_renderer);
+    g_object_unref(priv->date_renderer);
+    g_object_unref(priv->time_renderer);
+    g_object_unref(priv->progress_renderer);
+    g_tree_destroy(priv->row_references);
+    g_tree_destroy(priv->column_references);
 }
 
-GttProjectsTree *
-gtt_projects_tree_new (void)
+GttProjectsTree *gtt_projects_tree_new(void)
 {
-	return g_object_new (gtt_projects_tree_get_type(), NULL);
+    return g_object_new(gtt_projects_tree_get_type(), NULL);
 }
 
-static void
-gtt_projects_tree_class_init (GttProjectsTreeClass *klass)
+static void gtt_projects_tree_class_init(GttProjectsTreeClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS (klass);
-	object_class->finalize = gtt_projects_tree_finalize;
-	g_type_class_add_private (object_class, sizeof (GttProjectsTreePrivate));
-	projects_tree_signals[COLUMNS_SETUP_DONE] =
-		g_signal_new ("columns_setup_done",
-					  G_TYPE_FROM_CLASS (object_class),
-					  G_SIGNAL_RUN_LAST,
-					  0, NULL, NULL,
-					  g_cclosure_marshal_VOID__VOID,
-					  G_TYPE_NONE, 0);
+    GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    object_class->finalize = gtt_projects_tree_finalize;
+    g_type_class_add_private(object_class, sizeof(GttProjectsTreePrivate));
+    projects_tree_signals[COLUMNS_SETUP_DONE] = g_signal_new(
+        "columns_setup_done", G_TYPE_FROM_CLASS(object_class), G_SIGNAL_RUN_LAST, 0, NULL, NULL,
+        g_cclosure_marshal_VOID__VOID, G_TYPE_NONE, 0
+    );
 }
 
-static void
-gtt_projects_tree_set_time_value (GttProjectsTree *gpt, GtkTreeStore *tree_model, GtkTreeIter *iter, gint column, gint value)
+static void gtt_projects_tree_set_time_value(
+    GttProjectsTree *gpt, GtkTreeStore *tree_model, GtkTreeIter *iter, gint column, gint value
+)
 {
 
-	GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE (gpt);
-	char buff[13];
-	memset(buff, 0, 13);
-	/* Format time and set column value */
-	if (value == 0)
-	{
-		buff[0] = '-';
-	}
-	else
-	{
-		if (priv->show_seconds)
-		{
-			sprintf (buff, "%02d:%02d:%02d", value / 3600, (value / 60) % 60, value % 60);
-		}
-		else
-		{
-			sprintf (buff, "%02d:%02d", value / 3600, (value / 60) % 60);
-		}
-	}
-	gtk_tree_store_set (tree_model, iter, column, buff, -1);
+    GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE(gpt);
+    char buff[13];
+    memset(buff, 0, 13);
+    /* Format time and set column value */
+    if (value == 0)
+    {
+        buff[0] = '-';
+    }
+    else
+    {
+        if (priv->show_seconds)
+        {
+            sprintf(buff, "%02d:%02d:%02d", value / 3600, (value / 60) % 60, value % 60);
+        }
+        else
+        {
+            sprintf(buff, "%02d:%02d", value / 3600, (value / 60) % 60);
+        }
+    }
+    gtk_tree_store_set(tree_model, iter, column, buff, -1);
 }
 
-
-static void
-gtt_projects_tree_set_date_value (GttProjectsTree *gpt, GtkTreeStore *tree_model, GtkTreeIter *iter, gint column, time_t value)
+static void gtt_projects_tree_set_date_value(
+    GttProjectsTree *gpt, GtkTreeStore *tree_model, GtkTreeIter *iter, gint column, time_t value
+)
 {
-	gchar buff[100];
-	memset(buff, 0, 100);
-	if (value > -1)
-	{
-		strftime (buff, 100, "%x", localtime(&value));
-	}
-	else
-	{
-		buff[0] = '-';
-	}
-	gtk_tree_store_set (tree_model, iter, column, buff, -1);
+    gchar buff[100];
+    memset(buff, 0, 100);
+    if (value > -1)
+    {
+        strftime(buff, 100, "%x", localtime(&value));
+    }
+    else
+    {
+        buff[0] = '-';
+    }
+    gtk_tree_store_set(tree_model, iter, column, buff, -1);
 }
 
-
-static void
-gtt_projects_tree_set_project_times (GttProjectsTree *gpt, GtkTreeStore *tree_model, GttProject *prj, GtkTreeIter *iter)
+static void gtt_projects_tree_set_project_times(
+    GttProjectsTree *gpt, GtkTreeStore *tree_model, GttProject *prj, GtkTreeIter *iter
+)
 {
-	GtkTreePath *path = gtk_tree_model_get_path (GTK_TREE_MODEL (tree_model), iter);
+    GtkTreePath *path = gtk_tree_model_get_path(GTK_TREE_MODEL(tree_model), iter);
 
-	if (gtk_tree_view_row_expanded (GTK_TREE_VIEW (gpt), path))
-	{
-		gtt_projects_tree_set_time_value (gpt, tree_model, iter, TIME_EVER_COLUMN, gtt_project_get_secs_ever (prj));
-		gtt_projects_tree_set_time_value (gpt, tree_model, iter, TIME_YEAR_COLUMN, gtt_project_get_secs_year (prj));
-		gtt_projects_tree_set_time_value (gpt, tree_model, iter, TIME_MONTH_COLUMN, gtt_project_get_secs_month (prj));
-		gtt_projects_tree_set_time_value (gpt, tree_model, iter, TIME_WEEK_COLUMN, gtt_project_get_secs_week (prj));
-		gtt_projects_tree_set_time_value (gpt, tree_model, iter, TIME_LASTWEEK_COLUMN, gtt_project_get_secs_lastweek (prj));
-		gtt_projects_tree_set_time_value (gpt, tree_model, iter, TIME_YESTERDAY_COLUMN, gtt_project_get_secs_yesterday (prj));
-		gtt_projects_tree_set_time_value (gpt, tree_model, iter, TIME_TODAY_COLUMN, gtt_project_get_secs_day (prj));
-		gtt_projects_tree_set_time_value (gpt, tree_model, iter, TIME_TASK_COLUMN, gtt_project_get_secs_current (prj));
-	}
-	else
-	{
-		gtt_projects_tree_set_time_value (gpt, tree_model, iter, TIME_EVER_COLUMN, gtt_project_total_secs_ever (prj));
-		gtt_projects_tree_set_time_value (gpt, tree_model, iter, TIME_YEAR_COLUMN, gtt_project_total_secs_year (prj));
-		gtt_projects_tree_set_time_value (gpt, tree_model, iter, TIME_MONTH_COLUMN, gtt_project_total_secs_month (prj));
-		gtt_projects_tree_set_time_value (gpt, tree_model, iter, TIME_WEEK_COLUMN, gtt_project_total_secs_week (prj));
-		gtt_projects_tree_set_time_value (gpt, tree_model, iter, TIME_LASTWEEK_COLUMN, gtt_project_total_secs_lastweek (prj));
-		gtt_projects_tree_set_time_value (gpt, tree_model, iter, TIME_YESTERDAY_COLUMN, gtt_project_total_secs_yesterday (prj));
-		gtt_projects_tree_set_time_value (gpt, tree_model, iter, TIME_TODAY_COLUMN, gtt_project_total_secs_day (prj));
-		gtt_projects_tree_set_time_value (gpt, tree_model, iter, TIME_TASK_COLUMN, gtt_project_total_secs_current (prj));
-	}
+    if (gtk_tree_view_row_expanded(GTK_TREE_VIEW(gpt), path))
+    {
+        gtt_projects_tree_set_time_value(
+            gpt, tree_model, iter, TIME_EVER_COLUMN, gtt_project_get_secs_ever(prj)
+        );
+        gtt_projects_tree_set_time_value(
+            gpt, tree_model, iter, TIME_YEAR_COLUMN, gtt_project_get_secs_year(prj)
+        );
+        gtt_projects_tree_set_time_value(
+            gpt, tree_model, iter, TIME_MONTH_COLUMN, gtt_project_get_secs_month(prj)
+        );
+        gtt_projects_tree_set_time_value(
+            gpt, tree_model, iter, TIME_WEEK_COLUMN, gtt_project_get_secs_week(prj)
+        );
+        gtt_projects_tree_set_time_value(
+            gpt, tree_model, iter, TIME_LASTWEEK_COLUMN, gtt_project_get_secs_lastweek(prj)
+        );
+        gtt_projects_tree_set_time_value(
+            gpt, tree_model, iter, TIME_YESTERDAY_COLUMN, gtt_project_get_secs_yesterday(prj)
+        );
+        gtt_projects_tree_set_time_value(
+            gpt, tree_model, iter, TIME_TODAY_COLUMN, gtt_project_get_secs_day(prj)
+        );
+        gtt_projects_tree_set_time_value(
+            gpt, tree_model, iter, TIME_TASK_COLUMN, gtt_project_get_secs_current(prj)
+        );
+    }
+    else
+    {
+        gtt_projects_tree_set_time_value(
+            gpt, tree_model, iter, TIME_EVER_COLUMN, gtt_project_total_secs_ever(prj)
+        );
+        gtt_projects_tree_set_time_value(
+            gpt, tree_model, iter, TIME_YEAR_COLUMN, gtt_project_total_secs_year(prj)
+        );
+        gtt_projects_tree_set_time_value(
+            gpt, tree_model, iter, TIME_MONTH_COLUMN, gtt_project_total_secs_month(prj)
+        );
+        gtt_projects_tree_set_time_value(
+            gpt, tree_model, iter, TIME_WEEK_COLUMN, gtt_project_total_secs_week(prj)
+        );
+        gtt_projects_tree_set_time_value(
+            gpt, tree_model, iter, TIME_LASTWEEK_COLUMN, gtt_project_total_secs_lastweek(prj)
+        );
+        gtt_projects_tree_set_time_value(
+            gpt, tree_model, iter, TIME_YESTERDAY_COLUMN, gtt_project_total_secs_yesterday(prj)
+        );
+        gtt_projects_tree_set_time_value(
+            gpt, tree_model, iter, TIME_TODAY_COLUMN, gtt_project_total_secs_day(prj)
+        );
+        gtt_projects_tree_set_time_value(
+            gpt, tree_model, iter, TIME_TASK_COLUMN, gtt_project_total_secs_current(prj)
+        );
+    }
 }
 
-
-static void
-gtt_projects_tree_set_project_dates (GttProjectsTree *gpt, GtkTreeStore *tree_model, GttProject *prj, GtkTreeIter *iter)
+static void gtt_projects_tree_set_project_dates(
+    GttProjectsTree *gpt, GtkTreeStore *tree_model, GttProject *prj, GtkTreeIter *iter
+)
 {
-	gtt_projects_tree_set_date_value (gpt, tree_model, iter, ESTIMATED_START_COLUMN, gtt_project_get_estimated_start (prj));
-	gtt_projects_tree_set_date_value (gpt, tree_model, iter, ESTIMATED_END_COLUMN, gtt_project_get_estimated_end (prj));
-	gtt_projects_tree_set_date_value (gpt, tree_model, iter, DUE_DATE_COLUMN, gtt_project_get_due_date (prj));
+    gtt_projects_tree_set_date_value(
+        gpt, tree_model, iter, ESTIMATED_START_COLUMN, gtt_project_get_estimated_start(prj)
+    );
+    gtt_projects_tree_set_date_value(
+        gpt, tree_model, iter, ESTIMATED_END_COLUMN, gtt_project_get_estimated_end(prj)
+    );
+    gtt_projects_tree_set_date_value(
+        gpt, tree_model, iter, DUE_DATE_COLUMN, gtt_project_get_due_date(prj)
+    );
 }
 
-static void
-gtt_projects_tree_set_style (GttProjectsTree *gpt, GtkTreeStore *tree_model, GttProject *prj, GtkTreeIter *iter)
+static void gtt_projects_tree_set_style(
+    GttProjectsTree *gpt, GtkTreeStore *tree_model, GttProject *prj, GtkTreeIter *iter
+)
 {
-	GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE (gpt);
-	PangoWeight weight = PANGO_WEIGHT_NORMAL;
-	gchar *bgcolor = NULL;
+    GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE(gpt);
+    PangoWeight weight = PANGO_WEIGHT_NORMAL;
+    gchar *bgcolor = NULL;
 
-	if (priv->highlight_active)
-	{
-		if (timer_project_is_running (prj))
-		{
-			bgcolor = priv->active_bgcolor;
-			weight = PANGO_WEIGHT_BOLD;
-		}
-	}
-	gtk_tree_store_set (tree_model,
-						iter,
-						BACKGROUND_COLOR_COLUMN, bgcolor,
-						WEIGHT_COLUMN, weight,
-						-1);
+    if (priv->highlight_active)
+    {
+        if (timer_project_is_running(prj))
+        {
+            bgcolor = priv->active_bgcolor;
+            weight = PANGO_WEIGHT_BOLD;
+        }
+    }
+    gtk_tree_store_set(
+        tree_model, iter, BACKGROUND_COLOR_COLUMN, bgcolor, WEIGHT_COLUMN, weight, -1
+    );
 }
 
-static void
-gtt_projects_tree_set_project_urgency (GttProjectsTree *gpt, GtkTreeStore *tree_model, GttProject *prj, GtkTreeIter *iter)
+static void gtt_projects_tree_set_project_urgency(
+    GttProjectsTree *gpt, GtkTreeStore *tree_model, GttProject *prj, GtkTreeIter *iter
+)
 {
-	gchar *value;
-	switch (gtt_project_get_urgency (prj)) {
-	case GTT_UNDEFINED: value = "-"; break;
-	case GTT_LOW:    value = _("Low"); break;
-	case GTT_MEDIUM: value = _("Med"); break;
-	case GTT_HIGH:   value = _("High"); break;
-	default: value = "-"; break;
-	}
+    gchar *value;
+    switch (gtt_project_get_urgency(prj))
+    {
+    case GTT_UNDEFINED:
+        value = "-";
+        break;
+    case GTT_LOW:
+        value = _("Low");
+        break;
+    case GTT_MEDIUM:
+        value = _("Med");
+        break;
+    case GTT_HIGH:
+        value = _("High");
+        break;
+    default:
+        value = "-";
+        break;
+    }
 
-
-	gtk_tree_store_set (tree_model,
-						iter,
-						URGENCY_COLUMN, value,
-						-1);
+    gtk_tree_store_set(tree_model, iter, URGENCY_COLUMN, value, -1);
 }
 
-static void
-gtt_projects_tree_set_project_importance (GttProjectsTree *gpt, GtkTreeStore *tree_model, GttProject *prj, GtkTreeIter *iter)
+static void gtt_projects_tree_set_project_importance(
+    GttProjectsTree *gpt, GtkTreeStore *tree_model, GttProject *prj, GtkTreeIter *iter
+)
 {
-	gchar *value;
-	switch (gtt_project_get_importance (prj)) {
-	case GTT_UNDEFINED: value = "-"; break;
-	case GTT_LOW:    value = _("Low"); break;
-	case GTT_MEDIUM: value = _("Med"); break;
-	case GTT_HIGH:   value = _("High"); break;
-	default: value = "-"; break;
-	}
+    gchar *value;
+    switch (gtt_project_get_importance(prj))
+    {
+    case GTT_UNDEFINED:
+        value = "-";
+        break;
+    case GTT_LOW:
+        value = _("Low");
+        break;
+    case GTT_MEDIUM:
+        value = _("Med");
+        break;
+    case GTT_HIGH:
+        value = _("High");
+        break;
+    default:
+        value = "-";
+        break;
+    }
 
-	gtk_tree_store_set (tree_model,
-						iter,
-						IMPORTANCE_COLUMN, value,
-						-1);
+    gtk_tree_store_set(tree_model, iter, IMPORTANCE_COLUMN, value, -1);
 }
 
-static void
-gtt_projects_tree_set_project_status (GttProjectsTree *gpt, GtkTreeStore *tree_model, GttProject *prj, GtkTreeIter *iter)
+static void gtt_projects_tree_set_project_status(
+    GttProjectsTree *gpt, GtkTreeStore *tree_model, GttProject *prj, GtkTreeIter *iter
+)
 {
 
-	gchar *value;
-	switch (gtt_project_get_status (prj)) {
-	case GTT_NO_STATUS:   value = "-"; break;
-	case GTT_NOT_STARTED: value = _("Not Started"); break;
-	case GTT_IN_PROGRESS: value = _("In Progress"); break;
-	case GTT_ON_HOLD:     value = _("On Hold"); break;
-	case GTT_CANCELLED:   value = _("Cancelled"); break;
-	case GTT_COMPLETED:   value = _("Completed"); break;
-	default: value = "-"; break;
-	}
+    gchar *value;
+    switch (gtt_project_get_status(prj))
+    {
+    case GTT_NO_STATUS:
+        value = "-";
+        break;
+    case GTT_NOT_STARTED:
+        value = _("Not Started");
+        break;
+    case GTT_IN_PROGRESS:
+        value = _("In Progress");
+        break;
+    case GTT_ON_HOLD:
+        value = _("On Hold");
+        break;
+    case GTT_CANCELLED:
+        value = _("Cancelled");
+        break;
+    case GTT_COMPLETED:
+        value = _("Completed");
+        break;
+    default:
+        value = "-";
+        break;
+    }
 
-	gtk_tree_store_set (tree_model,
-						iter,
-						STATUS_COLUMN, value,
-						-1);
+    gtk_tree_store_set(tree_model, iter, STATUS_COLUMN, value, -1);
 }
 
-static void
-gtt_projects_tree_set_project_data (GttProjectsTree *gpt, GtkTreeStore *tree_model, GttProject *prj, GtkTreeIter *iter)
+static void gtt_projects_tree_set_project_data(
+    GttProjectsTree *gpt, GtkTreeStore *tree_model, GttProject *prj, GtkTreeIter *iter
+)
 {
 
-	GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE (gpt);
-	if (priv->row_changed_handler)
-	{
-		g_signal_handler_disconnect (tree_model, priv->row_changed_handler);
-		priv->row_changed_handler = 0;
-	}
-	gtk_tree_store_set (tree_model,
-						iter,
-						TITLE_COLUMN, gtt_project_get_title (prj),
-						DESCRIPTION_COLUMN, gtt_project_get_desc (prj),
-						TASK_COLUMN, gtt_task_get_memo (gtt_project_get_current_task (prj)),
-						SIZING_COLUMN, gtt_project_get_sizing (prj),
-						PERCENT_COLUMN, gtt_project_get_percent_complete (prj),
-						GTT_PROJECT_COLUMN, prj,
-						-1);
-	gtt_projects_tree_set_project_times (gpt, tree_model, prj, iter);
-	gtt_projects_tree_set_project_dates (gpt, tree_model, prj, iter);
-	gtt_projects_tree_set_style (gpt, tree_model, prj, iter);
-	gtt_projects_tree_set_project_urgency (gpt, tree_model, prj, iter);
-	gtt_projects_tree_set_project_importance (gpt, tree_model, prj, iter);
-	gtt_projects_tree_set_project_status (gpt, tree_model, prj, iter);
+    GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE(gpt);
+    if (priv->row_changed_handler)
+    {
+        g_signal_handler_disconnect(tree_model, priv->row_changed_handler);
+        priv->row_changed_handler = 0;
+    }
+    gtk_tree_store_set(
+        tree_model, iter, TITLE_COLUMN, gtt_project_get_title(prj), DESCRIPTION_COLUMN,
+        gtt_project_get_desc(prj), TASK_COLUMN,
+        gtt_task_get_memo(gtt_project_get_current_task(prj)), SIZING_COLUMN,
+        gtt_project_get_sizing(prj), PERCENT_COLUMN, gtt_project_get_percent_complete(prj),
+        GTT_PROJECT_COLUMN, prj, -1
+    );
+    gtt_projects_tree_set_project_times(gpt, tree_model, prj, iter);
+    gtt_projects_tree_set_project_dates(gpt, tree_model, prj, iter);
+    gtt_projects_tree_set_style(gpt, tree_model, prj, iter);
+    gtt_projects_tree_set_project_urgency(gpt, tree_model, prj, iter);
+    gtt_projects_tree_set_project_importance(gpt, tree_model, prj, iter);
+    gtt_projects_tree_set_project_status(gpt, tree_model, prj, iter);
 
-	priv->row_changed_handler = g_signal_connect (GTK_TREE_MODEL(tree_model),
-												  "row-changed",
-												  G_CALLBACK (gtt_projects_tree_model_row_changed_callback),
-												  gpt);
+    priv->row_changed_handler = g_signal_connect(
+        GTK_TREE_MODEL(tree_model), "row-changed",
+        G_CALLBACK(gtt_projects_tree_model_row_changed_callback), gpt
+    );
 }
 
-static void
-gtt_projects_tree_add_project (GttProjectsTree *gpt, GtkTreeStore *tree_model, GttProject *prj, GtkTreeIter *parent, GtkTreePath *path, gboolean recursive)
+static void gtt_projects_tree_add_project(
+    GttProjectsTree *gpt, GtkTreeStore *tree_model, GttProject *prj, GtkTreeIter *parent,
+    GtkTreePath *path, gboolean recursive
+)
 {
-	GtkTreeIter iter;
-	GList *node;
-	GtkTreePath *child_path;
-	GtkTreeRowReference *row_reference;
-	GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE (gpt);
-	
-	gtk_tree_store_append (tree_model, &iter, parent);
-	gtt_projects_tree_set_project_data (gpt, tree_model, prj, &iter);
-	row_reference = gtk_tree_row_reference_new ( GTK_TREE_MODEL(tree_model), path);
-	g_tree_insert (priv->row_references, prj, row_reference);
-	gtt_project_add_notifier (prj, project_changed, gpt);
-	if (recursive)
-	{
-		child_path = gtk_tree_path_copy (path);
-		gtk_tree_path_down (child_path);
-		for (node = gtt_project_get_children (prj); node; node = node->next, gtk_tree_path_next (child_path))
-		{
-			GttProject *sub_prj = node->data;
-			gtt_projects_tree_add_project(gpt, tree_model, sub_prj, &iter, child_path, recursive);
-		}
-			gtk_tree_path_free (child_path);
-	}
+    GtkTreeIter iter;
+    GList *node;
+    GtkTreePath *child_path;
+    GtkTreeRowReference *row_reference;
+    GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE(gpt);
+
+    gtk_tree_store_append(tree_model, &iter, parent);
+    gtt_projects_tree_set_project_data(gpt, tree_model, prj, &iter);
+    row_reference = gtk_tree_row_reference_new(GTK_TREE_MODEL(tree_model), path);
+    g_tree_insert(priv->row_references, prj, row_reference);
+    gtt_project_add_notifier(prj, project_changed, gpt);
+    if (recursive)
+    {
+        child_path = gtk_tree_path_copy(path);
+        gtk_tree_path_down(child_path);
+        for (node = gtt_project_get_children(prj); node;
+             node = node->next, gtk_tree_path_next(child_path))
+        {
+            GttProject *sub_prj = node->data;
+            gtt_projects_tree_add_project(
+                gpt, tree_model, sub_prj, &iter, child_path, recursive
+            );
+        }
+        gtk_tree_path_free(child_path);
+    }
 }
 
-
-static void
-gtt_projects_tree_populate_tree_store (GttProjectsTree *gpt,
-									   GtkTreeStore *tree_model,
-									   GList *prj_list,
-									   gboolean recursive)
+static void gtt_projects_tree_populate_tree_store(
+    GttProjectsTree *gpt, GtkTreeStore *tree_model, GList *prj_list, gboolean recursive
+)
 {
-	GList *node;
-	GtkTreePath *path = gtk_tree_path_new_first ();
-	if (prj_list)
-	{
-		for (node = prj_list; node; node = node->next, gtk_tree_path_next (path))
-		{
-			GttProject *prj = node->data;
-			gtt_projects_tree_add_project(gpt, tree_model, prj, NULL, path, recursive);
-		}
-	}
-	gtk_tree_path_free (path);
-
+    GList *node;
+    GtkTreePath *path = gtk_tree_path_new_first();
+    if (prj_list)
+    {
+        for (node = prj_list; node; node = node->next, gtk_tree_path_next(path))
+        {
+            GttProject *prj = node->data;
+            gtt_projects_tree_add_project(gpt, tree_model, prj, NULL, path, recursive);
+        }
+    }
+    gtk_tree_path_free(path);
 }
 
-void
-gtt_projects_tree_populate (GttProjectsTree *proj_tree,
-							GList *plist,
-							gboolean recursive)
+void gtt_projects_tree_populate(GttProjectsTree *proj_tree, GList *plist, gboolean recursive)
 {
-	GtkTreeStore *tree_model = GTK_TREE_STORE (gtk_tree_view_get_model (GTK_TREE_VIEW (proj_tree)));
+    GtkTreeStore *tree_model
+        = GTK_TREE_STORE(gtk_tree_view_get_model(GTK_TREE_VIEW(proj_tree)));
 
-	gtk_tree_store_clear (tree_model);
-	gtt_projects_tree_populate_tree_store (proj_tree, tree_model, plist, recursive);
-	gtk_tree_view_set_model (GTK_TREE_VIEW (proj_tree), GTK_TREE_MODEL(tree_model));
+    gtk_tree_store_clear(tree_model);
+    gtt_projects_tree_populate_tree_store(proj_tree, tree_model, plist, recursive);
+    gtk_tree_view_set_model(GTK_TREE_VIEW(proj_tree), GTK_TREE_MODEL(tree_model));
 }
 
-
-static void
-gtt_projects_tree_add_column (GttProjectsTree *project_tree, gchar *column_name)
+static void gtt_projects_tree_add_column(GttProjectsTree *project_tree, gchar *column_name)
 {
 
-	GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE (project_tree);
-	int index;
-	GtkTreeViewColumn *column;
+    GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE(project_tree);
+    int index;
+    GtkTreeViewColumn *column;
 
-	for (index = 0; index < N_VIEWABLE_COLS; index ++)
-	{
-		if (!strcmp (column_name, priv->column_definitions[index].name))
-		{
-			ColumnDefinition *c = &(priv->column_definitions[index]);
-			column = gtk_tree_view_column_new_with_attributes (c->label,
-															   c->renderer,
-															   c->value_property_name, c->model_column,
-															   "cell-background", BACKGROUND_COLOR_COLUMN,
-															   NULL);
-			if (GTK_IS_CELL_RENDERER_TEXT (c->renderer))
-			{
-				gtk_tree_view_column_add_attribute (column, c->renderer, "weight", WEIGHT_COLUMN);
-			}
-			gtk_tree_view_column_set_resizable (column, TRUE);
-			gtk_tree_view_column_set_sizing (column, GTK_TREE_VIEW_COLUMN_FIXED);
-			gtk_tree_view_column_set_fixed_width (column, c->default_width);
-			gtk_tree_view_column_set_clickable (column, TRUE);
-			gtk_tree_view_append_column (GTK_TREE_VIEW (project_tree), column);
-			if (!strcmp(c->name, "title"))
-			{
-				gtk_tree_view_set_expander_column (GTK_TREE_VIEW (project_tree), column);
-			}
-			g_tree_insert (priv->column_references, column_name, column);
-			return;
-		}
-	}
-	g_warning ("Illegal column name '%s' requested", column_name);
+    for (index = 0; index < N_VIEWABLE_COLS; index++)
+    {
+        if (!strcmp(column_name, priv->column_definitions[index].name))
+        {
+            ColumnDefinition *c = &(priv->column_definitions[index]);
+            column = gtk_tree_view_column_new_with_attributes(
+                c->label, c->renderer, c->value_property_name, c->model_column,
+                "cell-background", BACKGROUND_COLOR_COLUMN, NULL
+            );
+            if (GTK_IS_CELL_RENDERER_TEXT(c->renderer))
+            {
+                gtk_tree_view_column_add_attribute(
+                    column, c->renderer, "weight", WEIGHT_COLUMN
+                );
+            }
+            gtk_tree_view_column_set_resizable(column, TRUE);
+            gtk_tree_view_column_set_sizing(column, GTK_TREE_VIEW_COLUMN_FIXED);
+            gtk_tree_view_column_set_fixed_width(column, c->default_width);
+            gtk_tree_view_column_set_clickable(column, TRUE);
+            gtk_tree_view_append_column(GTK_TREE_VIEW(project_tree), column);
+            if (!strcmp(c->name, "title"))
+            {
+                gtk_tree_view_set_expander_column(GTK_TREE_VIEW(project_tree), column);
+            }
+            g_tree_insert(priv->column_references, column_name, column);
+            return;
+        }
+    }
+    g_warning("Illegal column name '%s' requested", column_name);
 }
 
-void
-gtt_projects_tree_set_visible_columns (GttProjectsTree *project_tree,
-									   GList *columns)
+void gtt_projects_tree_set_visible_columns(GttProjectsTree *project_tree, GList *columns)
 {
-	GtkTreeViewColumn *column = NULL;
-	GtkTreeView * tree_view = GTK_TREE_VIEW (project_tree);
-	GList *p;
-	GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE (project_tree);
+    GtkTreeViewColumn *column = NULL;
+    GtkTreeView *tree_view = GTK_TREE_VIEW(project_tree);
+    GList *p;
+    GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE(project_tree);
 
-	if (priv->column_references)
-	{
-		g_tree_destroy (priv->column_references);
-	}
-	priv->column_references = g_tree_new ((GCompareFunc) strcmp);
+    if (priv->column_references)
+    {
+        g_tree_destroy(priv->column_references);
+    }
+    priv->column_references = g_tree_new((GCompareFunc) strcmp);
 
+    /* remove all columns */
+    while ((column = gtk_tree_view_get_column(tree_view, 0)))
+    {
+        gtk_tree_view_remove_column(tree_view, column);
+    }
 
-	/* remove all columns */
-	while ((column = gtk_tree_view_get_column (tree_view, 0)))
-	{
-		gtk_tree_view_remove_column (tree_view, column);
-	}
+    /* The title column is mandatory. If it's not on the list,
+       we add it as the first column. */
 
+    if (!g_list_find_custom(columns, "title", (GCompareFunc) strcmp))
+    {
+        gtt_projects_tree_add_column(project_tree, "title");
+    }
 
-	/* The title column is mandatory. If it's not on the list,
-	   we add it as the first column. */
+    for (p = columns; p; p = p->next)
+    {
+        gtt_projects_tree_add_column(project_tree, p->data);
+    }
 
-	if (!g_list_find_custom (columns, "title", (GCompareFunc) strcmp))
-	{
-		gtt_projects_tree_add_column (project_tree, "title");
-	}
-
-
-	for (p = columns; p; p = p->next)
-	{
-		gtt_projects_tree_add_column (project_tree, p->data);
-	}
-	
-	g_signal_emit (project_tree, projects_tree_signals[COLUMNS_SETUP_DONE], 0);
+    g_signal_emit(project_tree, projects_tree_signals[COLUMNS_SETUP_DONE], 0);
 }
 
-static void
-gtt_projects_tree_update_row_data (GttProjectsTree *gpt, GttProject *prj, GtkTreeRowReference *row_ref)
+static void gtt_projects_tree_update_row_data(
+    GttProjectsTree *gpt, GttProject *prj, GtkTreeRowReference *row_ref
+)
 {
-	g_return_if_fail (gtk_tree_row_reference_valid (row_ref));
-	GtkTreePath *path = gtk_tree_row_reference_get_path (row_ref);
-	if (path)
-	{
-		GtkTreeStore *tree_model = GTK_TREE_STORE (gtk_tree_view_get_model (GTK_TREE_VIEW (gpt)));
-		
-		GtkTreeIter iter;
-		if (gtk_tree_model_get_iter (GTK_TREE_MODEL (tree_model), &iter, path))
-		{
-			gtt_projects_tree_set_project_data (gpt, tree_model, prj, &iter);
-		}
-		else
-		{
-			gchar *path_str = gtk_tree_path_to_string (path);
-			g_warning ("Invalid path %s", path_str);
-			g_free (path_str);
-		}
-		gtk_tree_path_free (path);
-	}
+    g_return_if_fail(gtk_tree_row_reference_valid(row_ref));
+    GtkTreePath *path = gtk_tree_row_reference_get_path(row_ref);
+    if (path)
+    {
+        GtkTreeStore *tree_model = GTK_TREE_STORE(gtk_tree_view_get_model(GTK_TREE_VIEW(gpt)));
+
+        GtkTreeIter iter;
+        if (gtk_tree_model_get_iter(GTK_TREE_MODEL(tree_model), &iter, path))
+        {
+            gtt_projects_tree_set_project_data(gpt, tree_model, prj, &iter);
+        }
+        else
+        {
+            gchar *path_str = gtk_tree_path_to_string(path);
+            g_warning("Invalid path %s", path_str);
+            g_free(path_str);
+        }
+        gtk_tree_path_free(path);
+    }
 }
 
-
-void
-gtt_projects_tree_update_project_data (GttProjectsTree *gpt, GttProject *prj)
+void gtt_projects_tree_update_project_data(GttProjectsTree *gpt, GttProject *prj)
 {
-	GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE (gpt);
-	GtkTreeRowReference *row_ref = (GtkTreeRowReference *) g_tree_lookup (priv->row_references, prj);
-	
-	if (row_ref)
-	{
-		gtt_projects_tree_update_row_data (gpt, prj, row_ref);
-	}
-	else
-	{
-		g_warning ("Updating non-existant project");
-	}
+    GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE(gpt);
+    GtkTreeRowReference *row_ref
+        = (GtkTreeRowReference *) g_tree_lookup(priv->row_references, prj);
+
+    if (row_ref)
+    {
+        gtt_projects_tree_update_row_data(gpt, prj, row_ref);
+    }
+    else
+    {
+        g_warning("Updating non-existant project");
+    }
 }
 
-
-static gboolean
-update_row_data (gpointer key, gpointer value, gpointer data)
+static gboolean update_row_data(gpointer key, gpointer value, gpointer data)
 {
-	GttProject *prj = (GttProject *) key;
-	GtkTreeRowReference *row_ref = (GtkTreeRowReference *) value;
-	GttProjectsTree *gpt = GTT_PROJECTS_TREE (data);
+    GttProject *prj = (GttProject *) key;
+    GtkTreeRowReference *row_ref = (GtkTreeRowReference *) value;
+    GttProjectsTree *gpt = GTT_PROJECTS_TREE(data);
 
-	gtt_projects_tree_update_row_data (gpt, prj, row_ref);
-	return FALSE;
+    gtt_projects_tree_update_row_data(gpt, prj, row_ref);
+    return FALSE;
 }
 
-void
-gtt_projects_tree_update_all_rows (GttProjectsTree *gpt)
+void gtt_projects_tree_update_all_rows(GttProjectsTree *gpt)
 {
-	GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE (gpt);
+    GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE(gpt);
 
-	g_tree_foreach (priv->row_references, update_row_data, gpt);
-
+    g_tree_foreach(priv->row_references, update_row_data, gpt);
 }
 
-void
-gtt_projects_tree_set_active_bgcolor (GttProjectsTree *gpt, gchar *color)
+void gtt_projects_tree_set_active_bgcolor(GttProjectsTree *gpt, gchar *color)
 {
-	GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE (gpt);
+    GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE(gpt);
 
-	if (priv->active_bgcolor)
-	{
-		g_free (priv->active_bgcolor);
-	}
+    if (priv->active_bgcolor)
+    {
+        g_free(priv->active_bgcolor);
+    }
 
-	if (color)
-	{
-		priv->active_bgcolor = g_strdup (color);
-	}
-	else
-	{
-		priv->active_bgcolor = NULL;
-	}
+    if (color)
+    {
+        priv->active_bgcolor = g_strdup(color);
+    }
+    else
+    {
+        priv->active_bgcolor = NULL;
+    }
 
-	gtt_projects_tree_update_all_rows (gpt);
-
+    gtt_projects_tree_update_all_rows(gpt);
 }
 
-gchar *
-gtt_projects_tree_get_active_bgcolor (GttProjectsTree *gpt)
+gchar *gtt_projects_tree_get_active_bgcolor(GttProjectsTree *gpt)
 {
-	GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE (gpt);
-	return priv->active_bgcolor;
+    GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE(gpt);
+    return priv->active_bgcolor;
 }
 
-void
-gtt_projects_tree_set_show_seconds (GttProjectsTree *gpt, gboolean show_seconds)
+void gtt_projects_tree_set_show_seconds(GttProjectsTree *gpt, gboolean show_seconds)
 {
-	GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE (gpt);
-	priv->show_seconds = show_seconds;
-	gtt_projects_tree_update_all_rows (gpt);
+    GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE(gpt);
+    priv->show_seconds = show_seconds;
+    gtt_projects_tree_update_all_rows(gpt);
 }
 
-gboolean
-gtt_projects_tree_get_show_seconds (GttProjectsTree *gpt)
+gboolean gtt_projects_tree_get_show_seconds(GttProjectsTree *gpt)
 {
-	GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE (gpt);
-	return priv->show_seconds;
+    GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE(gpt);
+    return priv->show_seconds;
 }
 
-void
-gtt_projects_tree_set_highlight_active (GttProjectsTree *gpt, gboolean highlight_active)
+void gtt_projects_tree_set_highlight_active(GttProjectsTree *gpt, gboolean highlight_active)
 {
-		GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE (gpt);
-		priv->highlight_active = highlight_active;
-		gtt_projects_tree_update_all_rows (gpt);
+    GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE(gpt);
+    priv->highlight_active = highlight_active;
+    gtt_projects_tree_update_all_rows(gpt);
 }
 
-gboolean
-gtt_projects_tree_get_highlight_active (GttProjectsTree *gpt)
+gboolean gtt_projects_tree_get_highlight_active(GttProjectsTree *gpt)
 {
-	GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE (gpt);
-	return priv->highlight_active;
+    GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE(gpt);
+    return priv->highlight_active;
 }
 
-
-GttProject *
-gtt_projects_tree_get_selected_project (GttProjectsTree *gpt)
+GttProject *gtt_projects_tree_get_selected_project(GttProjectsTree *gpt)
 {
-	GtkTreeSelection *selection = gtk_tree_view_get_selection (GTK_TREE_VIEW (gpt));
-		GtkTreeModel *model = gtk_tree_view_get_model (GTK_TREE_VIEW (gpt));
-	GList *list = gtk_tree_selection_get_selected_rows(selection, NULL);
-	GttProject *prj = NULL;
-	if (list)
-	{
-		GtkTreePath *path = (GtkTreePath *)list->data;
-		GtkTreeIter iter;
-		if (gtk_tree_model_get_iter (model, &iter, path))
-		{
-			gtk_tree_model_get (model, &iter, GTT_PROJECT_COLUMN, &prj, -1);
-		}
-		g_list_foreach (list, (GFunc) gtk_tree_path_free, NULL);
-		g_list_free (list);
-	}
-	return prj;
+    GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(gpt));
+    GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(gpt));
+    GList *list = gtk_tree_selection_get_selected_rows(selection, NULL);
+    GttProject *prj = NULL;
+    if (list)
+    {
+        GtkTreePath *path = (GtkTreePath *) list->data;
+        GtkTreeIter iter;
+        if (gtk_tree_model_get_iter(model, &iter, path))
+        {
+            gtk_tree_model_get(model, &iter, GTT_PROJECT_COLUMN, &prj, -1);
+        }
+        g_list_foreach(list, (GFunc) gtk_tree_path_free, NULL);
+        g_list_free(list);
+    }
+    return prj;
 }
 
-static void
-gtt_projects_tree_remove_project_recursively (GttProjectsTree *gpt,
-											  GttProject *prj,
-											  GtkTreeModel *model,
-											  GTree *row_references)
+static void gtt_projects_tree_remove_project_recursively(
+    GttProjectsTree *gpt, GttProject *prj, GtkTreeModel *model, GTree *row_references
+)
 {
-	GtkTreeRowReference *row = g_tree_lookup (row_references, prj);
+    GtkTreeRowReference *row = g_tree_lookup(row_references, prj);
 
-	if (row)
-	{
-		GtkTreePath *path = gtk_tree_row_reference_get_path (row);
-		GtkTreeIter iter;
-		if (gtk_tree_model_get_iter (model, &iter, path))
-		{
-			gtk_tree_store_remove (GTK_TREE_STORE (model), &iter);
-		}
-		g_tree_remove (row_references, prj);
-		gtk_tree_path_free (path);
+    if (row)
+    {
+        GtkTreePath *path = gtk_tree_row_reference_get_path(row);
+        GtkTreeIter iter;
+        if (gtk_tree_model_get_iter(model, &iter, path))
+        {
+            gtk_tree_store_remove(GTK_TREE_STORE(model), &iter);
+        }
+        g_tree_remove(row_references, prj);
+        gtk_tree_path_free(path);
 
-		GList *node;
-		for (node = gtt_project_get_children (prj); node; node = node->next)
-		{
-			GttProject *sub_prj = node->data;
-			gtt_projects_tree_remove_project_recursively(gpt, sub_prj, model, row_references);
-		}
-	}
+        GList *node;
+        for (node = gtt_project_get_children(prj); node; node = node->next)
+        {
+            GttProject *sub_prj = node->data;
+            gtt_projects_tree_remove_project_recursively(gpt, sub_prj, model, row_references);
+        }
+    }
 }
 
-void
-gtt_projects_tree_remove_project (GttProjectsTree *gpt, GttProject *prj)
+void gtt_projects_tree_remove_project(GttProjectsTree *gpt, GttProject *prj)
 {
-	GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE (gpt);
-	GtkTreeModel *model = gtk_tree_view_get_model (GTK_TREE_VIEW (gpt));
+    GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE(gpt);
+    GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(gpt));
 
-	gtt_projects_tree_remove_project_recursively (gpt, prj, model, priv->row_references);
+    gtt_projects_tree_remove_project_recursively(gpt, prj, model, priv->row_references);
 }
 
-
-static void
-gtt_projects_tree_append_projects_recursively (GttProjectsTree * gpt,
-											   GtkTreeModel *model, GTree *row_references,
-											   GttProject *prj, GttProject *parent)
+static void gtt_projects_tree_append_projects_recursively(
+    GttProjectsTree *gpt, GtkTreeModel *model, GTree *row_references, GttProject *prj,
+    GttProject *parent
+)
 {
-	GtkTreeIter parent_iter;
-	GtkTreeIter prj_iter;
-	GtkTreePath *path = NULL;
-	if (parent)
-	{
-		GtkTreeRowReference *row = g_tree_lookup (row_references, parent);
-		path = gtk_tree_row_reference_get_path (row);
-		gtk_tree_model_get_iter (model, &parent_iter, path);
-		gtk_tree_store_append (GTK_TREE_STORE (model), &prj_iter, &parent_iter);
-		gtk_tree_path_free (path);
-	}
-	else
-	{
-		gtk_tree_store_append (GTK_TREE_STORE (model), &prj_iter, NULL);
-	}
+    GtkTreeIter parent_iter;
+    GtkTreeIter prj_iter;
+    GtkTreePath *path = NULL;
+    if (parent)
+    {
+        GtkTreeRowReference *row = g_tree_lookup(row_references, parent);
+        path = gtk_tree_row_reference_get_path(row);
+        gtk_tree_model_get_iter(model, &parent_iter, path);
+        gtk_tree_store_append(GTK_TREE_STORE(model), &prj_iter, &parent_iter);
+        gtk_tree_path_free(path);
+    }
+    else
+    {
+        gtk_tree_store_append(GTK_TREE_STORE(model), &prj_iter, NULL);
+    }
 
-	gtt_projects_tree_set_project_data (gpt, GTK_TREE_STORE (model),
-										prj, &prj_iter);
-	path = gtk_tree_model_get_path (model, &prj_iter);
+    gtt_projects_tree_set_project_data(gpt, GTK_TREE_STORE(model), prj, &prj_iter);
+    path = gtk_tree_model_get_path(model, &prj_iter);
 
-	GtkTreeRowReference *row_reference = gtk_tree_row_reference_new ( model,
-																	  path);
-	g_tree_insert (row_references, prj, row_reference);
-	gtk_tree_path_free (path);
-	GList *children;
-	for (children = gtt_project_get_children (prj); children; children = children->next)
-	{
-		gtt_projects_tree_append_projects_recursively (gpt, model,
-													  row_references,
-													  children->data, prj);
-	}
+    GtkTreeRowReference *row_reference = gtk_tree_row_reference_new(model, path);
+    g_tree_insert(row_references, prj, row_reference);
+    gtk_tree_path_free(path);
+    GList *children;
+    for (children = gtt_project_get_children(prj); children; children = children->next)
+    {
+        gtt_projects_tree_append_projects_recursively(
+            gpt, model, row_references, children->data, prj
+        );
+    }
 }
 
 /*
@@ -954,16 +987,15 @@ gtt_projects_tree_append_projects_recursively (GttProjectsTree * gpt,
  *            a toplevel project.
  */
 
-void
-gtt_projects_tree_append_project (GttProjectsTree *gpt, GttProject *prj, GttProject *parent)
+void gtt_projects_tree_append_project(GttProjectsTree *gpt, GttProject *prj, GttProject *parent)
 {
-	GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE (gpt);
-	GtkTreeModel *model = gtk_tree_view_get_model (GTK_TREE_VIEW (gpt));
+    GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE(gpt);
+    GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(gpt));
 
-	gtt_projects_tree_append_projects_recursively (gpt, model, priv->row_references, prj, parent);
+    gtt_projects_tree_append_projects_recursively(
+        gpt, model, priv->row_references, prj, parent
+    );
 }
-
-
 
 /*
  * Inserts a new project to the Projects Tree. The project is inserted
@@ -976,261 +1008,244 @@ gtt_projects_tree_append_project (GttProjectsTree *gpt, GttProject *prj, GttProj
  * - prj - The project to be append
  * - sibling - The sibling before wich the project will be inserted.
  */
-void
-gtt_projects_tree_insert_project_before (GttProjectsTree *gpt, GttProject *prj, GttProject *sibling)
+void gtt_projects_tree_insert_project_before(
+    GttProjectsTree *gpt, GttProject *prj, GttProject *sibling
+)
 {
-	GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE (gpt);
-	GtkTreeModel *model = gtk_tree_view_get_model (GTK_TREE_VIEW (gpt));
+    GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE(gpt);
+    GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(gpt));
 
-	GtkTreeIter sib_iter;
-	GtkTreeIter prj_iter;
-	GtkTreePath *path = NULL;
-	if (sibling)
-	{
-		GtkTreeRowReference *row = g_tree_lookup (priv->row_references, sibling);
-		path = gtk_tree_row_reference_get_path (row);
-		gtk_tree_model_get_iter (model, &sib_iter, path);
-		gtk_tree_store_insert_before (GTK_TREE_STORE (model), &prj_iter, NULL, &sib_iter);
-		gtk_tree_path_free (path);
-	}
-	else
-	{
-		gtk_tree_store_append (GTK_TREE_STORE (model), &prj_iter, NULL);
-	}
+    GtkTreeIter sib_iter;
+    GtkTreeIter prj_iter;
+    GtkTreePath *path = NULL;
+    if (sibling)
+    {
+        GtkTreeRowReference *row = g_tree_lookup(priv->row_references, sibling);
+        path = gtk_tree_row_reference_get_path(row);
+        gtk_tree_model_get_iter(model, &sib_iter, path);
+        gtk_tree_store_insert_before(GTK_TREE_STORE(model), &prj_iter, NULL, &sib_iter);
+        gtk_tree_path_free(path);
+    }
+    else
+    {
+        gtk_tree_store_append(GTK_TREE_STORE(model), &prj_iter, NULL);
+    }
 
-	gtt_projects_tree_set_project_data (gpt, GTK_TREE_STORE (model),
-										prj, &prj_iter);
-	path = gtk_tree_model_get_path (model, &prj_iter);
+    gtt_projects_tree_set_project_data(gpt, GTK_TREE_STORE(model), prj, &prj_iter);
+    path = gtk_tree_model_get_path(model, &prj_iter);
 
-	GtkTreeRowReference *row_reference = gtk_tree_row_reference_new ( model,
-																	  path);
-	g_tree_insert (priv->row_references, prj, row_reference);
-	gtk_tree_path_free (path);
+    GtkTreeRowReference *row_reference = gtk_tree_row_reference_new(model, path);
+    g_tree_insert(priv->row_references, prj, row_reference);
+    gtk_tree_path_free(path);
 
-	GList *children;
-	for (children = gtt_project_get_children (prj); children; children = children->next)
-	{
-		gtt_projects_tree_append_projects_recursively (gpt, model,
-													   priv->row_references,
-													   children->data, prj);
-	}
-
+    GList *children;
+    for (children = gtt_project_get_children(prj); children; children = children->next)
+    {
+        gtt_projects_tree_append_projects_recursively(
+            gpt, model, priv->row_references, children->data, prj
+        );
+    }
 }
 
-static void
-gtt_projects_tree_row_expand_collapse_callback (GtkTreeView *view,
-												GtkTreeIter *iter,
-												GtkTreePath *path,
-												gpointer data)
+static void gtt_projects_tree_row_expand_collapse_callback(
+    GtkTreeView *view, GtkTreeIter *iter, GtkTreePath *path, gpointer data
+)
 {
-	GttProjectsTree *gpt = GTT_PROJECTS_TREE (view);
-	GttProject *prj = NULL;
-	GtkTreeModel *tree_model = gtk_tree_view_get_model (view);
+    GttProjectsTree *gpt = GTT_PROJECTS_TREE(view);
+    GttProject *prj = NULL;
+    GtkTreeModel *tree_model = gtk_tree_view_get_model(view);
 
-	gtk_tree_model_get (tree_model, iter, GTT_PROJECT_COLUMN, &prj, -1);
+    gtk_tree_model_get(tree_model, iter, GTT_PROJECT_COLUMN, &prj, -1);
 
-	gtt_projects_tree_set_project_data (gpt, GTK_TREE_STORE (tree_model),
-										prj, iter);
-
+    gtt_projects_tree_set_project_data(gpt, GTK_TREE_STORE(tree_model), prj, iter);
 }
 
-
-static void
-gtt_projects_tree_model_row_changed_callback (GtkTreeModel *model,
-											  GtkTreePath *path,
-											  GtkTreeIter *iter,
-											  gpointer data)
+static void gtt_projects_tree_model_row_changed_callback(
+    GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer data
+)
 {
-	GttProjectsTree *gpt = GTT_PROJECTS_TREE (data);
-	GttProject *prj = NULL;
-	GttProject *parent = NULL;
+    GttProjectsTree *gpt = GTT_PROJECTS_TREE(data);
+    GttProject *prj = NULL;
+    GttProject *parent = NULL;
 
-	gtk_tree_model_get (model, iter, GTT_PROJECT_COLUMN, &prj, -1);
+    gtk_tree_model_get(model, iter, GTT_PROJECT_COLUMN, &prj, -1);
 
-	if (prj)
-	{
-		int path_depth = gtk_tree_path_get_depth (path);
-		gint *indices = gtk_tree_path_get_indices (path);
-		int position = 0;
-		if (indices)
-		{
-			position = indices[path_depth - 1];
-		}
-		else
-		{
-			g_message ("indices is NULL");
-		}
-		GtkTreeIter parent_iter;
-		if (gtk_tree_model_iter_parent (model, &parent_iter, iter))
-		{
-			gtk_tree_model_get (model, &parent_iter, GTT_PROJECT_COLUMN, &parent, -1);
-		}
+    if (prj)
+    {
+        int path_depth = gtk_tree_path_get_depth(path);
+        gint *indices = gtk_tree_path_get_indices(path);
+        int position = 0;
+        if (indices)
+        {
+            position = indices[path_depth - 1];
+        }
+        else
+        {
+            g_message("indices is NULL");
+        }
+        GtkTreeIter parent_iter;
+        if (gtk_tree_model_iter_parent(model, &parent_iter, iter))
+        {
+            gtk_tree_model_get(model, &parent_iter, GTT_PROJECT_COLUMN, &parent, -1);
+        }
 
-		GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE (gpt);
-		GtkTreeRowReference *row_ref = (GtkTreeRowReference *) g_tree_lookup (priv->row_references, prj);
-		if (row_ref)
-		{
-			GtkTreePath *ref_path = gtk_tree_row_reference_get_path (row_ref);
+        GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE(gpt);
+        GtkTreeRowReference *row_ref
+            = (GtkTreeRowReference *) g_tree_lookup(priv->row_references, prj);
+        if (row_ref)
+        {
+            GtkTreePath *ref_path = gtk_tree_row_reference_get_path(row_ref);
 
-			/* If the row has been moved around we reparent it and
-			   update its row reference */
-			if (gtk_tree_path_compare (path, ref_path))
-			{
-				gtt_project_reparent (prj, parent, position);
-				row_ref = gtk_tree_row_reference_new (model, path);
-				g_tree_insert (priv->row_references, prj, row_ref);
-			}
-		}
-	}
-}
-
-
-
-static gboolean
-count_rows (GtkTreeModel *model, GtkTreeIter *iter, GtkTreePath *path, gpointer data)
-{
-	int *rows = (int *)data;
-	++*rows;
-	return FALSE;
+            /* If the row has been moved around we reparent it and
+               update its row reference */
+            if (gtk_tree_path_compare(path, ref_path))
+            {
+                gtt_project_reparent(prj, parent, position);
+                row_ref = gtk_tree_row_reference_new(model, path);
+                g_tree_insert(priv->row_references, prj, row_ref);
+            }
+        }
+    }
 }
 
 static gboolean
-get_expander_state (GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer data)
+count_rows(GtkTreeModel *model, GtkTreeIter *iter, GtkTreePath *path, gpointer data)
 {
-	ExpanderStateHelper *esh = (ExpanderStateHelper *) data;
-	if (gtk_tree_view_row_expanded (esh->view, path))
-	{
-		esh->states[*esh->row] = 'y';
-	}
-	else
-	{
-		esh->states[*esh->row] = 'n';
-	}
-	++(*esh->row);
-	return FALSE;
-}
-
-
-char *
-gtt_projects_tree_get_expander_state (GttProjectsTree *gpt)
-{
-	GtkTreeModel *model = gtk_tree_view_get_model (GTK_TREE_VIEW (gpt));
-	int rows = 0;
-
-	gtk_tree_model_foreach (model, (GtkTreeModelForeachFunc) count_rows, &rows);
-
-	ExpanderStateHelper esh;
-	esh.view = GTK_TREE_VIEW (gpt);
-	esh.states = g_new0(char, rows + 1);
-	rows = 0;
-	esh.row = &rows;
-
-	gtk_tree_model_foreach (model, get_expander_state, &esh);
-
-	GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE (gpt);
-
-	if (priv->expander_states)
-	{
-		g_free (priv->expander_states);
-	}
-
-	priv->expander_states = esh.states;
-
-	return priv->expander_states;
+    int *rows = (int *) data;
+    ++*rows;
+    return FALSE;
 }
 
 static gboolean
-set_expander_state (GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer data)
+get_expander_state(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer data)
 {
-	ExpanderStateHelper *esh = (ExpanderStateHelper *) data;
-	if (esh->states[*esh->row] == 'y')
-	{
-		gtk_tree_view_expand_row (esh->view, path, FALSE);
-	}
-	else
-	{
-		gtk_tree_view_collapse_row (esh->view, path);
-	}
-	++(*esh->row);
-	return FALSE;
+    ExpanderStateHelper *esh = (ExpanderStateHelper *) data;
+    if (gtk_tree_view_row_expanded(esh->view, path))
+    {
+        esh->states[*esh->row] = 'y';
+    }
+    else
+    {
+        esh->states[*esh->row] = 'n';
+    }
+    ++(*esh->row);
+    return FALSE;
 }
 
-void
-gtt_projects_tree_set_expander_state (GttProjectsTree *gpt, gchar *states)
+char *gtt_projects_tree_get_expander_state(GttProjectsTree *gpt)
 {
-	g_return_if_fail(states != NULL);
-	GtkTreeModel *model = gtk_tree_view_get_model (GTK_TREE_VIEW (gpt));
-	ExpanderStateHelper esh;
-	int row = 0;
+    GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(gpt));
+    int rows = 0;
 
-	esh.states = states;
-	esh.row = &row;
-	esh.view = GTK_TREE_VIEW (gpt);
+    gtk_tree_model_foreach(model, (GtkTreeModelForeachFunc) count_rows, &rows);
 
-	gtk_tree_model_foreach (model, set_expander_state, &esh);
+    ExpanderStateHelper esh;
+    esh.view = GTK_TREE_VIEW(gpt);
+    esh.states = g_new0(char, rows + 1);
+    rows = 0;
+    esh.row = &rows;
+
+    gtk_tree_model_foreach(model, get_expander_state, &esh);
+
+    GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE(gpt);
+
+    if (priv->expander_states)
+    {
+        g_free(priv->expander_states);
+    }
+
+    priv->expander_states = esh.states;
+
+    return priv->expander_states;
 }
 
-
-gint
-gtt_projects_tree_get_col_width (GttProjectsTree *gpt, int col)
+static gboolean
+set_expander_state(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer data)
 {
-	g_return_val_if_fail (col >= 0, 0);
-
-	GtkTreeViewColumn *column = gtk_tree_view_get_column (GTK_TREE_VIEW (gpt), col);
-	if (column == NULL)
-	{
-		return -1;
-	}
-	return gtk_tree_view_column_get_width (column);
+    ExpanderStateHelper *esh = (ExpanderStateHelper *) data;
+    if (esh->states[*esh->row] == 'y')
+    {
+        gtk_tree_view_expand_row(esh->view, path, FALSE);
+    }
+    else
+    {
+        gtk_tree_view_collapse_row(esh->view, path);
+    }
+    ++(*esh->row);
+    return FALSE;
 }
 
-
-
-void
-gtt_projects_tree_set_col_width (GttProjectsTree *gpt, int col, int width)
+void gtt_projects_tree_set_expander_state(GttProjectsTree *gpt, gchar *states)
 {
-	g_return_if_fail (col >= 0);
+    g_return_if_fail(states != NULL);
+    GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(gpt));
+    ExpanderStateHelper esh;
+    int row = 0;
 
-	GtkTreeViewColumn *column = gtk_tree_view_get_column (GTK_TREE_VIEW (gpt), col);
-	g_return_if_fail (column != NULL);
-	gtk_tree_view_column_set_fixed_width (column, width);
+    esh.states = states;
+    esh.row = &row;
+    esh.view = GTK_TREE_VIEW(gpt);
+
+    gtk_tree_model_foreach(model, set_expander_state, &esh);
+}
+
+gint gtt_projects_tree_get_col_width(GttProjectsTree *gpt, int col)
+{
+    g_return_val_if_fail(col >= 0, 0);
+
+    GtkTreeViewColumn *column = gtk_tree_view_get_column(GTK_TREE_VIEW(gpt), col);
+    if (column == NULL)
+    {
+        return -1;
+    }
+    return gtk_tree_view_column_get_width(column);
+}
+
+void gtt_projects_tree_set_col_width(GttProjectsTree *gpt, int col, int width)
+{
+    g_return_if_fail(col >= 0);
+
+    GtkTreeViewColumn *column = gtk_tree_view_get_column(GTK_TREE_VIEW(gpt), col);
+    g_return_if_fail(column != NULL);
+    gtk_tree_view_column_set_fixed_width(column, width);
 }
 
 GtkTreeViewColumn *
-gtt_projects_tree_get_column_by_name (GttProjectsTree *gpt, gchar *column_name)
+gtt_projects_tree_get_column_by_name(GttProjectsTree *gpt, gchar *column_name)
 {
-	g_return_val_if_fail (gpt, NULL);
-	GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE (gpt);
+    g_return_val_if_fail(gpt, NULL);
+    GttProjectsTreePrivate *priv = GTT_PROJECTS_TREE_GET_PRIVATE(gpt);
 
-	g_return_val_if_fail (priv->column_references, NULL);
-	return g_tree_lookup (priv->column_references, column_name);
+    g_return_val_if_fail(priv->column_references, NULL);
+    return g_tree_lookup(priv->column_references, column_name);
 }
 
-void
-gtt_projects_tree_set_sorted_column (GttProjectsTree *gpt, GtkTreeViewColumn *column)
+void gtt_projects_tree_set_sorted_column(GttProjectsTree *gpt, GtkTreeViewColumn *column)
 {
-	GList *columns = gtk_tree_view_get_columns (GTK_TREE_VIEW (gpt));
+    GList *columns = gtk_tree_view_get_columns(GTK_TREE_VIEW(gpt));
 
-	GList *p = columns;
+    GList *p = columns;
 
-	for (; p != NULL; p = p->next)
-	{
-		if (p->data == column)
-		{
-			gtk_tree_view_column_set_sort_indicator (GTK_TREE_VIEW_COLUMN(p->data), TRUE);
-			gtk_tree_view_column_set_sort_order (GTK_TREE_VIEW_COLUMN(p->data), GTK_SORT_ASCENDING);
-		}
-		else
-		{
-			gtk_tree_view_column_set_sort_indicator (GTK_TREE_VIEW_COLUMN(p->data), FALSE);
-		}
-	}
+    for (; p != NULL; p = p->next)
+    {
+        if (p->data == column)
+        {
+            gtk_tree_view_column_set_sort_indicator(GTK_TREE_VIEW_COLUMN(p->data), TRUE);
+            gtk_tree_view_column_set_sort_order(
+                GTK_TREE_VIEW_COLUMN(p->data), GTK_SORT_ASCENDING
+            );
+        }
+        else
+        {
+            gtk_tree_view_column_set_sort_indicator(GTK_TREE_VIEW_COLUMN(p->data), FALSE);
+        }
+    }
 
-	g_list_free (columns);
+    g_list_free(columns);
 }
 
-static void project_changed (GttProject *prj, gpointer user_data)
+static void project_changed(GttProject *prj, gpointer user_data)
 {
-	GttProjectsTree *gpt = GTT_PROJECTS_TREE (user_data);
-	gtt_projects_tree_update_project_data (gpt, prj);
+    GttProjectsTree *gpt = GTT_PROJECTS_TREE(user_data);
+    gtt_projects_tree_update_project_data(gpt, prj);
 }

--- a/src/projects-tree.h
+++ b/src/projects-tree.h
@@ -33,67 +33,69 @@
 
 #include "proj.h"
 
-
-#define GTT_TYPE_PROJECTS_TREE		(gtt_projects_tree_get_type ())
-#define GTT_PROJECTS_TREE(obj)		(G_TYPE_CHECK_INSTANCE_CAST ((obj), GTT_TYPE_PROJECTS_TREE, GttProjectsTree))
-#define GTT_PROJECTS_TREE_CLASS(klass)	(G_TYPE_CHECK_CLASS_CAST ((klass), GTT_TYPE_PROJECTS_TREE, GttProjectsTreeClass))
-#define GTT_IS_PROJECTS_TREE(obj)		(G_TYPE_CHECK_INSTANCE_TYPE ((obj), GTT_TYPE_PROJECTS_TREE))
-#define GTT_IS_PROJECTS_TREE_CLASS(klass)	(G_TYPE_CHECK_CLASS_TYPE ((klass), GTT_TYPE_PROJECTS_TREE))
-#define GTT_PROJECTS_TREE_GET_CLASS(obj)    (G_TYPE_INSTANCE_GET_CLASS ((obj), GTT_TYPE_PROJECTS_TREE, GttProjectsTreeClass))
-
+#define GTT_TYPE_PROJECTS_TREE (gtt_projects_tree_get_type())
+#define GTT_PROJECTS_TREE(obj) \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), GTT_TYPE_PROJECTS_TREE, GttProjectsTree))
+#define GTT_PROJECTS_TREE_CLASS(klass) \
+    (G_TYPE_CHECK_CLASS_CAST((klass), GTT_TYPE_PROJECTS_TREE, GttProjectsTreeClass))
+#define GTT_IS_PROJECTS_TREE(obj) (G_TYPE_CHECK_INSTANCE_TYPE((obj), GTT_TYPE_PROJECTS_TREE))
+#define GTT_IS_PROJECTS_TREE_CLASS(klass) \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), GTT_TYPE_PROJECTS_TREE))
+#define GTT_PROJECTS_TREE_GET_CLASS(obj) \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), GTT_TYPE_PROJECTS_TREE, GttProjectsTreeClass))
 
 typedef struct _GttProjectsTree GttProjectsTree;
 typedef struct _GttProjectsTreeClass GttProjectsTreeClass;
 
 struct _GttProjectsTree
 {
-	GtkTreeView parent;
+    GtkTreeView parent;
 };
 
 struct _GttProjectsTreeClass
 {
-	GtkTreeViewClass parent_class;
-	
+    GtkTreeViewClass parent_class;
 };
 
-
 /* Creators */
-GType gtt_projects_tree_get_type (void);
+GType gtt_projects_tree_get_type(void);
 
 /* Create a new GttProjectsTree component */
-GttProjectsTree *gtt_projects_tree_new (void);
+GttProjectsTree *gtt_projects_tree_new(void);
 
 /* Populates the tree model with data of the projects in the
  * give project list.
  */
-void gtt_projects_tree_populate (GttProjectsTree *ptree,
-								 GList *plist,
-								 gboolean recursive);
+void gtt_projects_tree_populate(GttProjectsTree *ptree, GList *plist, gboolean recursive);
 
-void gtt_projects_tree_set_visible_columns (GttProjectsTree *project_tree,
-											GList *columns);
+void gtt_projects_tree_set_visible_columns(GttProjectsTree *project_tree, GList *columns);
 
-void gtt_projects_tree_update_project_data (GttProjectsTree *gpt, GttProject *prj);
+void gtt_projects_tree_update_project_data(GttProjectsTree *gpt, GttProject *prj);
 
-void gtt_projects_tree_set_active_bgcolor (GttProjectsTree *gpt, gchar *color);
-gchar * gtt_projects_tree_get_active_bgcolor (GttProjectsTree *gpt);
-void gtt_projects_tree_set_show_seconds (GttProjectsTree *gpt, gboolean show_seconds);
-gboolean gtt_projects_tree_get_show_seconds (GttProjectsTree *gpt);
-void gtt_projects_tree_set_highlight_active (GttProjectsTree *gpt, gboolean highlight_active);
-gboolean gtt_projects_tree_get_highlight_active (GttProjectsTree *gpt);
-GttProject *gtt_projects_tree_get_selected_project (GttProjectsTree *gpt);
-void gtt_projects_tree_update_all_rows (GttProjectsTree *gpt);
-void gtt_projects_tree_remove_project (GttProjectsTree *gpt, GttProject *prj);
-void gtt_projects_tree_append_project (GttProjectsTree *gpt, GttProject *prj, GttProject *sibling);
-void gtt_projects_tree_insert_project_before (GttProjectsTree *gpt, GttProject *prj, GttProject *sibling);
-gchar *gtt_projects_tree_get_expander_state (GttProjectsTree *gpt);
-void gtt_projects_tree_set_expander_state (GttProjectsTree *gpt, gchar *states);
+void gtt_projects_tree_set_active_bgcolor(GttProjectsTree *gpt, gchar *color);
+gchar *gtt_projects_tree_get_active_bgcolor(GttProjectsTree *gpt);
+void gtt_projects_tree_set_show_seconds(GttProjectsTree *gpt, gboolean show_seconds);
+gboolean gtt_projects_tree_get_show_seconds(GttProjectsTree *gpt);
+void gtt_projects_tree_set_highlight_active(GttProjectsTree *gpt, gboolean highlight_active);
+gboolean gtt_projects_tree_get_highlight_active(GttProjectsTree *gpt);
+GttProject *gtt_projects_tree_get_selected_project(GttProjectsTree *gpt);
+void gtt_projects_tree_update_all_rows(GttProjectsTree *gpt);
+void gtt_projects_tree_remove_project(GttProjectsTree *gpt, GttProject *prj);
+void gtt_projects_tree_append_project(
+    GttProjectsTree *gpt, GttProject *prj, GttProject *sibling
+);
+void gtt_projects_tree_insert_project_before(
+    GttProjectsTree *gpt, GttProject *prj, GttProject *sibling
+);
+gchar *gtt_projects_tree_get_expander_state(GttProjectsTree *gpt);
+void gtt_projects_tree_set_expander_state(GttProjectsTree *gpt, gchar *states);
 
-gint gtt_projects_tree_get_col_width (GttProjectsTree *gpt, int col);
-void gtt_projects_tree_set_col_width (GttProjectsTree *gpt, int col, int width);
+gint gtt_projects_tree_get_col_width(GttProjectsTree *gpt, int col);
+void gtt_projects_tree_set_col_width(GttProjectsTree *gpt, int col, int width);
 
-GtkTreeViewColumn *gtt_projects_tree_get_column_by_name (GttProjectsTree *gpt, gchar *column_name);
+GtkTreeViewColumn *
+gtt_projects_tree_get_column_by_name(GttProjectsTree *gpt, gchar *column_name);
 
-void gtt_projects_tree_set_sorted_column (GttProjectsTree *gpt, GtkTreeViewColumn *column);
+void gtt_projects_tree_set_sorted_column(GttProjectsTree *gpt, GtkTreeViewColumn *column);
 
 #endif // __PROJECTS_TREE_H__

--- a/src/props-invl.c
+++ b/src/props-invl.c
@@ -30,244 +30,243 @@
 
 struct EditIntervalDialog_s
 {
-	GttInterval *interval;
-	GladeXML *gtxml;
-	GtkWidget *interval_edit;
-	GtkWidget *start_widget;
-	GtkWidget *stop_widget;
-	GtkWidget *fuzz_widget;
+    GttInterval *interval;
+    GladeXML *gtxml;
+    GtkWidget *interval_edit;
+    GtkWidget *start_widget;
+    GtkWidget *stop_widget;
+    GtkWidget *fuzz_widget;
 };
 
 /* ============================================================== */
 /* interval dialog edits */
 
-static void
-interval_edit_apply_cb(GtkWidget * w, gpointer data)
+static void interval_edit_apply_cb(GtkWidget *w, gpointer data)
 {
-	EditIntervalDialog *dlg = (EditIntervalDialog *) data;
-	GtkWidget *menu, *menu_item;
-	GttTask * task;
-	GttProject * prj;
-	time_t start, stop, tmp;
-	int fuzz, min_invl;
+    EditIntervalDialog *dlg = (EditIntervalDialog *) data;
+    GtkWidget *menu, *menu_item;
+    GttTask *task;
+    GttProject *prj;
+    time_t start, stop, tmp;
+    int fuzz, min_invl;
 
-	start = gnome_date_edit_get_time(GNOME_DATE_EDIT(dlg->start_widget));
-	stop = gnome_date_edit_get_time(GNOME_DATE_EDIT(dlg->stop_widget));
+    start = gnome_date_edit_get_time(GNOME_DATE_EDIT(dlg->start_widget));
+    stop = gnome_date_edit_get_time(GNOME_DATE_EDIT(dlg->stop_widget));
 
-	/* If user reversed start and stop, flip them back */
-	if (start > stop) { tmp=start; start=stop; stop=tmp; }
+    /* If user reversed start and stop, flip them back */
+    if (start > stop)
+    {
+        tmp = start;
+        start = stop;
+        stop = tmp;
+    }
 
-	/* Caution: we must avoid setting very short time intervals
-	 * through this interface; otherwise the interval will get
-	 * scrubbed away on us, and we'll be holding an invalid pointer.
-	 * In fact, we should probably assume the pointer is invalid
-	 * if prj is null ...
-	 */
+    /* Caution: we must avoid setting very short time intervals
+     * through this interface; otherwise the interval will get
+     * scrubbed away on us, and we'll be holding an invalid pointer.
+     * In fact, we should probably assume the pointer is invalid
+     * if prj is null ...
+     */
 
-	task = gtt_interval_get_parent (dlg->interval);
-	prj = gtt_task_get_parent (task);
-	min_invl = gtt_project_get_min_interval (prj);
-	if (min_invl >= stop-start) stop = start + min_invl+1;
+    task = gtt_interval_get_parent(dlg->interval);
+    prj = gtt_task_get_parent(task);
+    min_invl = gtt_project_get_min_interval(prj);
+    if (min_invl >= stop - start)
+        stop = start + min_invl + 1;
 
-	gtt_interval_freeze (dlg->interval);
-	gtt_interval_set_start (dlg->interval, start);
-	gtt_interval_set_stop (dlg->interval, stop);
+    gtt_interval_freeze(dlg->interval);
+    gtt_interval_set_start(dlg->interval, start);
+    gtt_interval_set_stop(dlg->interval, stop);
 
-	menu = gtk_option_menu_get_menu (GTK_OPTION_MENU(dlg->fuzz_widget));
-	menu_item = gtk_menu_get_active(GTK_MENU(menu));
-	fuzz = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(menu_item),
-                                             "fuzz_factor"));
+    menu = gtk_option_menu_get_menu(GTK_OPTION_MENU(dlg->fuzz_widget));
+    menu_item = gtk_menu_get_active(GTK_MENU(menu));
+    fuzz = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(menu_item), "fuzz_factor"));
 
-	gtt_interval_set_fuzz (dlg->interval, fuzz);
+    gtt_interval_set_fuzz(dlg->interval, fuzz);
 
-	/* The thaw may cause  the interval to change.  If so, redo the GUI. */
-	dlg->interval = gtt_interval_thaw (dlg->interval);
-	edit_interval_set_interval (dlg, dlg->interval);
+    /* The thaw may cause  the interval to change.  If so, redo the GUI. */
+    dlg->interval = gtt_interval_thaw(dlg->interval);
+    edit_interval_set_interval(dlg, dlg->interval);
 }
 
-static void
-interval_edit_ok_cb(GtkWidget * w, gpointer data)
+static void interval_edit_ok_cb(GtkWidget *w, gpointer data)
 {
-	EditIntervalDialog *dlg = (EditIntervalDialog *) data;
-	interval_edit_apply_cb(w, data);
-	gtk_widget_hide (dlg->interval_edit);
-	dlg->interval = NULL;
+    EditIntervalDialog *dlg = (EditIntervalDialog *) data;
+    interval_edit_apply_cb(w, data);
+    gtk_widget_hide(dlg->interval_edit);
+    dlg->interval = NULL;
 }
 
-static void
-interval_edit_cancel_cb(GtkWidget * w, gpointer data)
+static void interval_edit_cancel_cb(GtkWidget *w, gpointer data)
 {
-	EditIntervalDialog *dlg = (EditIntervalDialog *) data;
-	gtk_widget_hide (dlg->interval_edit);
-	dlg->interval = NULL;
+    EditIntervalDialog *dlg = (EditIntervalDialog *) data;
+    gtk_widget_hide(dlg->interval_edit);
+    dlg->interval = NULL;
 }
 
 /* ============================================================== */
 /* Set values into interval editor widgets */
 
-void
-edit_interval_set_interval (EditIntervalDialog *dlg, GttInterval *ivl)
+void edit_interval_set_interval(EditIntervalDialog *dlg, GttInterval *ivl)
 {
-	GtkWidget *w;
-	GtkOptionMenu *fw;
-	time_t start, stop;
-	int fuzz;
+    GtkWidget *w;
+    GtkOptionMenu *fw;
+    time_t start, stop;
+    int fuzz;
 
-	if (!dlg) return;
-	dlg->interval = ivl;
+    if (!dlg)
+        return;
+    dlg->interval = ivl;
 
-	if (!ivl)
-	{
-		w = dlg->start_widget;
-		gnome_date_edit_set_time (GNOME_DATE_EDIT(w), 0);
-		w = dlg->stop_widget;
-		gnome_date_edit_set_time (GNOME_DATE_EDIT(w), 0);
+    if (!ivl)
+    {
+        w = dlg->start_widget;
+        gnome_date_edit_set_time(GNOME_DATE_EDIT(w), 0);
+        w = dlg->stop_widget;
+        gnome_date_edit_set_time(GNOME_DATE_EDIT(w), 0);
 
-		fw = GTK_OPTION_MENU(dlg->fuzz_widget);
-		gtk_option_menu_set_history(fw, 0);
-		return;
-	}
+        fw = GTK_OPTION_MENU(dlg->fuzz_widget);
+        gtk_option_menu_set_history(fw, 0);
+        return;
+    }
 
-	w = dlg->start_widget;
-	start = gtt_interval_get_start (ivl);
-	gnome_date_edit_set_time (GNOME_DATE_EDIT(w), start);
+    w = dlg->start_widget;
+    start = gtt_interval_get_start(ivl);
+    gnome_date_edit_set_time(GNOME_DATE_EDIT(w), start);
 
-	w = dlg->stop_widget;
-	stop = gtt_interval_get_stop (ivl);
-	gnome_date_edit_set_time (GNOME_DATE_EDIT(w), stop);
+    w = dlg->stop_widget;
+    stop = gtt_interval_get_stop(ivl);
+    gnome_date_edit_set_time(GNOME_DATE_EDIT(w), stop);
 
-	fuzz = gtt_interval_get_fuzz (dlg->interval);
-	fw = GTK_OPTION_MENU(dlg->fuzz_widget);
+    fuzz = gtt_interval_get_fuzz(dlg->interval);
+    fw = GTK_OPTION_MENU(dlg->fuzz_widget);
 
-	/* OK, now set the initial value */
-	gtk_option_menu_set_history(fw, 0);
-	if (90 < fuzz) gtk_option_menu_set_history(fw, 1);
-	if (450 < fuzz) gtk_option_menu_set_history(fw, 2);
-	if (750 < fuzz) gtk_option_menu_set_history(fw, 3);
-	if (1050 < fuzz) gtk_option_menu_set_history(fw, 4);
-	if (1500 < fuzz) gtk_option_menu_set_history(fw, 5);
-	if (2700 < fuzz) gtk_option_menu_set_history(fw, 6);
-	if (5400 < fuzz) gtk_option_menu_set_history(fw, 7);
-	if (9000 < fuzz) gtk_option_menu_set_history(fw, 8);
-	if (6*3600 < fuzz) gtk_option_menu_set_history(fw, 9);
-
+    /* OK, now set the initial value */
+    gtk_option_menu_set_history(fw, 0);
+    if (90 < fuzz)
+        gtk_option_menu_set_history(fw, 1);
+    if (450 < fuzz)
+        gtk_option_menu_set_history(fw, 2);
+    if (750 < fuzz)
+        gtk_option_menu_set_history(fw, 3);
+    if (1050 < fuzz)
+        gtk_option_menu_set_history(fw, 4);
+    if (1500 < fuzz)
+        gtk_option_menu_set_history(fw, 5);
+    if (2700 < fuzz)
+        gtk_option_menu_set_history(fw, 6);
+    if (5400 < fuzz)
+        gtk_option_menu_set_history(fw, 7);
+    if (9000 < fuzz)
+        gtk_option_menu_set_history(fw, 8);
+    if (6 * 3600 < fuzz)
+        gtk_option_menu_set_history(fw, 9);
 }
 
 /* ============================================================== */
 /* interval popup actions */
 
-EditIntervalDialog *
-edit_interval_dialog_new (void)
+EditIntervalDialog *edit_interval_dialog_new(void)
 {
-	EditIntervalDialog *dlg;
-	GladeXML  *glxml;
-	GtkWidget *w, *menu, *menu_item;
+    EditIntervalDialog *dlg;
+    GladeXML *glxml;
+    GtkWidget *w, *menu, *menu_item;
 
-	dlg = g_malloc (sizeof(EditIntervalDialog));
-	dlg->interval = NULL;
+    dlg = g_malloc(sizeof(EditIntervalDialog));
+    dlg->interval = NULL;
 
-	glxml = gtt_glade_xml_new ("glade/interval_edit.glade", "Interval Edit");
-	dlg->gtxml = glxml;
+    glxml = gtt_glade_xml_new("glade/interval_edit.glade", "Interval Edit");
+    dlg->gtxml = glxml;
 
-	dlg->interval_edit = glade_xml_get_widget (glxml, "Interval Edit");
+    dlg->interval_edit = glade_xml_get_widget(glxml, "Interval Edit");
 
-	glade_xml_signal_connect_data (glxml, "on_ok_button_clicked",
-	        GTK_SIGNAL_FUNC (interval_edit_ok_cb), dlg);
+    glade_xml_signal_connect_data(
+        glxml, "on_ok_button_clicked", GTK_SIGNAL_FUNC(interval_edit_ok_cb), dlg
+    );
 
-	glade_xml_signal_connect_data (glxml, "on_apply_button_clicked",
-	        GTK_SIGNAL_FUNC (interval_edit_apply_cb), dlg);
+    glade_xml_signal_connect_data(
+        glxml, "on_apply_button_clicked", GTK_SIGNAL_FUNC(interval_edit_apply_cb), dlg
+    );
 
-	glade_xml_signal_connect_data (glxml, "on_cancel_button_clicked",
-	        GTK_SIGNAL_FUNC (interval_edit_cancel_cb), dlg);
+    glade_xml_signal_connect_data(
+        glxml, "on_cancel_button_clicked", GTK_SIGNAL_FUNC(interval_edit_cancel_cb), dlg
+    );
 
-	dlg->start_widget = glade_xml_get_widget (glxml, "start_date");
-	dlg->stop_widget = glade_xml_get_widget (glxml, "stop_date");
-	dlg->fuzz_widget = glade_xml_get_widget (glxml, "fuzz_menu");
+    dlg->start_widget = glade_xml_get_widget(glxml, "start_date");
+    dlg->stop_widget = glade_xml_get_widget(glxml, "stop_date");
+    dlg->fuzz_widget = glade_xml_get_widget(glxml, "fuzz_menu");
 
-	/* ----------------------------------------------- */
-	/* install option data by hand ... ugh
-	 * wish glade did this for us .. */
-	w = dlg->fuzz_widget;
-	menu = gtk_option_menu_get_menu (GTK_OPTION_MENU(w));
+    /* ----------------------------------------------- */
+    /* install option data by hand ... ugh
+     * wish glade did this for us .. */
+    w = dlg->fuzz_widget;
+    menu = gtk_option_menu_get_menu(GTK_OPTION_MENU(w));
 
-	gtk_option_menu_set_history(GTK_OPTION_MENU(w), 0);
-	menu_item =  gtk_menu_get_active(GTK_MENU(menu));
-	g_object_set_data(G_OBJECT(menu_item),
-		"fuzz_factor", GINT_TO_POINTER(0));
+    gtk_option_menu_set_history(GTK_OPTION_MENU(w), 0);
+    menu_item = gtk_menu_get_active(GTK_MENU(menu));
+    g_object_set_data(G_OBJECT(menu_item), "fuzz_factor", GINT_TO_POINTER(0));
 
-	gtk_option_menu_set_history(GTK_OPTION_MENU(w), 1);
-	menu_item =  gtk_menu_get_active(GTK_MENU(menu));
-	g_object_set_data(G_OBJECT(menu_item),
-		"fuzz_factor", GINT_TO_POINTER(300));
+    gtk_option_menu_set_history(GTK_OPTION_MENU(w), 1);
+    menu_item = gtk_menu_get_active(GTK_MENU(menu));
+    g_object_set_data(G_OBJECT(menu_item), "fuzz_factor", GINT_TO_POINTER(300));
 
-	gtk_option_menu_set_history(GTK_OPTION_MENU(w), 2);
-	menu_item =  gtk_menu_get_active(GTK_MENU(menu));
-	g_object_set_data(G_OBJECT(menu_item),
-		"fuzz_factor", GINT_TO_POINTER(600));
+    gtk_option_menu_set_history(GTK_OPTION_MENU(w), 2);
+    menu_item = gtk_menu_get_active(GTK_MENU(menu));
+    g_object_set_data(G_OBJECT(menu_item), "fuzz_factor", GINT_TO_POINTER(600));
 
-	gtk_option_menu_set_history(GTK_OPTION_MENU(w), 3);
-	menu_item =  gtk_menu_get_active(GTK_MENU(menu));
-	g_object_set_data(G_OBJECT(menu_item),
-		"fuzz_factor", GINT_TO_POINTER(900));
+    gtk_option_menu_set_history(GTK_OPTION_MENU(w), 3);
+    menu_item = gtk_menu_get_active(GTK_MENU(menu));
+    g_object_set_data(G_OBJECT(menu_item), "fuzz_factor", GINT_TO_POINTER(900));
 
-	gtk_option_menu_set_history(GTK_OPTION_MENU(w), 4);
-	menu_item =  gtk_menu_get_active(GTK_MENU(menu));
-	g_object_set_data(G_OBJECT(menu_item),
-		"fuzz_factor", GINT_TO_POINTER(1200));
+    gtk_option_menu_set_history(GTK_OPTION_MENU(w), 4);
+    menu_item = gtk_menu_get_active(GTK_MENU(menu));
+    g_object_set_data(G_OBJECT(menu_item), "fuzz_factor", GINT_TO_POINTER(1200));
 
-	gtk_option_menu_set_history(GTK_OPTION_MENU(w), 5);
-	menu_item =  gtk_menu_get_active(GTK_MENU(menu));
-	g_object_set_data(G_OBJECT(menu_item),
-		"fuzz_factor", GINT_TO_POINTER(1800));
+    gtk_option_menu_set_history(GTK_OPTION_MENU(w), 5);
+    menu_item = gtk_menu_get_active(GTK_MENU(menu));
+    g_object_set_data(G_OBJECT(menu_item), "fuzz_factor", GINT_TO_POINTER(1800));
 
-	gtk_option_menu_set_history(GTK_OPTION_MENU(w), 6);
-	menu_item =  gtk_menu_get_active(GTK_MENU(menu));
-	g_object_set_data(G_OBJECT(menu_item),
-		"fuzz_factor", GINT_TO_POINTER(3600));
+    gtk_option_menu_set_history(GTK_OPTION_MENU(w), 6);
+    menu_item = gtk_menu_get_active(GTK_MENU(menu));
+    g_object_set_data(G_OBJECT(menu_item), "fuzz_factor", GINT_TO_POINTER(3600));
 
-	gtk_option_menu_set_history(GTK_OPTION_MENU(w), 7);
-	menu_item =  gtk_menu_get_active(GTK_MENU(menu));
-	g_object_set_data(G_OBJECT(menu_item),
-		"fuzz_factor", GINT_TO_POINTER(7200));
+    gtk_option_menu_set_history(GTK_OPTION_MENU(w), 7);
+    menu_item = gtk_menu_get_active(GTK_MENU(menu));
+    g_object_set_data(G_OBJECT(menu_item), "fuzz_factor", GINT_TO_POINTER(7200));
 
-	gtk_option_menu_set_history(GTK_OPTION_MENU(w), 8);
-	menu_item =  gtk_menu_get_active(GTK_MENU(menu));
-	g_object_set_data(G_OBJECT(menu_item),
-		"fuzz_factor", GINT_TO_POINTER(3*3600));
+    gtk_option_menu_set_history(GTK_OPTION_MENU(w), 8);
+    menu_item = gtk_menu_get_active(GTK_MENU(menu));
+    g_object_set_data(G_OBJECT(menu_item), "fuzz_factor", GINT_TO_POINTER(3 * 3600));
 
-	gtk_option_menu_set_history(GTK_OPTION_MENU(w), 9);
-	menu_item =  gtk_menu_get_active(GTK_MENU(menu));
-	g_object_set_data(G_OBJECT(menu_item),
-		"fuzz_factor", GINT_TO_POINTER(12*3600));
+    gtk_option_menu_set_history(GTK_OPTION_MENU(w), 9);
+    menu_item = gtk_menu_get_active(GTK_MENU(menu));
+    g_object_set_data(G_OBJECT(menu_item), "fuzz_factor", GINT_TO_POINTER(12 * 3600));
 
-	/* gnome_dialog_close_hides(GNOME_DIALOG(dlg->interval_edit), TRUE); */
-	gtk_widget_hide_on_delete (dlg->interval_edit);
-	return dlg;
+    /* gnome_dialog_close_hides(GNOME_DIALOG(dlg->interval_edit), TRUE); */
+    gtk_widget_hide_on_delete(dlg->interval_edit);
+    return dlg;
 }
 
 /* ============================================================== */
 
-void
-edit_interval_dialog_show(EditIntervalDialog *dlg)
+void edit_interval_dialog_show(EditIntervalDialog *dlg)
 {
-	if (!dlg) return;
-	gtk_widget_show(GTK_WIDGET(dlg->interval_edit));
+    if (!dlg)
+        return;
+    gtk_widget_show(GTK_WIDGET(dlg->interval_edit));
 }
 
-void
-edit_interval_dialog_destroy(EditIntervalDialog *dlg)
+void edit_interval_dialog_destroy(EditIntervalDialog *dlg)
 {
-	if (!dlg) return;
-	gtk_widget_destroy (GTK_WIDGET(dlg->interval_edit));
-	g_free (dlg);
+    if (!dlg)
+        return;
+    gtk_widget_destroy(GTK_WIDGET(dlg->interval_edit));
+    g_free(dlg);
 }
 
-void
-edit_interval_set_close_callback (EditIntervalDialog *dlg,
-								  GCallback f,
-								  gpointer data)
+void edit_interval_set_close_callback(EditIntervalDialog *dlg, GCallback f, gpointer data)
 {
-	g_signal_connect (dlg->interval_edit, "close", f, data);
+    g_signal_connect(dlg->interval_edit, "close", f, data);
 }
 
 /* ===================== END OF FILE ==============================  */

--- a/src/props-invl.h
+++ b/src/props-invl.h
@@ -16,7 +16,6 @@
  *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-
 #ifndef __PROPS_INVL_H__
 #define __PROPS_INVL_H__
 
@@ -24,17 +23,13 @@
 
 typedef struct EditIntervalDialog_s EditIntervalDialog;
 
-EditIntervalDialog * edit_interval_dialog_new (void);
+EditIntervalDialog *edit_interval_dialog_new(void);
 void edit_interval_dialog_destroy(EditIntervalDialog *dlg);
 
-void edit_interval_set_interval (EditIntervalDialog *dlg, GttInterval *ivl);
+void edit_interval_set_interval(EditIntervalDialog *dlg, GttInterval *ivl);
 
 /* pop up a dialog box for editing an interval */
 void edit_interval_dialog_show(EditIntervalDialog *dlg);
-void edit_interval_set_close_callback (EditIntervalDialog *dlg,
-									   GCallback f,
-									   gpointer data);
-
-
+void edit_interval_set_close_callback(EditIntervalDialog *dlg, GCallback f, gpointer data);
 
 #endif /* __PROPS_INVL_H__ */

--- a/src/props-proj.c
+++ b/src/props-proj.c
@@ -30,407 +30,424 @@
 
 typedef struct _PropDlg
 {
-	GladeXML *gtxml;
-	GnomePropertyBox *dlg;
-	GtkEntry *title;
-	GtkEntry *desc;
-	GtkTextView *notes;
+    GladeXML *gtxml;
+    GnomePropertyBox *dlg;
+    GtkEntry *title;
+    GtkEntry *desc;
+    GtkTextView *notes;
 
-	GtkEntry *regular;
-	GtkEntry *overtime;
-	GtkEntry *overover;
-	GtkEntry *flatfee;
+    GtkEntry *regular;
+    GtkEntry *overtime;
+    GtkEntry *overover;
+    GtkEntry *flatfee;
 
-	GtkEntry *minimum;
-	GtkEntry *interval;
-	GtkEntry *gap;
+    GtkEntry *minimum;
+    GtkEntry *interval;
+    GtkEntry *gap;
 
-	GtkOptionMenu *urgency;
-	GtkOptionMenu *importance;
-	GtkOptionMenu *status;
+    GtkOptionMenu *urgency;
+    GtkOptionMenu *importance;
+    GtkOptionMenu *status;
 
-	GnomeDateEdit *start;
-	GnomeDateEdit *end;
-	GnomeDateEdit *due;
+    GnomeDateEdit *start;
+    GnomeDateEdit *end;
+    GnomeDateEdit *due;
 
-	GtkEntry *sizing;
-	GtkEntry *percent;
+    GtkEntry *sizing;
+    GtkEntry *percent;
 
-	GttProject *proj;
+    GttProject *proj;
 } PropDlg;
 
-
 /* ============================================================== */
 
-#define GET_MENU(WIDGET,NAME) ({                                \
-        GtkWidget *menu, *menu_item;                            \
-        menu = gtk_option_menu_get_menu (WIDGET);               \
-        menu_item = gtk_menu_get_active(GTK_MENU(menu));        \
-        (g_object_get_data(G_OBJECT(menu_item), NAME));         \
-})
+#define GET_MENU(WIDGET, NAME)                           \
+    ({                                                   \
+        GtkWidget *menu, *menu_item;                     \
+        menu = gtk_option_menu_get_menu(WIDGET);         \
+        menu_item = gtk_menu_get_active(GTK_MENU(menu)); \
+        (g_object_get_data(G_OBJECT(menu_item), NAME));  \
+    })
 
-
-static void
-prop_set(GnomePropertyBox * pb, gint page, PropDlg *dlg)
+static void prop_set(GnomePropertyBox *pb, gint page, PropDlg *dlg)
 {
-	long ivl;
-	const gchar *cstr;
-	gchar *str;
-	double rate;
-	time_t tval;
+    long ivl;
+    const gchar *cstr;
+    gchar *str;
+    double rate;
+    time_t tval;
 
-	if (!dlg->proj) return;
+    if (!dlg->proj)
+        return;
 
-	if (0 == page)
-	{
-		gtt_project_freeze (dlg->proj);
-		cstr = gtk_entry_get_text(dlg->title);
-		if (cstr && cstr[0])
-		{
-			gtt_project_set_title(dlg->proj, cstr);
-		}
-		else
-		{
-			gtt_project_set_title(dlg->proj, _("empty"));
-			gtk_entry_set_text(dlg->title, _("empty"));
-		}
-	
-		gtt_project_set_desc(dlg->proj, gtk_entry_get_text(dlg->desc));
-		str = xxxgtk_textview_get_text(dlg->notes);
-		gtt_project_set_notes(dlg->proj, str);
-		g_free(str);
-		gtt_project_thaw (dlg->proj);
-	}
+    if (0 == page)
+    {
+        gtt_project_freeze(dlg->proj);
+        cstr = gtk_entry_get_text(dlg->title);
+        if (cstr && cstr[0])
+        {
+            gtt_project_set_title(dlg->proj, cstr);
+        }
+        else
+        {
+            gtt_project_set_title(dlg->proj, _("empty"));
+            gtk_entry_set_text(dlg->title, _("empty"));
+        }
 
-	if (1 == page)
-	{
-		gtt_project_freeze (dlg->proj);
-		rate = atof (gtk_entry_get_text(dlg->regular));
-		gtt_project_set_billrate (dlg->proj, rate);
-		rate = atof (gtk_entry_get_text(dlg->overtime));
-		gtt_project_set_overtime_rate (dlg->proj, rate);
-		rate = atof (gtk_entry_get_text(dlg->overover));
-		gtt_project_set_overover_rate (dlg->proj, rate);
-		rate = atof (gtk_entry_get_text(dlg->flatfee));
-		gtt_project_set_flat_fee (dlg->proj, rate);
-		gtt_project_thaw (dlg->proj);
-	}
-	
-	if (2 == page)
-	{
-		gtt_project_freeze (dlg->proj);
-		ivl = atoi (gtk_entry_get_text(dlg->minimum));
-		gtt_project_set_min_interval (dlg->proj, ivl);
-		ivl = atoi (gtk_entry_get_text(dlg->interval));
-		gtt_project_set_auto_merge_interval (dlg->proj, ivl);
-		ivl = atoi (gtk_entry_get_text(dlg->gap));
-		gtt_project_set_auto_merge_gap (dlg->proj, ivl);
-		gtt_project_thaw (dlg->proj);
-	}
-	if (3 == page)
-	{
-		gtt_project_freeze (dlg->proj);
-		
-		ivl = (long) GET_MENU (dlg->urgency, "urgency");
-		gtt_project_set_urgency (dlg->proj, (GttRank) ivl);
-		ivl = (long) GET_MENU (dlg->importance, "importance");
-		gtt_project_set_importance (dlg->proj, (GttRank) ivl);
+        gtt_project_set_desc(dlg->proj, gtk_entry_get_text(dlg->desc));
+        str = xxxgtk_textview_get_text(dlg->notes);
+        gtt_project_set_notes(dlg->proj, str);
+        g_free(str);
+        gtt_project_thaw(dlg->proj);
+    }
 
-		ivl = (long) GET_MENU (dlg->status, "status");
-		gtt_project_set_status (dlg->proj, (GttProjectStatus) ivl);
+    if (1 == page)
+    {
+        gtt_project_freeze(dlg->proj);
+        rate = atof(gtk_entry_get_text(dlg->regular));
+        gtt_project_set_billrate(dlg->proj, rate);
+        rate = atof(gtk_entry_get_text(dlg->overtime));
+        gtt_project_set_overtime_rate(dlg->proj, rate);
+        rate = atof(gtk_entry_get_text(dlg->overover));
+        gtt_project_set_overover_rate(dlg->proj, rate);
+        rate = atof(gtk_entry_get_text(dlg->flatfee));
+        gtt_project_set_flat_fee(dlg->proj, rate);
+        gtt_project_thaw(dlg->proj);
+    }
 
-		tval = gnome_date_edit_get_time (dlg->start);
-		gtt_project_set_estimated_start (dlg->proj, tval);
-		tval = gnome_date_edit_get_time (dlg->end);
-		gtt_project_set_estimated_end (dlg->proj, tval);
-		tval = gnome_date_edit_get_time (dlg->due);
-		gtt_project_set_due_date (dlg->proj, tval);
+    if (2 == page)
+    {
+        gtt_project_freeze(dlg->proj);
+        ivl = atoi(gtk_entry_get_text(dlg->minimum));
+        gtt_project_set_min_interval(dlg->proj, ivl);
+        ivl = atoi(gtk_entry_get_text(dlg->interval));
+        gtt_project_set_auto_merge_interval(dlg->proj, ivl);
+        ivl = atoi(gtk_entry_get_text(dlg->gap));
+        gtt_project_set_auto_merge_gap(dlg->proj, ivl);
+        gtt_project_thaw(dlg->proj);
+    }
+    if (3 == page)
+    {
+        gtt_project_freeze(dlg->proj);
 
-		rate = atof (gtk_entry_get_text(dlg->sizing));
-		ivl = rate * 3600.0;
-		gtt_project_set_sizing (dlg->proj, ivl);
+        ivl = (long) GET_MENU(dlg->urgency, "urgency");
+        gtt_project_set_urgency(dlg->proj, (GttRank) ivl);
+        ivl = (long) GET_MENU(dlg->importance, "importance");
+        gtt_project_set_importance(dlg->proj, (GttRank) ivl);
 
-		ivl = atoi (gtk_entry_get_text(dlg->percent));
-		gtt_project_set_percent_complete (dlg->proj, ivl);
+        ivl = (long) GET_MENU(dlg->status, "status");
+        gtt_project_set_status(dlg->proj, (GttProjectStatus) ivl);
 
-		gtt_project_thaw (dlg->proj);
-	}
+        tval = gnome_date_edit_get_time(dlg->start);
+        gtt_project_set_estimated_start(dlg->proj, tval);
+        tval = gnome_date_edit_get_time(dlg->end);
+        gtt_project_set_estimated_end(dlg->proj, tval);
+        tval = gnome_date_edit_get_time(dlg->due);
+        gtt_project_set_due_date(dlg->proj, tval);
+
+        rate = atof(gtk_entry_get_text(dlg->sizing));
+        ivl = rate * 3600.0;
+        gtt_project_set_sizing(dlg->proj, ivl);
+
+        ivl = atoi(gtk_entry_get_text(dlg->percent));
+        gtt_project_set_percent_complete(dlg->proj, ivl);
+
+        gtt_project_thaw(dlg->proj);
+    }
 }
-
 
 /* ============================================================== */
 
-
-static void
-do_set_project(GttProject *proj, PropDlg *dlg)
+static void do_set_project(GttProject *proj, PropDlg *dlg)
 {
-	GttProjectStatus status;
-	GttRank rank;
-	time_t tval;
-	char buff[132];
-	time_t now = time(NULL);
+    GttProjectStatus status;
+    GttRank rank;
+    time_t tval;
+    char buff[132];
+    time_t now = time(NULL);
 
-	if (!dlg) return;
+    if (!dlg)
+        return;
 
-	if (!proj)
-	{
-		/* We null these out, because old values may be left
-		 * over from an earlier project */
-		dlg->proj = NULL;
-		gtk_entry_set_text(dlg->title, "");
-		gtk_entry_set_text(dlg->desc, "");
-		xxxgtk_textview_set_text(dlg->notes, "");
-		gtk_entry_set_text(dlg->regular, "0.0");
-		gtk_entry_set_text(dlg->overtime, "0.0");
-		gtk_entry_set_text(dlg->overover, "0.0");
-		gtk_entry_set_text(dlg->flatfee, "0.0");
-		gtk_entry_set_text(dlg->minimum, "0");
-		gtk_entry_set_text(dlg->interval, "0");
-		gtk_entry_set_text(dlg->gap, "0");
+    if (!proj)
+    {
+        /* We null these out, because old values may be left
+         * over from an earlier project */
+        dlg->proj = NULL;
+        gtk_entry_set_text(dlg->title, "");
+        gtk_entry_set_text(dlg->desc, "");
+        xxxgtk_textview_set_text(dlg->notes, "");
+        gtk_entry_set_text(dlg->regular, "0.0");
+        gtk_entry_set_text(dlg->overtime, "0.0");
+        gtk_entry_set_text(dlg->overover, "0.0");
+        gtk_entry_set_text(dlg->flatfee, "0.0");
+        gtk_entry_set_text(dlg->minimum, "0");
+        gtk_entry_set_text(dlg->interval, "0");
+        gtk_entry_set_text(dlg->gap, "0");
 
-		gnome_date_edit_set_time(dlg->start, now);
-		gnome_date_edit_set_time(dlg->end, now);
-		gnome_date_edit_set_time(dlg->due, now+86400);
-		gtk_entry_set_text(dlg->sizing, "0.0");
-		gtk_entry_set_text(dlg->percent, "0");
-		return;
-	}
+        gnome_date_edit_set_time(dlg->start, now);
+        gnome_date_edit_set_time(dlg->end, now);
+        gnome_date_edit_set_time(dlg->due, now + 86400);
+        gtk_entry_set_text(dlg->sizing, "0.0");
+        gtk_entry_set_text(dlg->percent, "0");
+        return;
+    }
 
+    /* set all the values. Do this even is new project is same as old
+     * project, since widget may be holding rejected changes. */
+    dlg->proj = proj;
 
-	/* set all the values. Do this even is new project is same as old
-	 * project, since widget may be holding rejected changes. */
-	dlg->proj = proj;
+    gtk_entry_set_text(dlg->title, gtt_project_get_title(proj));
+    gtk_entry_set_text(dlg->desc, gtt_project_get_desc(proj));
+    xxxgtk_textview_set_text(dlg->notes, gtt_project_get_notes(proj));
 
-	gtk_entry_set_text(dlg->title, gtt_project_get_title(proj));
-	gtk_entry_set_text(dlg->desc, gtt_project_get_desc(proj));
-	xxxgtk_textview_set_text(dlg->notes, gtt_project_get_notes (proj));
+    /* hack alert should use local currencies for this */
+    g_snprintf(buff, 132, "%.2f", gtt_project_get_billrate(proj));
+    gtk_entry_set_text(dlg->regular, buff);
+    g_snprintf(buff, 132, "%.2f", gtt_project_get_overtime_rate(proj));
+    gtk_entry_set_text(dlg->overtime, buff);
+    g_snprintf(buff, 132, "%.2f", gtt_project_get_overover_rate(proj));
+    gtk_entry_set_text(dlg->overover, buff);
+    g_snprintf(buff, 132, "%.2f", gtt_project_get_flat_fee(proj));
+    gtk_entry_set_text(dlg->flatfee, buff);
 
-	/* hack alert should use local currencies for this */
-	g_snprintf (buff, 132, "%.2f", gtt_project_get_billrate(proj));
-	gtk_entry_set_text(dlg->regular, buff);
-	g_snprintf (buff, 132, "%.2f", gtt_project_get_overtime_rate(proj));
-	gtk_entry_set_text(dlg->overtime, buff);
-	g_snprintf (buff, 132, "%.2f", gtt_project_get_overover_rate(proj));
-	gtk_entry_set_text(dlg->overover, buff);
-	g_snprintf (buff, 132, "%.2f", gtt_project_get_flat_fee(proj));
-	gtk_entry_set_text(dlg->flatfee, buff);
+    g_snprintf(buff, 132, "%d", gtt_project_get_min_interval(proj));
+    gtk_entry_set_text(dlg->minimum, buff);
+    g_snprintf(buff, 132, "%d", gtt_project_get_auto_merge_interval(proj));
+    gtk_entry_set_text(dlg->interval, buff);
+    g_snprintf(buff, 132, "%d", gtt_project_get_auto_merge_gap(proj));
+    gtk_entry_set_text(dlg->gap, buff);
 
-	g_snprintf (buff, 132, "%d", gtt_project_get_min_interval(proj));
-	gtk_entry_set_text(dlg->minimum, buff);
-	g_snprintf (buff, 132, "%d", gtt_project_get_auto_merge_interval(proj));
-	gtk_entry_set_text(dlg->interval, buff);
-	g_snprintf (buff, 132, "%d", gtt_project_get_auto_merge_gap(proj));
-	gtk_entry_set_text(dlg->gap, buff);
+    rank = gtt_project_get_urgency(proj);
+    if (GTT_UNDEFINED == rank)
+        gtk_option_menu_set_history(dlg->urgency, 0);
+    else if (GTT_LOW == rank)
+        gtk_option_menu_set_history(dlg->urgency, 1);
+    else if (GTT_MEDIUM == rank)
+        gtk_option_menu_set_history(dlg->urgency, 2);
+    else if (GTT_HIGH == rank)
+        gtk_option_menu_set_history(dlg->urgency, 3);
 
-	rank = gtt_project_get_urgency (proj);
-	if (GTT_UNDEFINED   == rank) gtk_option_menu_set_history (dlg->urgency, 0);
-	else if (GTT_LOW    == rank) gtk_option_menu_set_history (dlg->urgency, 1);
-	else if (GTT_MEDIUM == rank) gtk_option_menu_set_history (dlg->urgency, 2);
-	else if (GTT_HIGH   == rank) gtk_option_menu_set_history (dlg->urgency, 3);
+    rank = gtt_project_get_importance(proj);
+    if (GTT_UNDEFINED == rank)
+        gtk_option_menu_set_history(dlg->importance, 0);
+    else if (GTT_LOW == rank)
+        gtk_option_menu_set_history(dlg->importance, 1);
+    else if (GTT_MEDIUM == rank)
+        gtk_option_menu_set_history(dlg->importance, 2);
+    else if (GTT_HIGH == rank)
+        gtk_option_menu_set_history(dlg->importance, 3);
 
-	rank = gtt_project_get_importance (proj);
-	if (GTT_UNDEFINED   == rank) gtk_option_menu_set_history (dlg->importance, 0);
-	else if (GTT_LOW    == rank) gtk_option_menu_set_history (dlg->importance, 1);
-	else if (GTT_MEDIUM == rank) gtk_option_menu_set_history (dlg->importance, 2);
-	else if (GTT_HIGH   == rank) gtk_option_menu_set_history (dlg->importance, 3);
+    status = gtt_project_get_status(proj);
+    if (GTT_NO_STATUS == status)
+        gtk_option_menu_set_history(dlg->status, 0);
+    else if (GTT_NOT_STARTED == status)
+        gtk_option_menu_set_history(dlg->status, 1);
+    else if (GTT_IN_PROGRESS == status)
+        gtk_option_menu_set_history(dlg->status, 2);
+    else if (GTT_ON_HOLD == status)
+        gtk_option_menu_set_history(dlg->status, 3);
+    else if (GTT_CANCELLED == status)
+        gtk_option_menu_set_history(dlg->status, 4);
+    else if (GTT_COMPLETED == status)
+        gtk_option_menu_set_history(dlg->status, 5);
 
-	status = gtt_project_get_status (proj);
-	if (GTT_NO_STATUS	 == status) gtk_option_menu_set_history (dlg->status, 0);
-	else if (GTT_NOT_STARTED == status) gtk_option_menu_set_history (dlg->status, 1);
-	else if (GTT_IN_PROGRESS == status) gtk_option_menu_set_history (dlg->status, 2);
-	else if (GTT_ON_HOLD     == status) gtk_option_menu_set_history (dlg->status, 3);
-	else if (GTT_CANCELLED   == status) gtk_option_menu_set_history (dlg->status, 4);
-	else if (GTT_COMPLETED   == status) gtk_option_menu_set_history (dlg->status, 5);
+    tval = gtt_project_get_estimated_start(proj);
+    if (-1 == tval)
+        tval = now;
+    gnome_date_edit_set_time(dlg->start, tval);
+    tval = gtt_project_get_estimated_end(proj);
+    if (-1 == tval)
+        tval = now + 3600;
+    gnome_date_edit_set_time(dlg->end, tval);
+    tval = gtt_project_get_due_date(proj);
+    if (-1 == tval)
+        tval = now + 86400;
+    gnome_date_edit_set_time(dlg->due, tval);
 
-	tval = gtt_project_get_estimated_start (proj);
-	if (-1 == tval) tval = now;
-	gnome_date_edit_set_time (dlg->start, tval);
-	tval = gtt_project_get_estimated_end (proj);
-	if (-1 == tval) tval = now+3600;
-	gnome_date_edit_set_time (dlg->end, tval);
-	tval = gtt_project_get_due_date (proj);
-	if (-1 == tval) tval = now+86400;
-	gnome_date_edit_set_time (dlg->due, tval);
+    g_snprintf(buff, 132, "%.2f", ((double) gtt_project_get_sizing(proj)) / 3600.0);
+    gtk_entry_set_text(dlg->sizing, buff);
+    g_snprintf(buff, 132, "%d", gtt_project_get_percent_complete(proj));
+    gtk_entry_set_text(dlg->percent, buff);
 
-	g_snprintf (buff, 132, "%.2f", ((double) gtt_project_get_sizing(proj))/3600.0);
-	gtk_entry_set_text(dlg->sizing, buff);
-	g_snprintf (buff, 132, "%d", gtt_project_get_percent_complete(proj));
-	gtk_entry_set_text(dlg->percent, buff);
-
-	/* set to unmodified as it reflects the current state of the project */
-	gnome_property_box_set_modified(GNOME_PROPERTY_BOX(dlg->dlg),
-					FALSE);
+    /* set to unmodified as it reflects the current state of the project */
+    gnome_property_box_set_modified(GNOME_PROPERTY_BOX(dlg->dlg), FALSE);
 }
 
 /* ============================================================== */
 
+#define TAGGED(NAME)                                                                    \
+    ({                                                                                  \
+        GtkWidget *widget;                                                              \
+        widget = glade_xml_get_widget(gtxml, NAME);                                     \
+        gtk_signal_connect_object(                                                      \
+            GTK_OBJECT(widget), "changed", GTK_SIGNAL_FUNC(gnome_property_box_changed), \
+            GTK_OBJECT(dlg->dlg)                                                        \
+        );                                                                              \
+        widget;                                                                         \
+    })
 
-#define TAGGED(NAME) ({                                           \
-	GtkWidget *widget;                                             \
-	widget = glade_xml_get_widget (gtxml, NAME);                   \
-	gtk_signal_connect_object(GTK_OBJECT(widget), "changed",       \
-	        GTK_SIGNAL_FUNC(gnome_property_box_changed),           \
-	        GTK_OBJECT(dlg->dlg));                                 \
-	widget; })
+#define DATED(NAME)                                                                          \
+    ({                                                                                       \
+        GtkWidget *widget;                                                                   \
+        widget = glade_xml_get_widget(gtxml, NAME);                                          \
+        gtk_signal_connect_object(                                                           \
+            GTK_OBJECT(widget), "date_changed", GTK_SIGNAL_FUNC(gnome_property_box_changed), \
+            GTK_OBJECT(dlg->dlg)                                                             \
+        );                                                                                   \
+        gtk_signal_connect_object(                                                           \
+            GTK_OBJECT(widget), "time_changed", GTK_SIGNAL_FUNC(gnome_property_box_changed), \
+            GTK_OBJECT(dlg->dlg)                                                             \
+        );                                                                                   \
+        GNOME_DATE_EDIT(widget);                                                             \
+    })
 
-#define DATED(NAME) ({                                            \
-	GtkWidget *widget;                                             \
-	widget = glade_xml_get_widget (gtxml, NAME);                   \
-	gtk_signal_connect_object(GTK_OBJECT(widget), "date_changed",  \
-	        GTK_SIGNAL_FUNC(gnome_property_box_changed),           \
-	        GTK_OBJECT(dlg->dlg));                                 \
-	gtk_signal_connect_object(GTK_OBJECT(widget), "time_changed",  \
-	        GTK_SIGNAL_FUNC(gnome_property_box_changed),           \
-	        GTK_OBJECT(dlg->dlg));                                 \
-	GNOME_DATE_EDIT(widget); })
-
-static void wrapper (void * gobj, void * data) {
-	gnome_property_box_changed (GNOME_PROPERTY_BOX(data));
+static void wrapper(void *gobj, void *data)
+{
+    gnome_property_box_changed(GNOME_PROPERTY_BOX(data));
 }
 
-#define TEXTED(NAME) ({                                          \
-	GtkWidget *widget;                                            \
-	GtkTextBuffer *buff;                                          \
-	widget = glade_xml_get_widget (gtxml, NAME);                  \
-	buff = gtk_text_view_get_buffer (GTK_TEXT_VIEW(widget));      \
-	g_signal_connect_object(G_OBJECT(buff), "changed",            \
-	        G_CALLBACK(wrapper),                                  \
-	        G_OBJECT(dlg->dlg), 0);                               \
-	widget; })
+#define TEXTED(NAME)                                                              \
+    ({                                                                            \
+        GtkWidget *widget;                                                        \
+        GtkTextBuffer *buff;                                                      \
+        widget = glade_xml_get_widget(gtxml, NAME);                               \
+        buff = gtk_text_view_get_buffer(GTK_TEXT_VIEW(widget));                   \
+        g_signal_connect_object(                                                  \
+            G_OBJECT(buff), "changed", G_CALLBACK(wrapper), G_OBJECT(dlg->dlg), 0 \
+        );                                                                        \
+        widget;                                                                   \
+    })
 
+#define MUGGED(NAME)                                                                       \
+    ({                                                                                     \
+        GtkWidget *widget, *mw;                                                            \
+        widget = glade_xml_get_widget(gtxml, NAME);                                        \
+        mw = gtk_option_menu_get_menu(GTK_OPTION_MENU(widget));                            \
+        gtk_signal_connect_object(                                                         \
+            GTK_OBJECT(mw), "selection_done", GTK_SIGNAL_FUNC(gnome_property_box_changed), \
+            GTK_OBJECT(dlg->dlg)                                                           \
+        );                                                                                 \
+        GTK_OPTION_MENU(widget);                                                           \
+    })
 
-#define MUGGED(NAME) ({                                          \
-	GtkWidget *widget, *mw;                                       \
-	widget = glade_xml_get_widget (gtxml, NAME);                  \
-	mw = gtk_option_menu_get_menu (GTK_OPTION_MENU(widget));      \
-	gtk_signal_connect_object(GTK_OBJECT(mw), "selection_done",   \
-	         GTK_SIGNAL_FUNC(gnome_property_box_changed),         \
-	         GTK_OBJECT(dlg->dlg));                               \
-	GTK_OPTION_MENU(widget);                                      \
-})
-
-
-#define MENTRY(WIDGET,NAME,ORDER,VAL) {                          \
-	GtkWidget *menu_item;                                         \
-	GtkMenu *menu = GTK_MENU(gtk_option_menu_get_menu (WIDGET));  \
-	gtk_option_menu_set_history (WIDGET, ORDER);                  \
-	menu_item =  gtk_menu_get_active(menu);                       \
-	g_object_set_data(G_OBJECT(menu_item), NAME, (gpointer) VAL); \
-}
+#define MENTRY(WIDGET, NAME, ORDER, VAL)                              \
+    {                                                                 \
+        GtkWidget *menu_item;                                         \
+        GtkMenu *menu = GTK_MENU(gtk_option_menu_get_menu(WIDGET));   \
+        gtk_option_menu_set_history(WIDGET, ORDER);                   \
+        menu_item = gtk_menu_get_active(menu);                        \
+        g_object_set_data(G_OBJECT(menu_item), NAME, (gpointer) VAL); \
+    }
 
 /* ================================================================= */
 
-static void
-help_cb (GnomePropertyBox *propertybox, gint page_num, gpointer data)
+static void help_cb(GnomePropertyBox *propertybox, gint page_num, gpointer data)
 {
-	gtt_help_popup (GTK_WIDGET(propertybox), data);
+    gtt_help_popup(GTK_WIDGET(propertybox), data);
 }
 
-static PropDlg *
-prop_dialog_new (void)
+static PropDlg *prop_dialog_new(void)
 {
-	PropDlg *dlg;
-	GladeXML *gtxml;
+    PropDlg *dlg;
+    GladeXML *gtxml;
 
-	dlg = g_new0(PropDlg, 1);
+    dlg = g_new0(PropDlg, 1);
 
-	gtxml = gtt_glade_xml_new ("glade/project_properties.glade", "Project Properties");
-	dlg->gtxml = gtxml;
+    gtxml = gtt_glade_xml_new("glade/project_properties.glade", "Project Properties");
+    dlg->gtxml = gtxml;
 
-	dlg->dlg = GNOME_PROPERTY_BOX (glade_xml_get_widget (gtxml,  "Project Properties"));
+    dlg->dlg = GNOME_PROPERTY_BOX(glade_xml_get_widget(gtxml, "Project Properties"));
 
-	gtk_signal_connect(GTK_OBJECT(dlg->dlg), "help",
-	                   GTK_SIGNAL_FUNC(help_cb),
-			             "projects-editing");
+    gtk_signal_connect(
+        GTK_OBJECT(dlg->dlg), "help", GTK_SIGNAL_FUNC(help_cb), "projects-editing"
+    );
 
-	gtk_signal_connect(GTK_OBJECT(dlg->dlg), "apply",
-			   GTK_SIGNAL_FUNC(prop_set), dlg);
+    gtk_signal_connect(GTK_OBJECT(dlg->dlg), "apply", GTK_SIGNAL_FUNC(prop_set), dlg);
 
-	/* ------------------------------------------------------ */
-	/* grab the various entry boxes and hook them up */
+    /* ------------------------------------------------------ */
+    /* grab the various entry boxes and hook them up */
 
-	dlg->title      = GTK_ENTRY(TAGGED("title box"));
-	dlg->desc       = GTK_ENTRY(TAGGED("desc box"));
-	dlg->notes      = GTK_TEXT_VIEW(TEXTED("notes box"));
+    dlg->title = GTK_ENTRY(TAGGED("title box"));
+    dlg->desc = GTK_ENTRY(TAGGED("desc box"));
+    dlg->notes = GTK_TEXT_VIEW(TEXTED("notes box"));
 
-	dlg->regular    = GTK_ENTRY(TAGGED("regular box"));
-	dlg->overtime   = GTK_ENTRY(TAGGED("overtime box"));
-	dlg->overover   = GTK_ENTRY(TAGGED("overover box"));
-	dlg->flatfee    = GTK_ENTRY(TAGGED("flatfee box"));
+    dlg->regular = GTK_ENTRY(TAGGED("regular box"));
+    dlg->overtime = GTK_ENTRY(TAGGED("overtime box"));
+    dlg->overover = GTK_ENTRY(TAGGED("overover box"));
+    dlg->flatfee = GTK_ENTRY(TAGGED("flatfee box"));
 
-	dlg->minimum    = GTK_ENTRY(TAGGED("minimum box"));
-	dlg->interval   = GTK_ENTRY(TAGGED("interval box"));
-	dlg->gap        = GTK_ENTRY(TAGGED("gap box"));
+    dlg->minimum = GTK_ENTRY(TAGGED("minimum box"));
+    dlg->interval = GTK_ENTRY(TAGGED("interval box"));
+    dlg->gap = GTK_ENTRY(TAGGED("gap box"));
 
-	dlg->urgency    = MUGGED("urgency menu");
-	dlg->importance = MUGGED("importance menu");
-	dlg->status     = MUGGED("status menu");
+    dlg->urgency = MUGGED("urgency menu");
+    dlg->importance = MUGGED("importance menu");
+    dlg->status = MUGGED("status menu");
 
-	dlg->start      = DATED("start date");
-	dlg->end        = DATED("end date");
-	dlg->due        = DATED("due date");
+    dlg->start = DATED("start date");
+    dlg->end = DATED("end date");
+    dlg->due = DATED("due date");
 
-	dlg->sizing     = GTK_ENTRY(TAGGED("sizing box"));
-	dlg->percent    = GTK_ENTRY(TAGGED("percent box"));
+    dlg->sizing = GTK_ENTRY(TAGGED("sizing box"));
+    dlg->percent = GTK_ENTRY(TAGGED("percent box"));
 
-	/* ------------------------------------------------------ */
-	/* initialize menu values */
+    /* ------------------------------------------------------ */
+    /* initialize menu values */
 
-	MENTRY (dlg->urgency, "urgency", 0, GTT_UNDEFINED);
-	MENTRY (dlg->urgency, "urgency", 1, GTT_LOW);
-	MENTRY (dlg->urgency, "urgency", 2, GTT_MEDIUM);
-	MENTRY (dlg->urgency, "urgency", 3, GTT_HIGH);
+    MENTRY(dlg->urgency, "urgency", 0, GTT_UNDEFINED);
+    MENTRY(dlg->urgency, "urgency", 1, GTT_LOW);
+    MENTRY(dlg->urgency, "urgency", 2, GTT_MEDIUM);
+    MENTRY(dlg->urgency, "urgency", 3, GTT_HIGH);
 
-	MENTRY (dlg->importance, "importance", 0, GTT_UNDEFINED);
-	MENTRY (dlg->importance, "importance", 1, GTT_LOW);
-	MENTRY (dlg->importance, "importance", 2, GTT_MEDIUM);
-	MENTRY (dlg->importance, "importance", 3, GTT_HIGH);
+    MENTRY(dlg->importance, "importance", 0, GTT_UNDEFINED);
+    MENTRY(dlg->importance, "importance", 1, GTT_LOW);
+    MENTRY(dlg->importance, "importance", 2, GTT_MEDIUM);
+    MENTRY(dlg->importance, "importance", 3, GTT_HIGH);
 
-	MENTRY (dlg->status, "status", 0, GTT_NO_STATUS);
-	MENTRY (dlg->status, "status", 1, GTT_NOT_STARTED);
-	MENTRY (dlg->status, "status", 2, GTT_IN_PROGRESS);
-	MENTRY (dlg->status, "status", 3, GTT_ON_HOLD);
-	MENTRY (dlg->status, "status", 4, GTT_CANCELLED);
-	MENTRY (dlg->status, "status", 5, GTT_COMPLETED);
+    MENTRY(dlg->status, "status", 0, GTT_NO_STATUS);
+    MENTRY(dlg->status, "status", 1, GTT_NOT_STARTED);
+    MENTRY(dlg->status, "status", 2, GTT_IN_PROGRESS);
+    MENTRY(dlg->status, "status", 3, GTT_ON_HOLD);
+    MENTRY(dlg->status, "status", 4, GTT_CANCELLED);
+    MENTRY(dlg->status, "status", 5, GTT_COMPLETED);
 
-	gnome_dialog_close_hides(GNOME_DIALOG(dlg->dlg), TRUE);
+    gnome_dialog_close_hides(GNOME_DIALOG(dlg->dlg), TRUE);
 
-	return dlg;
+    return dlg;
 }
-
 
 /* ============================================================== */
 
-static void
-redraw (GttProject *prj, gpointer data)
+static void redraw(GttProject *prj, gpointer data)
 {
-	PropDlg *dlg = data;
-	do_set_project(prj, dlg);
+    PropDlg *dlg = data;
+    do_set_project(prj, dlg);
 }
 
 /* ============================================================== */
 
 static PropDlg *dlog = NULL;
 
-void
-prop_dialog_show(GttProject *proj)
+void prop_dialog_show(GttProject *proj)
 {
-	if (!dlog) dlog = prop_dialog_new();
+    if (!dlog)
+        dlog = prop_dialog_new();
 
-	gtt_project_remove_notifier (dlog->proj, redraw, dlog);
-	do_set_project(proj, dlog);
-	gtt_project_add_notifier (proj, redraw, dlog);
-	gtk_widget_show(GTK_WIDGET(dlog->dlg));
+    gtt_project_remove_notifier(dlog->proj, redraw, dlog);
+    do_set_project(proj, dlog);
+    gtt_project_add_notifier(proj, redraw, dlog);
+    gtk_widget_show(GTK_WIDGET(dlog->dlg));
 }
 
-void
-prop_dialog_set_project(GttProject *proj)
+void prop_dialog_set_project(GttProject *proj)
 {
-	if (!dlog) return;
+    if (!dlog)
+        return;
 
-	gtt_project_remove_notifier (dlog->proj, redraw, dlog);
-	do_set_project(proj, dlog);
-	gtt_project_add_notifier (proj, redraw, dlog);
+    gtt_project_remove_notifier(dlog->proj, redraw, dlog);
+    do_set_project(proj, dlog);
+    gtt_project_add_notifier(proj, redraw, dlog);
 }
 
 /* ==================== END OF FILE ============================= */

--- a/src/props-proj.h
+++ b/src/props-proj.h
@@ -16,7 +16,6 @@
  *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-
 #ifndef __PROPS_PROJ_H__
 #define __PROPS_PROJ_H__
 
@@ -28,6 +27,5 @@
  */
 void prop_dialog_set_project(GttProject *proj);
 void prop_dialog_show(GttProject *proj);
-
 
 #endif /* __PROPS_PROJ_H__ */

--- a/src/props-task.c
+++ b/src/props-task.c
@@ -29,320 +29,330 @@
 
 typedef struct PropTaskDlg_s
 {
-	GladeXML *gtxml;
-	GtkDialog *dlg;
-	GtkEntry *memo;
-	GtkTextView *notes;
-	GtkOptionMenu *billstatus;
-	GtkOptionMenu *billable;
-	GtkOptionMenu *billrate;
-	GtkEntry *unit;
+    GladeXML *gtxml;
+    GtkDialog *dlg;
+    GtkEntry *memo;
+    GtkTextView *notes;
+    GtkOptionMenu *billstatus;
+    GtkOptionMenu *billable;
+    GtkOptionMenu *billrate;
+    GtkEntry *unit;
 
-	GttTask *task;
+    GttTask *task;
 
-	/* The goal of 'ignore events' is to prevent an inifinite
-	 * loop of cascading events as we modify the project and the GUI.
-	 */
-	gboolean ignore_events;
+    /* The goal of 'ignore events' is to prevent an inifinite
+     * loop of cascading events as we modify the project and the GUI.
+     */
+    gboolean ignore_events;
 
-	/* The goal of the freezes is to prevent more than one update
-	 * of windows per second.  The problem is that without this,
-	 * there would be one event per keystroke, which could cause
-	 * a redraw of e.g. the journal window.  In such a case, even
-	 * moderate typists on a slow CPU could saturate the CPU entirely.
-	 */
-	gboolean task_freeze;
-	
+    /* The goal of the freezes is to prevent more than one update
+     * of windows per second.  The problem is that without this,
+     * there would be one event per keystroke, which could cause
+     * a redraw of e.g. the journal window.  In such a case, even
+     * moderate typists on a slow CPU could saturate the CPU entirely.
+     */
+    gboolean task_freeze;
+
 } PropTaskDlg;
 
 /* ============================================================== */
 
-#define TSK_SETUP(dlg)                          \
-	if (NULL == dlg->task) return;               \
-	if (dlg->ignore_events) return;              \
-	                                             \
-	dlg->ignore_events = TRUE;                   \
-	dlg->task_freeze = TRUE;                     \
-	gtt_task_freeze (dlg->task);
+#define TSK_SETUP(dlg)         \
+    if (NULL == dlg->task)     \
+        return;                \
+    if (dlg->ignore_events)    \
+        return;                \
+                               \
+    dlg->ignore_events = TRUE; \
+    dlg->task_freeze = TRUE;   \
+    gtt_task_freeze(dlg->task);
 
 /* ============================================================== */
 /* Copy from widget to gtt objects */
 
-#define GET_MENU(WIDGET,NAME) ({                          \
-	GtkWidget *menu, *menu_item;                           \
-	menu = gtk_option_menu_get_menu (WIDGET);              \
-	menu_item = gtk_menu_get_active(GTK_MENU(menu));       \
-	(g_object_get_data(G_OBJECT(menu_item), NAME));        \
-})
+#define GET_MENU(WIDGET, NAME)                           \
+    ({                                                   \
+        GtkWidget *menu, *menu_item;                     \
+        menu = gtk_option_menu_get_menu(WIDGET);         \
+        menu_item = gtk_menu_get_active(GTK_MENU(menu)); \
+        (g_object_get_data(G_OBJECT(menu_item), NAME));  \
+    })
 
-static void
-save_task_notes(GtkWidget *w, PropTaskDlg *dlg)
+static void save_task_notes(GtkWidget *w, PropTaskDlg *dlg)
 {
-	const gchar *cstr;
-	gchar *str;
+    const gchar *cstr;
+    gchar *str;
 
-	TSK_SETUP(dlg);
+    TSK_SETUP(dlg);
 
-	cstr = gtk_entry_get_text(dlg->memo);
-	if (cstr && cstr[0])
-	{
-		gtt_task_set_memo(dlg->task, cstr);
-	}
-	else
-	{
-		gtt_task_set_memo(dlg->task, "");
-		gtk_entry_set_text(dlg->memo, "");
-	}
+    cstr = gtk_entry_get_text(dlg->memo);
+    if (cstr && cstr[0])
+    {
+        gtt_task_set_memo(dlg->task, cstr);
+    }
+    else
+    {
+        gtt_task_set_memo(dlg->task, "");
+        gtk_entry_set_text(dlg->memo, "");
+    }
 
-	str = xxxgtk_textview_get_text(dlg->notes);
-	gtt_task_set_notes(dlg->task, str);
-	g_free (str);
+    str = xxxgtk_textview_get_text(dlg->notes);
+    gtt_task_set_notes(dlg->task, str);
+    g_free(str);
 
-	dlg->ignore_events = FALSE;
+    dlg->ignore_events = FALSE;
 }
 
-static void
-save_task_billinfo(GtkWidget *w, PropTaskDlg *dlg)
+static void save_task_billinfo(GtkWidget *w, PropTaskDlg *dlg)
 {
-	GttBillStatus status;
-	GttBillable able;
-	GttBillRate rate;
-	int ivl;
+    GttBillStatus status;
+    GttBillable able;
+    GttBillRate rate;
+    int ivl;
 
-	TSK_SETUP(dlg);
+    TSK_SETUP(dlg);
 
-	ivl = (int) (60.0 * atof (gtk_entry_get_text(dlg->unit)));
-	gtt_task_set_bill_unit (dlg->task, ivl);
+    ivl = (int) (60.0 * atof(gtk_entry_get_text(dlg->unit)));
+    gtt_task_set_bill_unit(dlg->task, ivl);
 
-	status = (GttBillStatus) GET_MENU (dlg->billstatus, "billstatus");
-	gtt_task_set_billstatus (dlg->task, status);
+    status = (GttBillStatus) GET_MENU(dlg->billstatus, "billstatus");
+    gtt_task_set_billstatus(dlg->task, status);
 
-	able = (GttBillable) GET_MENU (dlg->billable, "billable");
-	gtt_task_set_billable (dlg->task, able);
+    able = (GttBillable) GET_MENU(dlg->billable, "billable");
+    gtt_task_set_billable(dlg->task, able);
 
-	rate = (GttBillRate) GET_MENU (dlg->billrate, "billrate");
-	gtt_task_set_billrate (dlg->task, rate);
+    rate = (GttBillRate) GET_MENU(dlg->billrate, "billrate");
+    gtt_task_set_billrate(dlg->task, rate);
 
-	dlg->ignore_events = FALSE;
+    dlg->ignore_events = FALSE;
 }
-
 
 /* ============================================================== */
 /* Copy values from gnotime object to widget */
 
-static void
-do_set_task(GttTask *tsk, PropTaskDlg *dlg)
+static void do_set_task(GttTask *tsk, PropTaskDlg *dlg)
 {
-	GttBillStatus status;
-	GttBillable able;
-	GttBillRate rate;
-	char buff[132];
+    GttBillStatus status;
+    GttBillable able;
+    GttBillRate rate;
+    char buff[132];
 
-	if (!tsk)
-	{
-		dlg->task = NULL;
-		gtk_entry_set_text(dlg->memo, "");
-		xxxgtk_textview_set_text(dlg->notes, "");
-		gtk_entry_set_text(dlg->unit, "0.0");
-		return;
-	}
+    if (!tsk)
+    {
+        dlg->task = NULL;
+        gtk_entry_set_text(dlg->memo, "");
+        xxxgtk_textview_set_text(dlg->notes, "");
+        gtk_entry_set_text(dlg->unit, "0.0");
+        return;
+    }
 
-	/* Set the task, even if its same as the old task.  Do this because
-	 * the widget may contain rejected edit values.  */
-	dlg->task = tsk;
-	TSK_SETUP (dlg);
+    /* Set the task, even if its same as the old task.  Do this because
+     * the widget may contain rejected edit values.  */
+    dlg->task = tsk;
+    TSK_SETUP(dlg);
 
-	gtk_entry_set_text(dlg->memo, gtt_task_get_memo(tsk));
-	xxxgtk_textview_set_text(dlg->notes, gtt_task_get_notes (tsk));
+    gtk_entry_set_text(dlg->memo, gtt_task_get_memo(tsk));
+    xxxgtk_textview_set_text(dlg->notes, gtt_task_get_notes(tsk));
 
-	g_snprintf (buff, 132, "%g", ((double) gtt_task_get_bill_unit(tsk))/60.0);
-	gtk_entry_set_text(dlg->unit, buff);
+    g_snprintf(buff, 132, "%g", ((double) gtt_task_get_bill_unit(tsk)) / 60.0);
+    gtk_entry_set_text(dlg->unit, buff);
 
-	status = gtt_task_get_billstatus (tsk);
-	if (GTT_HOLD == status) gtk_option_menu_set_history (dlg->billstatus, 0);
-	else if (GTT_BILL == status) gtk_option_menu_set_history (dlg->billstatus, 1);
-	else if (GTT_PAID == status) gtk_option_menu_set_history (dlg->billstatus, 2);
+    status = gtt_task_get_billstatus(tsk);
+    if (GTT_HOLD == status)
+        gtk_option_menu_set_history(dlg->billstatus, 0);
+    else if (GTT_BILL == status)
+        gtk_option_menu_set_history(dlg->billstatus, 1);
+    else if (GTT_PAID == status)
+        gtk_option_menu_set_history(dlg->billstatus, 2);
 
-	able = gtt_task_get_billable (tsk);
-	if (GTT_BILLABLE == able) gtk_option_menu_set_history (dlg->billable, 0);
-	else if (GTT_NOT_BILLABLE == able) gtk_option_menu_set_history (dlg->billable, 1);
-	else if (GTT_NO_CHARGE == able) gtk_option_menu_set_history (dlg->billable, 2);
+    able = gtt_task_get_billable(tsk);
+    if (GTT_BILLABLE == able)
+        gtk_option_menu_set_history(dlg->billable, 0);
+    else if (GTT_NOT_BILLABLE == able)
+        gtk_option_menu_set_history(dlg->billable, 1);
+    else if (GTT_NO_CHARGE == able)
+        gtk_option_menu_set_history(dlg->billable, 2);
 
-	rate = gtt_task_get_billrate (tsk);
-	if (GTT_REGULAR == rate) gtk_option_menu_set_history (dlg->billrate, 0);
-	else if (GTT_OVERTIME == rate) gtk_option_menu_set_history (dlg->billrate, 1);
-	else if (GTT_OVEROVER == rate) gtk_option_menu_set_history (dlg->billrate, 2);
-	else if (GTT_FLAT_FEE == rate) gtk_option_menu_set_history (dlg->billrate, 3);
+    rate = gtt_task_get_billrate(tsk);
+    if (GTT_REGULAR == rate)
+        gtk_option_menu_set_history(dlg->billrate, 0);
+    else if (GTT_OVERTIME == rate)
+        gtk_option_menu_set_history(dlg->billrate, 1);
+    else if (GTT_OVEROVER == rate)
+        gtk_option_menu_set_history(dlg->billrate, 2);
+    else if (GTT_FLAT_FEE == rate)
+        gtk_option_menu_set_history(dlg->billrate, 3);
 
-	dlg->ignore_events = FALSE;
+    dlg->ignore_events = FALSE;
 }
 
 /* ============================================================== */
 
-static void
-redraw (GttProject *prj, gpointer data)
+static void redraw(GttProject *prj, gpointer data)
 {
-	PropTaskDlg *dlg = data;
-	do_set_task (dlg->task, dlg);
+    PropTaskDlg *dlg = data;
+    do_set_task(dlg->task, dlg);
 }
 
-static void
-close_cb (GtkWidget *w,  PropTaskDlg *dlg)
+static void close_cb(GtkWidget *w, PropTaskDlg *dlg)
 {
-	GttProject *prj;
-	prj = gtt_task_get_parent (dlg->task);
-	gtt_project_remove_notifier (prj, redraw, dlg);
+    GttProject *prj;
+    prj = gtt_task_get_parent(dlg->task);
+    gtt_project_remove_notifier(prj, redraw, dlg);
 
-	dlg->ignore_events = FALSE;
-	gtt_task_thaw (dlg->task);
-	dlg->task_freeze = FALSE;
-	save_task_notes (w, dlg);
-	save_task_billinfo (w, dlg);
-	dlg->task = NULL;
-	gtk_widget_hide (GTK_WIDGET(dlg->dlg));
+    dlg->ignore_events = FALSE;
+    gtt_task_thaw(dlg->task);
+    dlg->task_freeze = FALSE;
+    save_task_notes(w, dlg);
+    save_task_billinfo(w, dlg);
+    dlg->task = NULL;
+    gtk_widget_hide(GTK_WIDGET(dlg->dlg));
 }
 
 static PropTaskDlg *global_dlog = NULL;
 
-static void
-destroy_cb (GtkWidget *w, PropTaskDlg *dlg)
+static void destroy_cb(GtkWidget *w, PropTaskDlg *dlg)
 {
-	close_cb (w,dlg);
-	global_dlog = NULL;
-	g_free (dlg);
+    close_cb(w, dlg);
+    global_dlog = NULL;
+    g_free(dlg);
 }
 
 /* ============================================================== */
 
-#define NTAGGED(NAME) ({                                         \
-	GtkWidget *widget;                                            \
-	widget = glade_xml_get_widget (gtxml, NAME);                  \
-	g_signal_connect (G_OBJECT(widget), "changed",                \
-	        G_CALLBACK(save_task_notes), dlg);                    \
-	widget; })
+#define NTAGGED(NAME)                                                                    \
+    ({                                                                                   \
+        GtkWidget *widget;                                                               \
+        widget = glade_xml_get_widget(gtxml, NAME);                                      \
+        g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(save_task_notes), dlg); \
+        widget;                                                                          \
+    })
 
-#define BTAGGED(NAME) ({                                         \
-	GtkWidget *widget;                                            \
-	widget = glade_xml_get_widget (gtxml, NAME);                  \
-	g_signal_connect (G_OBJECT(widget), "changed",                \
-	        G_CALLBACK(save_task_billinfo), dlg);                 \
-	widget; })
+#define BTAGGED(NAME)                                                                       \
+    ({                                                                                      \
+        GtkWidget *widget;                                                                  \
+        widget = glade_xml_get_widget(gtxml, NAME);                                         \
+        g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(save_task_billinfo), dlg); \
+        widget;                                                                             \
+    })
 
-#define TEXTED(NAME) ({                                          \
-	GtkWidget *widget;                                            \
-	GtkTextBuffer *buff;                                          \
-	widget = glade_xml_get_widget (gtxml, NAME);                  \
-	buff = gtk_text_view_get_buffer (GTK_TEXT_VIEW(widget));      \
-	g_signal_connect(G_OBJECT(buff), "changed",                   \
-	        G_CALLBACK(save_task_notes), dlg);                    \
-	widget; })
+#define TEXTED(NAME)                                                                   \
+    ({                                                                                 \
+        GtkWidget *widget;                                                             \
+        GtkTextBuffer *buff;                                                           \
+        widget = glade_xml_get_widget(gtxml, NAME);                                    \
+        buff = gtk_text_view_get_buffer(GTK_TEXT_VIEW(widget));                        \
+        g_signal_connect(G_OBJECT(buff), "changed", G_CALLBACK(save_task_notes), dlg); \
+        widget;                                                                        \
+    })
 
-#define MUGGED(NAME) ({                                          \
-	GtkWidget *widget, *mw;                                       \
-	widget = glade_xml_get_widget (gtxml, NAME);                  \
-	mw = gtk_option_menu_get_menu (GTK_OPTION_MENU(widget));      \
-	g_signal_connect(G_OBJECT(mw), "selection_done",              \
-	         G_CALLBACK(save_task_billinfo), dlg);                \
-	GTK_OPTION_MENU(widget);                                      \
-})
+#define MUGGED(NAME)                                                                           \
+    ({                                                                                         \
+        GtkWidget *widget, *mw;                                                                \
+        widget = glade_xml_get_widget(gtxml, NAME);                                            \
+        mw = gtk_option_menu_get_menu(GTK_OPTION_MENU(widget));                                \
+        g_signal_connect(G_OBJECT(mw), "selection_done", G_CALLBACK(save_task_billinfo), dlg); \
+        GTK_OPTION_MENU(widget);                                                               \
+    })
 
-#define MENTRY(WIDGET,NAME,ORDER,VAL) {                          \
-	GtkWidget *menu_item;                                         \
-	GtkMenu *menu = GTK_MENU(gtk_option_menu_get_menu (WIDGET));  \
-	gtk_option_menu_set_history (WIDGET, ORDER);                  \
-	menu_item =  gtk_menu_get_active(menu);                       \
-	g_object_set_data(G_OBJECT(menu_item), NAME, (gpointer) VAL); \
-}
+#define MENTRY(WIDGET, NAME, ORDER, VAL)                              \
+    {                                                                 \
+        GtkWidget *menu_item;                                         \
+        GtkMenu *menu = GTK_MENU(gtk_option_menu_get_menu(WIDGET));   \
+        gtk_option_menu_set_history(WIDGET, ORDER);                   \
+        menu_item = gtk_menu_get_active(menu);                        \
+        g_object_set_data(G_OBJECT(menu_item), NAME, (gpointer) VAL); \
+    }
 
-
-static  PropTaskDlg *
-prop_task_dialog_new (void)
+static PropTaskDlg *prop_task_dialog_new(void)
 {
-	PropTaskDlg *dlg = NULL;
-	GladeXML *gtxml;
+    PropTaskDlg *dlg = NULL;
+    GladeXML *gtxml;
 
-	dlg = g_new0 (PropTaskDlg, 1);
+    dlg = g_new0(PropTaskDlg, 1);
 
-	gtxml = gtt_glade_xml_new ("glade/task_properties.glade", "Task Properties");
-	dlg->gtxml = gtxml;
+    gtxml = gtt_glade_xml_new("glade/task_properties.glade", "Task Properties");
+    dlg->gtxml = gtxml;
 
-	dlg->dlg = GTK_DIALOG (glade_xml_get_widget (gtxml,  "Task Properties"));
+    dlg->dlg = GTK_DIALOG(glade_xml_get_widget(gtxml, "Task Properties"));
 
-	glade_xml_signal_connect_data (gtxml, "on_help_button_clicked",
-		GTK_SIGNAL_FUNC (gtt_help_popup), "properties");
+    glade_xml_signal_connect_data(
+        gtxml, "on_help_button_clicked", GTK_SIGNAL_FUNC(gtt_help_popup), "properties"
+    );
 
-	glade_xml_signal_connect_data (gtxml, "on_ok_button_clicked",
-		GTK_SIGNAL_FUNC (close_cb), dlg);
+    glade_xml_signal_connect_data(
+        gtxml, "on_ok_button_clicked", GTK_SIGNAL_FUNC(close_cb), dlg
+    );
 
-	g_signal_connect(G_OBJECT(dlg->dlg), "close", G_CALLBACK(close_cb), dlg);
-	g_signal_connect(G_OBJECT(dlg->dlg), "destroy", G_CALLBACK(destroy_cb), dlg);
+    g_signal_connect(G_OBJECT(dlg->dlg), "close", G_CALLBACK(close_cb), dlg);
+    g_signal_connect(G_OBJECT(dlg->dlg), "destroy", G_CALLBACK(destroy_cb), dlg);
 
-	/* ------------------------------------------------------ */
-	/* grab the various entry boxes and hook them up */
+    /* ------------------------------------------------------ */
+    /* grab the various entry boxes and hook them up */
 
-	dlg->memo       = GTK_ENTRY(NTAGGED("memo box"));
-	dlg->notes      = GTK_TEXT_VIEW(TEXTED("notes box"));
+    dlg->memo = GTK_ENTRY(NTAGGED("memo box"));
+    dlg->notes = GTK_TEXT_VIEW(TEXTED("notes box"));
 
-	dlg->billstatus = MUGGED("billstatus menu");
-	dlg->billable   = MUGGED("billable menu");
-	dlg->billrate   = MUGGED("billrate menu");
-	dlg->unit       = GTK_ENTRY(BTAGGED("unit box"));
+    dlg->billstatus = MUGGED("billstatus menu");
+    dlg->billable = MUGGED("billable menu");
+    dlg->billrate = MUGGED("billrate menu");
+    dlg->unit = GTK_ENTRY(BTAGGED("unit box"));
 
-	/* ------------------------------------------------------ */
-	/* associate values with the three option menus */
+    /* ------------------------------------------------------ */
+    /* associate values with the three option menus */
 
-	MENTRY (dlg->billstatus, "billstatus", 0, GTT_HOLD);
-	MENTRY (dlg->billstatus, "billstatus", 1, GTT_BILL);
-	MENTRY (dlg->billstatus, "billstatus", 2, GTT_PAID);
+    MENTRY(dlg->billstatus, "billstatus", 0, GTT_HOLD);
+    MENTRY(dlg->billstatus, "billstatus", 1, GTT_BILL);
+    MENTRY(dlg->billstatus, "billstatus", 2, GTT_PAID);
 
-	MENTRY (dlg->billable, "billable", 0, GTT_BILLABLE);
-	MENTRY (dlg->billable, "billable", 1, GTT_NOT_BILLABLE);
-	MENTRY (dlg->billable, "billable", 2, GTT_NO_CHARGE);
+    MENTRY(dlg->billable, "billable", 0, GTT_BILLABLE);
+    MENTRY(dlg->billable, "billable", 1, GTT_NOT_BILLABLE);
+    MENTRY(dlg->billable, "billable", 2, GTT_NO_CHARGE);
 
-	MENTRY (dlg->billrate, "billrate", 0, GTT_REGULAR);
-	MENTRY (dlg->billrate, "billrate", 1, GTT_OVERTIME);
-	MENTRY (dlg->billrate, "billrate", 2, GTT_OVEROVER);
-	MENTRY (dlg->billrate, "billrate", 3, GTT_FLAT_FEE);
+    MENTRY(dlg->billrate, "billrate", 0, GTT_REGULAR);
+    MENTRY(dlg->billrate, "billrate", 1, GTT_OVERTIME);
+    MENTRY(dlg->billrate, "billrate", 2, GTT_OVEROVER);
+    MENTRY(dlg->billrate, "billrate", 3, GTT_FLAT_FEE);
 
-	dlg->ignore_events = FALSE;
-	dlg->task_freeze = FALSE;
-	gtk_widget_hide_on_delete (GTK_WIDGET(dlg->dlg));
+    dlg->ignore_events = FALSE;
+    dlg->task_freeze = FALSE;
+    gtk_widget_hide_on_delete(GTK_WIDGET(dlg->dlg));
 
-	return dlg;
+    return dlg;
 }
 
 /* ============================================================== */
 
-
-void
-gtt_diary_timer_callback (gpointer nuts)
+void gtt_diary_timer_callback(gpointer nuts)
 {
-	/* If there was a more elegant timer add func,
-	 * we wouldn't need this global */
-	PropTaskDlg *dlg = global_dlog;
-	if (!dlg) return;
-	dlg->ignore_events = TRUE;
-	if (dlg->task_freeze)
-	{
-		gtt_task_thaw (dlg->task);
-		dlg->task_freeze = FALSE;
-	}
-	dlg->ignore_events = FALSE;
+    /* If there was a more elegant timer add func,
+     * we wouldn't need this global */
+    PropTaskDlg *dlg = global_dlog;
+    if (!dlg)
+        return;
+    dlg->ignore_events = TRUE;
+    if (dlg->task_freeze)
+    {
+        gtt_task_thaw(dlg->task);
+        dlg->task_freeze = FALSE;
+    }
+    dlg->ignore_events = FALSE;
 }
 
-void
-prop_task_dialog_show (GttTask *task)
+void prop_task_dialog_show(GttTask *task)
 {
-	GttProject *prj;
-	if (!task) return;
-	if (!global_dlog) global_dlog = prop_task_dialog_new();
+    GttProject *prj;
+    if (!task)
+        return;
+    if (!global_dlog)
+        global_dlog = prop_task_dialog_new();
 
-	do_set_task(task, global_dlog);
-	
-	prj = gtt_task_get_parent (task);
-	gtt_project_add_notifier (prj, redraw, global_dlog);
-	
-	gtk_widget_show(GTK_WIDGET(global_dlog->dlg));
+    do_set_task(task, global_dlog);
+
+    prj = gtt_task_get_parent(task);
+    gtt_project_add_notifier(prj, redraw, global_dlog);
+
+    gtk_widget_show(GTK_WIDGET(global_dlog->dlg));
 }
 
 /* ===================== END OF FILE =========================== */

--- a/src/props-task.h
+++ b/src/props-task.h
@@ -16,7 +16,6 @@
  *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-
 #ifndef __PROPS_TASK_H__
 #define __PROPS_TASK_H__
 
@@ -29,7 +28,6 @@
 void prop_task_dialog_show(GttTask *task);
 
 /* priavte timer func for dealing with fast typeists */
-void gtt_diary_timer_callback (gpointer);
-
+void gtt_diary_timer_callback(gpointer);
 
 #endif /* __PROPS_TASK_H__ */

--- a/src/query.c
+++ b/src/query.c
@@ -21,7 +21,7 @@
 #include <glib.h>
 #include <limits.h>
 
-#include "prefs.h"  /* XXX tmp hack for global config_daystart */
+#include "prefs.h" /* XXX tmp hack for global config_daystart */
 #include "proj.h"
 #include "proj_p.h"
 #include "query.h"
@@ -30,324 +30,320 @@
 
 typedef struct DayArray_s
 {
-	int array_len;           /* same as number of days */
-	GArray *buckets;         /* holds array of GttBucket */
-	int start_cday;          /* day since 1900 */
-	struct tm start_tm;      /* start time struct */
+    int array_len;      /* same as number of days */
+    GArray *buckets;    /* holds array of GttBucket */
+    int start_cday;     /* day since 1900 */
+    struct tm start_tm; /* start time struct */
 } DayArray;
 
-static inline int
-yearday_to_centuryday (int yday, int year)
+static inline int yearday_to_centuryday(int yday, int year)
 {
-	int cd;
-	cd = 365*year + (year-1)/4 + yday;
-  cd -= (year - 1)/100; /* year that are multiple of 100 are not leap years */
-	return cd;
+    int cd;
+    cd = 365 * year + (year - 1) / 4 + yday;
+    cd -= (year - 1) / 100; /* year that are multiple of 100 are not leap years */
+    return cd;
 }
 
 /* ========================================================== */
 /** Sort list of tasks into daily bins */
 
-static int
-day_bin (GttInterval *ivl, gpointer data)
+static int day_bin(GttInterval *ivl, gpointer data)
 {
-	DayArray *da = data;
-	time_t start, start_off, stop, end_of_day;
-	struct tm stm;
-	int century_day, arr_day;
-	GttTask *tsk;
+    DayArray *da = data;
+    time_t start, start_off, stop, end_of_day;
+    struct tm stm;
+    int century_day, arr_day;
+    GttTask *tsk;
 
-	tsk = gtt_interval_get_parent (ivl);
-	start = gtt_interval_get_start (ivl);
-	stop = gtt_interval_get_stop (ivl);
+    tsk = gtt_interval_get_parent(ivl);
+    start = gtt_interval_get_start(ivl);
+    stop = gtt_interval_get_stop(ivl);
 
-	/* Get the starting point in array based on day-of-century */
-	start_off = start - config_daystart_offset;
-	localtime_r (&start_off, &stm);
-	century_day = yearday_to_centuryday (stm.tm_yday, stm.tm_year);
-	arr_day = century_day - da->start_cday;
+    /* Get the starting point in array based on day-of-century */
+    start_off = start - config_daystart_offset;
+    localtime_r(&start_off, &stm);
+    century_day = yearday_to_centuryday(stm.tm_yday, stm.tm_year);
+    arr_day = century_day - da->start_cday;
 
-	/* Loop over days until last day in interval */
-	stm.tm_sec = 0;
-	stm.tm_min = 0;
-	stm.tm_hour = 0;
+    /* Loop over days until last day in interval */
+    stm.tm_sec = 0;
+    stm.tm_min = 0;
+    stm.tm_hour = 0;
 
-	while (1)
-	{
-		/* Check error bounds, should never happen */
-		if ((0 > arr_day) || (arr_day >= da->array_len))
-		{
-			return 1;
-		}
-		GttBucket *bu;
-		bu = &g_array_index (da->buckets, GttBucket, arr_day);
+    while (1)
+    {
+        /* Check error bounds, should never happen */
+        if ((0 > arr_day) || (arr_day >= da->array_len))
+        {
+            return 1;
+        }
+        GttBucket *bu;
+        bu = &g_array_index(da->buckets, GttBucket, arr_day);
 
-		stm.tm_mday ++;
-		end_of_day = mktime (&stm);
-		/* config_daystart_offset==3*3600 means new day starts at 3AM */
-		end_of_day += config_daystart_offset;
-		
-		if (stop < end_of_day)
-		{
-			bu->total += stop - start;
-			bu->intervals = g_list_append (bu->intervals, ivl);
+        stm.tm_mday++;
+        end_of_day = mktime(&stm);
+        /* config_daystart_offset==3*3600 means new day starts at 3AM */
+        end_of_day += config_daystart_offset;
 
-			/* Avoid duplicate tasks by checking if same as last */
-			if (!bu->tasks || (bu->tasks->data != tsk))
-			{
-				bu->tasks = g_list_prepend (bu->tasks, tsk);
-			}
-			return 1;
-		}
-		else
-		{
-			bu->total+= end_of_day - start;
-			bu->intervals = g_list_append (bu->intervals, ivl);
+        if (stop < end_of_day)
+        {
+            bu->total += stop - start;
+            bu->intervals = g_list_append(bu->intervals, ivl);
 
-			/* Avoid duplicate tasks by checking if same as last */
-			if (!bu->tasks || (bu->tasks->data != tsk))
-			{
-				bu->tasks = g_list_prepend (bu->tasks, tsk);
-			}
-		}
-		arr_day ++;
-		start = end_of_day;
-	}
-	
-	return 1;
+            /* Avoid duplicate tasks by checking if same as last */
+            if (!bu->tasks || (bu->tasks->data != tsk))
+            {
+                bu->tasks = g_list_prepend(bu->tasks, tsk);
+            }
+            return 1;
+        }
+        else
+        {
+            bu->total += end_of_day - start;
+            bu->intervals = g_list_append(bu->intervals, ivl);
+
+            /* Avoid duplicate tasks by checking if same as last */
+            if (!bu->tasks || (bu->tasks->data != tsk))
+            {
+                bu->tasks = g_list_prepend(bu->tasks, tsk);
+            }
+        }
+        arr_day++;
+        start = end_of_day;
+    }
+
+    return 1;
 }
 
 /* ========================================================== */
 /** Set up the DayArray object so that the length (in days) is known,
  *  and so that the start day is known
  */
-static void
-count_days (DayArray *da, GttProject *proj, gboolean include_subprojects)
+static void count_days(DayArray *da, GttProject *proj, gboolean include_subprojects)
 {
-	time_t start, stop;
-	int num_days;
+    time_t start, stop;
+    int num_days;
 
-	/* Figure out how many days in the array */
-	start = gtt_project_get_earliest_start (proj, include_subprojects);
-	stop = gtt_project_get_latest_stop (proj, include_subprojects);
-	num_days = (stop - start) / (24*3600);
-	num_days += 2; /* two midnights might be crossed */
+    /* Figure out how many days in the array */
+    start = gtt_project_get_earliest_start(proj, include_subprojects);
+    stop = gtt_project_get_latest_stop(proj, include_subprojects);
+    num_days = (stop - start) / (24 * 3600);
+    num_days += 2; /* two midnights might be crossed */
 
-	da->array_len = num_days+1;
-	
-	localtime_r (&start, &da->start_tm);
-	
-	da->start_cday = yearday_to_centuryday (da->start_tm.tm_yday, da->start_tm.tm_year);
+    da->array_len = num_days + 1;
+
+    localtime_r(&start, &da->start_tm);
+
+    da->start_cday = yearday_to_centuryday(da->start_tm.tm_yday, da->start_tm.tm_year);
 }
 
-
-static void
-run_daily_bins(DayArray *da, GttProject *proj, gboolean include_subprojects)
+static void run_daily_bins(DayArray *da, GttProject *proj, gboolean include_subprojects)
 {
-	int i;
-	
-	/* apply recursively */
-	if (include_subprojects)
-	{
-		gtt_project_foreach_subproject_interval (proj, day_bin, da);
-	}
-	else
-	{
-		gtt_project_foreach_interval (proj, day_bin, da);
-	}
+    int i;
 
-	/* Clean up the taks lists by removing duplicates */
-	for (i=0; i<da->array_len; i++)
-	{
-		GttBucket *bu;
-		GList *node;
-		bu = &g_array_index (da->buckets, GttBucket, i);
+    /* apply recursively */
+    if (include_subprojects)
+    {
+        gtt_project_foreach_subproject_interval(proj, day_bin, da);
+    }
+    else
+    {
+        gtt_project_foreach_interval(proj, day_bin, da);
+    }
 
-		/* Reverse the list, since they went in backwards */
-		bu->tasks = g_list_reverse (bu->tasks);
-		
-		/* Scrub out duplicate task entries */
-		for (node=bu->tasks; node; node=node->next)
-		{
-			GList *sode;
-rerun:
-			for (sode=node->next; sode; sode=sode->next)
-			{
-				if (sode->data == node->data)
-				{
-					sode = g_list_delete_link (node, sode);
-					goto rerun;
-				}
-			}
-		}
-	}
+    /* Clean up the taks lists by removing duplicates */
+    for (i = 0; i < da->array_len; i++)
+    {
+        GttBucket *bu;
+        GList *node;
+        bu = &g_array_index(da->buckets, GttBucket, i);
+
+        /* Reverse the list, since they went in backwards */
+        bu->tasks = g_list_reverse(bu->tasks);
+
+        /* Scrub out duplicate task entries */
+        for (node = bu->tasks; node; node = node->next)
+        {
+            GList *sode;
+        rerun:
+            for (sode = node->next; sode; sode = sode->next)
+            {
+                if (sode->data == node->data)
+                {
+                    sode = g_list_delete_link(node, sode);
+                    goto rerun;
+                }
+            }
+        }
+    }
 }
 
 /* ========================================================== */
 /** Initialize array of buckets */
 
-static void
-init_bins (DayArray *da)
+static void init_bins(DayArray *da)
 {
-	time_t start_of_day, end_of_day;
-	struct tm stm;
-	int i;
+    time_t start_of_day, end_of_day;
+    struct tm stm;
+    int i;
 
-	/* Use system routines to get things like day-light savings
-	 * correct.  Otherwise, we could just have += 24*3600 */
-	stm = da->start_tm;
-	stm.tm_sec = 0;
-	stm.tm_min = 0;
-	stm.tm_hour = 0;
+    /* Use system routines to get things like day-light savings
+     * correct.  Otherwise, we could just have += 24*3600 */
+    stm = da->start_tm;
+    stm.tm_sec = 0;
+    stm.tm_min = 0;
+    stm.tm_hour = 0;
 
-	end_of_day = mktime (&stm);
-	/* config_daystart_offset==3*3600 means new day starts at 3AM */
-	end_of_day += config_daystart_offset;
-	for (i=0; i<da->array_len; i++)
-	{
-		GttBucket *bu;
-		bu = &g_array_index (da->buckets, GttBucket, i);
-		
-		start_of_day = end_of_day;
-		stm.tm_mday ++;
-		end_of_day = mktime (&stm);
-		end_of_day += config_daystart_offset;
-		
-		bu->start = start_of_day;
-		bu->end = end_of_day;
-		bu->total = 0;
-		bu->tasks = NULL;
-		bu->intervals = NULL;
-	}
+    end_of_day = mktime(&stm);
+    /* config_daystart_offset==3*3600 means new day starts at 3AM */
+    end_of_day += config_daystart_offset;
+    for (i = 0; i < da->array_len; i++)
+    {
+        GttBucket *bu;
+        bu = &g_array_index(da->buckets, GttBucket, i);
+
+        start_of_day = end_of_day;
+        stm.tm_mday++;
+        end_of_day = mktime(&stm);
+        end_of_day += config_daystart_offset;
+
+        bu->start = start_of_day;
+        bu->end = end_of_day;
+        bu->total = 0;
+        bu->tasks = NULL;
+        bu->intervals = NULL;
+    }
 }
 
 /* ========================================================== */
 
-GArray *
-gtt_project_get_daily_buckets (GttProject *proj, gboolean include_subprojects)
+GArray *gtt_project_get_daily_buckets(GttProject *proj, gboolean include_subprojects)
 {
-	DayArray da;
-	GArray *arr = NULL;
+    DayArray da;
+    GArray *arr = NULL;
 
-	if (!proj) return NULL;
-	
-	/* Figure out how many days in the array */
-	count_days (&da, proj, include_subprojects);
-	if (0 > da.array_len) return NULL;
+    if (!proj)
+        return NULL;
 
-	/* Alloc the array, fill it in, return the results */
-	arr = g_array_new (FALSE, TRUE, sizeof (GttBucket));
-	g_array_set_size (arr, da.array_len);
+    /* Figure out how many days in the array */
+    count_days(&da, proj, include_subprojects);
+    if (0 > da.array_len)
+        return NULL;
 
-	da.buckets = arr;
-	init_bins (&da);
-	run_daily_bins (&da, proj, include_subprojects);
+    /* Alloc the array, fill it in, return the results */
+    arr = g_array_new(FALSE, TRUE, sizeof(GttBucket));
+    g_array_set_size(arr, da.array_len);
 
-	return arr;
+    da.buckets = arr;
+    init_bins(&da);
+    run_daily_bins(&da, proj, include_subprojects);
+
+    return arr;
 }
 
 /* ========================================================== */
 
-int
-gtt_project_foreach_interval (GttProject *proj, GttIntervalCB cb, gpointer data)
+int gtt_project_foreach_interval(GttProject *proj, GttIntervalCB cb, gpointer data)
 {
-	int rc = 1;
-	GList *tnode, *inode;
-	
-	/* Get the list of tasks, and walk the list.  We are not
-	 * going to assume that the list is ordered in any way.
-	 */
-	tnode = gtt_project_get_tasks (proj);
-	for (; tnode; tnode=tnode->next)
-	{
-		GttTask *tsk = tnode->data;
-		inode = gtt_task_get_intervals (tsk);
-		for (; inode; inode=inode->next)
-		{
-			GttInterval *iv = inode->data;
-			rc = cb (iv, data);
-			if (0 == rc) return rc;
-		}
-	}
-	return rc;
+    int rc = 1;
+    GList *tnode, *inode;
+
+    /* Get the list of tasks, and walk the list.  We are not
+     * going to assume that the list is ordered in any way.
+     */
+    tnode = gtt_project_get_tasks(proj);
+    for (; tnode; tnode = tnode->next)
+    {
+        GttTask *tsk = tnode->data;
+        inode = gtt_task_get_intervals(tsk);
+        for (; inode; inode = inode->next)
+        {
+            GttInterval *iv = inode->data;
+            rc = cb(iv, data);
+            if (0 == rc)
+                return rc;
+        }
+    }
+    return rc;
 }
 
-int
-gtt_project_foreach_subproject_interval (GttProject *proj,
-					 GttIntervalCB cb, gpointer data)
+int gtt_project_foreach_subproject_interval(GttProject *proj, GttIntervalCB cb, gpointer data)
 {
-	int rc = 0;
-	GList *pnode;
-	
-	rc = gtt_project_foreach_interval (proj, cb, data);
-	if (0 == rc) return 0;
-	
-	/* Apply to the list of subprojects. */
-	pnode = gtt_project_get_children (proj);
-	for (; pnode; pnode=pnode->next)
-	{
-		GttProject *p = pnode->data;
-		rc = gtt_project_foreach_subproject_interval (p, cb, data);
-		if (0 == rc) return 0;
-	}
-	return rc;
+    int rc = 0;
+    GList *pnode;
+
+    rc = gtt_project_foreach_interval(proj, cb, data);
+    if (0 == rc)
+        return 0;
+
+    /* Apply to the list of subprojects. */
+    pnode = gtt_project_get_children(proj);
+    for (; pnode; pnode = pnode->next)
+    {
+        GttProject *p = pnode->data;
+        rc = gtt_project_foreach_subproject_interval(p, cb, data);
+        if (0 == rc)
+            return 0;
+    }
+    return rc;
 }
 
 /* ========================================================== */
 
-static int cmp_earliest (GttInterval *ivl, gpointer data)
+static int cmp_earliest(GttInterval *ivl, gpointer data)
 {
-	time_t * earliest = data;
-	time_t s = gtt_interval_get_start (ivl);
-	if (s < *earliest) *earliest = s;
-	return 1;
+    time_t *earliest = data;
+    time_t s = gtt_interval_get_start(ivl);
+    if (s < *earliest)
+        *earliest = s;
+    return 1;
 }
 
-static int cmp_latest (GttInterval *ivl, gpointer data)
+static int cmp_latest(GttInterval *ivl, gpointer data)
 {
-	time_t * latest = data;
-	time_t s = gtt_interval_get_stop (ivl);
-	if (s > *latest) *latest = s;
-	return 1;
+    time_t *latest = data;
+    time_t s = gtt_interval_get_stop(ivl);
+    if (s > *latest)
+        *latest = s;
+    return 1;
 }
 
-time_t
-gtt_project_get_earliest_start (GttProject *proj, gboolean include_subprojects)
+time_t gtt_project_get_earliest_start(GttProject *proj, gboolean include_subprojects)
 {
-	time_t earliest;
-	
-	earliest = INT_MAX;
-	if (!proj) return  earliest;
-	
-	if (include_subprojects)
-	{
-		gtt_project_foreach_subproject_interval (proj, cmp_earliest, &earliest);
-	}
-	else
-	{
-		gtt_project_foreach_interval (proj, cmp_earliest, &earliest);
-	}
-	return earliest;
+    time_t earliest;
+
+    earliest = INT_MAX;
+    if (!proj)
+        return earliest;
+
+    if (include_subprojects)
+    {
+        gtt_project_foreach_subproject_interval(proj, cmp_earliest, &earliest);
+    }
+    else
+    {
+        gtt_project_foreach_interval(proj, cmp_earliest, &earliest);
+    }
+    return earliest;
 }
 
-
-time_t
-gtt_project_get_latest_stop (GttProject *proj, gboolean include_subprojects)
+time_t gtt_project_get_latest_stop(GttProject *proj, gboolean include_subprojects)
 {
-	time_t latest;
-	
-	latest = 0;
-	if (!proj) return  latest;
-	
-	if (include_subprojects)
-	{
-		gtt_project_foreach_subproject_interval (proj, cmp_latest, &latest);
-	}
-	else
-	{
-		gtt_project_foreach_interval (proj, cmp_latest, &latest);
-	}
-	return latest;
+    time_t latest;
+
+    latest = 0;
+    if (!proj)
+        return latest;
+
+    if (include_subprojects)
+    {
+        gtt_project_foreach_subproject_interval(proj, cmp_latest, &latest);
+    }
+    else
+    {
+        gtt_project_foreach_interval(proj, cmp_latest, &latest);
+    }
+    return latest;
 }
 
 /* =========================== END OF FILE ========================= */

--- a/src/query.h
+++ b/src/query.h
@@ -19,8 +19,8 @@
 #ifndef __GTT_QUERY_H__
 #define __GTT_QUERY_H__
 
-#include <glib.h>
 #include "proj.h"
+#include <glib.h>
 
 /* This file contains routines that return various info about
  * the data in the system.  In some fancier world, these would
@@ -41,13 +41,12 @@ typedef struct GttBucket_s GttBucket;
 
 struct GttBucket_s
 {
-	time_t start;     /* Start time that defines this bucket */
-	time_t end;       /* End time that defines this bucket */
-	time_t total;     /* Total amount of time in the bucket */
-	GList *tasks;     /* List of GttTasks in the bucket */
-	GList *intervals; /* List of GttIntervals in the bucket */
+    time_t start;     /* Start time that defines this bucket */
+    time_t end;       /* End time that defines this bucket */
+    time_t total;     /* Total amount of time in the bucket */
+    GList *tasks;     /* List of GttTasks in the bucket */
+    GList *intervals; /* List of GttIntervals in the bucket */
 };
-
 
 /* The following routines are needed to implement a
  *    calendar report in GTT.
@@ -81,13 +80,10 @@ struct GttBucket_s
  *    included in the day totals.
  */
 
-GArray * gtt_project_get_daily_buckets (GttProject *proj,
-					      gboolean include_subprojects);
+GArray *gtt_project_get_daily_buckets(GttProject *proj, gboolean include_subprojects);
 
-time_t   gtt_project_get_earliest_start (GttProject *proj,
-					      gboolean include_subprojects);
+time_t gtt_project_get_earliest_start(GttProject *proj, gboolean include_subprojects);
 
-time_t   gtt_project_get_latest_stop (GttProject *proj,
-					      gboolean include_subprojects);
+time_t gtt_project_get_latest_stop(GttProject *proj, gboolean include_subprojects);
 
 #endif /* __GTT_QUERY_H__ */

--- a/src/status-icon.c
+++ b/src/status-icon.c
@@ -26,82 +26,82 @@
  * Modified by:   Goedson Teixeira Paixao <goedson@debian.org>
  ********************************************************************/
 
-#include <gtk/gtk.h>
-#include <gnome.h>
 #include "status-icon.h"
 #include "timer.h"
+#include <gnome.h>
+#include <gtk/gtk.h>
 
-extern GtkWidget *app_window;  /* global top-level window */
+extern GtkWidget *app_window; /* global top-level window */
 
 static GtkStatusIcon *status_icon;
 static gboolean timer_active;
 
-static void
-status_icon_activated(GtkStatusIcon *status_icon, gpointer data)
+static void status_icon_activated(GtkStatusIcon *status_icon, gpointer data)
 {
-	if (timer_active)
-	{
-		gen_stop_timer();
-	}
-	else
-	{
-		gen_start_timer();
-	}
+    if (timer_active)
+    {
+        gen_stop_timer();
+    }
+    else
+    {
+        gen_start_timer();
+    }
 }
 
-static void
-status_icon_menuitem_visibility(GtkWidget *toggle, gpointer *user_data)
+static void status_icon_menuitem_visibility(GtkWidget *toggle, gpointer *user_data)
 {
-	if (GTK_WIDGET_VISIBLE(app_window))
-		gtk_widget_hide(app_window);
-	else
-		gtk_widget_show(app_window);
+    if (GTK_WIDGET_VISIBLE(app_window))
+        gtk_widget_hide(app_window);
+    else
+        gtk_widget_show(app_window);
 }
 
-static void
-status_icon_popup_menu(GtkStatusIcon *status_icon, guint button, guint activate_time, gpointer user_data)
+static void status_icon_popup_menu(
+    GtkStatusIcon *status_icon, guint button, guint activate_time, gpointer user_data
+)
 {
-	GtkWidget *menu = gtk_menu_new ();
-	GtkWidget *menuitem = gtk_check_menu_item_new_with_mnemonic (_("_Hide main window"));
-	gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (menuitem), !GTK_WIDGET_VISIBLE(app_window));
-	g_signal_connect (G_OBJECT (menuitem), "toggled", G_CALLBACK (status_icon_menuitem_visibility), NULL);
-	gtk_menu_shell_append (GTK_MENU_SHELL (menu), menuitem);
-	gtk_widget_show_all (menu);
-	gtk_menu_popup (GTK_MENU(menu), NULL, NULL, NULL, NULL, button, activate_time);
+    GtkWidget *menu = gtk_menu_new();
+    GtkWidget *menuitem = gtk_check_menu_item_new_with_mnemonic(_("_Hide main window"));
+    gtk_check_menu_item_set_active(
+        GTK_CHECK_MENU_ITEM(menuitem), !GTK_WIDGET_VISIBLE(app_window)
+    );
+    g_signal_connect(
+        G_OBJECT(menuitem), "toggled", G_CALLBACK(status_icon_menuitem_visibility), NULL
+    );
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
+    gtk_widget_show_all(menu);
+    gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL, button, activate_time);
 }
 
-void
-gtt_status_icon_create()
+void gtt_status_icon_create()
 {
-	status_icon = gtk_status_icon_new_from_stock (GNOME_STOCK_TIMER_STOP);
-	gtk_status_icon_set_tooltip (status_icon, _("Timer is not running"));
-	g_signal_connect (G_OBJECT(status_icon), "activate", G_CALLBACK(status_icon_activated), NULL);
-	g_signal_connect (G_OBJECT(status_icon), "popup-menu", G_CALLBACK(status_icon_popup_menu), NULL);
+    status_icon = gtk_status_icon_new_from_stock(GNOME_STOCK_TIMER_STOP);
+    gtk_status_icon_set_tooltip(status_icon, _("Timer is not running"));
+    g_signal_connect(
+        G_OBJECT(status_icon), "activate", G_CALLBACK(status_icon_activated), NULL
+    );
+    g_signal_connect(
+        G_OBJECT(status_icon), "popup-menu", G_CALLBACK(status_icon_popup_menu), NULL
+    );
 }
 
-void
-gtt_status_icon_destroy()
+void gtt_status_icon_destroy()
 {
-	g_object_unref (G_OBJECT (status_icon));
+    g_object_unref(G_OBJECT(status_icon));
 }
 
-void
-gtt_status_icon_start_timer(GttProject *prj)
+void gtt_status_icon_start_timer(GttProject *prj)
 {
-	gtk_status_icon_set_from_stock (status_icon, GNOME_STOCK_TIMER);
-	gchar *text = g_strdup_printf(_("Timer running for %s"),
-								  gtt_project_get_title(prj));
-	gtk_status_icon_set_tooltip(status_icon, text);
-	g_free (text);
-	timer_active = TRUE;
+    gtk_status_icon_set_from_stock(status_icon, GNOME_STOCK_TIMER);
+    gchar *text = g_strdup_printf(_("Timer running for %s"), gtt_project_get_title(prj));
+    gtk_status_icon_set_tooltip(status_icon, text);
+    g_free(text);
+    timer_active = TRUE;
 }
 
-
-void
-gtt_status_icon_stop_timer(GttProject *prj)
+void gtt_status_icon_stop_timer(GttProject *prj)
 {
-	gtk_status_icon_set_tooltip (status_icon, _("Timer is not running"));
-	gtk_status_icon_set_from_stock (status_icon, GNOME_STOCK_TIMER_STOP);
-	timer_active = FALSE;
+    gtk_status_icon_set_tooltip(status_icon, _("Timer is not running"));
+    gtk_status_icon_set_from_stock(status_icon, GNOME_STOCK_TIMER_STOP);
+    timer_active = FALSE;
 }
-

--- a/src/status-icon.h
+++ b/src/status-icon.h
@@ -26,8 +26,8 @@
  * Modified by:   Goedson Teixeira Paixao <goedson@debian.org>
  ********************************************************************/
 
-#include <glib.h>
 #include "proj.h"
+#include <glib.h>
 
 void gtt_status_icon_create();
 void gtt_status_icon_destroy();

--- a/src/timer.c
+++ b/src/timer.c
@@ -30,12 +30,12 @@
 #include "notes-area.h"
 #include "prefs.h"
 #include "proj.h"
+#include "projects-tree.h"
 #include "props-task.h"
 #include "timer.h"
-#include "projects-tree.h"
 
 int config_autosave_period = 60;
-int config_autosave_props_period = (4*3600);
+int config_autosave_props_period = (4 * 3600);
 
 static gint main_timer = 0;
 static gint file_save_timer = 0;
@@ -49,189 +49,170 @@ static GttActiveDialog *active_dialog = NULL;
 static int day_last_reset = -1;
 static int year_last_reset = -1;
 
-void
-set_last_reset (time_t last)
+void set_last_reset(time_t last)
 {
-	struct tm *t0;
-	t0 = localtime (&last);
-	day_last_reset = t0->tm_yday;
-	year_last_reset = t0->tm_year;
+    struct tm *t0;
+    t0 = localtime(&last);
+    day_last_reset = t0->tm_yday;
+    year_last_reset = t0->tm_year;
 }
 
+static void schedule_zero_daily_counters_timer(void);
 
-static void schedule_zero_daily_counters_timer (void);
-
-gint
-zero_daily_counters (gpointer data)
+gint zero_daily_counters(gpointer data)
 {
-	struct tm *t1;
-	time_t now = time(0);
+    struct tm *t1;
+    time_t now = time(0);
 
-	/* zero out day counts */
-	t1 = localtime(&now);
-	if ((year_last_reset != t1->tm_year) ||
-		(day_last_reset != t1->tm_yday))
-	{
-		gtt_project_list_compute_secs ();
-		gtt_projects_tree_update_all_rows (projects_tree);
-		log_endofday();
-		year_last_reset = t1->tm_year;
-		day_last_reset = t1->tm_yday;
-	}
-	schedule_zero_daily_counters_timer ();
-	return 0;
+    /* zero out day counts */
+    t1 = localtime(&now);
+    if ((year_last_reset != t1->tm_year) || (day_last_reset != t1->tm_yday))
+    {
+        gtt_project_list_compute_secs();
+        gtt_projects_tree_update_all_rows(projects_tree);
+        log_endofday();
+        year_last_reset = t1->tm_year;
+        day_last_reset = t1->tm_yday;
+    }
+    schedule_zero_daily_counters_timer();
+    return 0;
 }
 
 /* =========================================================== */
 
-static gint
-file_save_timer_func (gpointer data)
+static gint file_save_timer_func(gpointer data)
 {
-	save_projects ();
-	return 1;
+    save_projects();
+    return 1;
 }
 
-static gint
-config_save_timer_func (gpointer data)
+static gint config_save_timer_func(gpointer data)
 {
-	save_properties ();
-	return 1;
+    save_properties();
+    return 1;
 }
 
-static gint
-main_timer_func(gpointer data)
+static gint main_timer_func(gpointer data)
 {
-	/* Wake up the notes area GUI, if needed. */
-	gtt_notes_timer_callback (global_na);
-	gtt_diary_timer_callback (NULL);
+    /* Wake up the notes area GUI, if needed. */
+    gtt_notes_timer_callback(global_na);
+    gtt_diary_timer_callback(NULL);
 
-	if (!cur_proj)
-	{
-		main_timer = 0;
-		return 0;
-	}
+    if (!cur_proj)
+    {
+        main_timer = 0;
+        return 0;
+    }
 
-	/* Update the data in the data engine. */
-	gtt_project_timer_update (cur_proj);
-	gtt_projects_tree_update_project_data (projects_tree, cur_proj);
-	update_status_bar ();
-	return 1;
+    /* Update the data in the data engine. */
+    gtt_project_timer_update(cur_proj);
+    gtt_projects_tree_update_project_data(projects_tree, cur_proj);
+    update_status_bar();
+    return 1;
 }
 
 static gboolean timer_inited = FALSE;
 
-void
-start_main_timer (void)
+void start_main_timer(void)
 {
-	if (main_timer)
-	{
-		g_source_remove (main_timer);
-	}
+    if (main_timer)
+    {
+        g_source_remove(main_timer);
+    }
 
-	/* If we're showing seconds, call the timer routine once a second */
-	/* else, do it once a minute */
-	if (config_show_secs)
-	{
-		main_timer = g_timeout_add_seconds (1, main_timer_func, NULL);
-	}
-	else
-	{
-		main_timer = g_timeout_add_seconds (60, main_timer_func, NULL);
-	}
+    /* If we're showing seconds, call the timer routine once a second */
+    /* else, do it once a minute */
+    if (config_show_secs)
+    {
+        main_timer = g_timeout_add_seconds(1, main_timer_func, NULL);
+    }
+    else
+    {
+        main_timer = g_timeout_add_seconds(60, main_timer_func, NULL);
+    }
 }
 
-static void
-start_file_save_timer (void)
+static void start_file_save_timer(void)
 {
-	g_return_if_fail (!file_save_timer);
-	file_save_timer = g_timeout_add_seconds (config_autosave_period,
-											 file_save_timer_func, NULL);
+    g_return_if_fail(!file_save_timer);
+    file_save_timer = g_timeout_add_seconds(config_autosave_period, file_save_timer_func, NULL);
 }
 
-static void
-start_config_save_timer (void)
+static void start_config_save_timer(void)
 {
-	g_return_if_fail (!config_save_timer);
-	config_save_timer = g_timeout_add_seconds (config_autosave_props_period,
-											   config_save_timer_func, NULL);
+    g_return_if_fail(!config_save_timer);
+    config_save_timer
+        = g_timeout_add_seconds(config_autosave_props_period, config_save_timer_func, NULL);
 }
 
-
-
-void
-stop_main_timer (void)
+void stop_main_timer(void)
 {
-	if (cur_proj)
-	{
-		/* Update the data in the data engine. */
-		gtt_project_timer_update (cur_proj);
-	}
-	g_return_if_fail (main_timer);
-	g_source_remove (main_timer);
-	main_timer = 0;
+    if (cur_proj)
+    {
+        /* Update the data in the data engine. */
+        gtt_project_timer_update(cur_proj);
+    }
+    g_return_if_fail(main_timer);
+    g_source_remove(main_timer);
+    main_timer = 0;
 }
 
-void
-init_timer(void)
+void init_timer(void)
 {
-	if (timer_inited) return;   // prevent multiple initialization
-	timer_inited = TRUE;
+    if (timer_inited)
+        return; // prevent multiple initialization
+    timer_inited = TRUE;
 
-	idle_dialog = idle_dialog_new();
-	active_dialog = active_dialog_new();
+    idle_dialog = idle_dialog_new();
+    active_dialog = active_dialog_new();
 
-	start_main_timer ();
-	start_file_save_timer ();
-	start_config_save_timer ();
+    start_main_timer();
+    start_file_save_timer();
+    start_config_save_timer();
 }
 
-gboolean
-timer_is_running (void)
+gboolean timer_is_running(void)
 {
-	return (NULL != cur_proj);
+    return (NULL != cur_proj);
 }
 
-void
-start_idle_timer (void)
+void start_idle_timer(void)
 {
-	if (!timer_inited)
-	{
-		init_timer();
-	}
+    if (!timer_inited)
+    {
+        init_timer();
+    }
 
-	if (timer_is_running ())
-	{
-		idle_dialog_activate_timer (idle_dialog);
-		active_dialog_deactivate_timer (active_dialog);
-	}
+    if (timer_is_running())
+    {
+        idle_dialog_activate_timer(idle_dialog);
+        active_dialog_deactivate_timer(active_dialog);
+    }
 }
 
-void
-start_no_project_timer (void)
+void start_no_project_timer(void)
 {
-	if (!timer_inited)
-	{
-		init_timer();
-	}
-	if (!idle_dialog_is_visible (idle_dialog) && !timer_is_running ())
-	{
-		idle_dialog_deactivate_timer (idle_dialog);
-		active_dialog_activate_timer (active_dialog);
-	}
+    if (!timer_inited)
+    {
+        init_timer();
+    }
+    if (!idle_dialog_is_visible(idle_dialog) && !timer_is_running())
+    {
+        idle_dialog_deactivate_timer(idle_dialog);
+        active_dialog_activate_timer(active_dialog);
+    }
 }
 
-static void
-schedule_zero_daily_counters_timer (void)
+static void schedule_zero_daily_counters_timer(void)
 {
-	time_t now = time(0);
-	time_t timeout = 3600 - (now % 3600);
-	g_timeout_add_seconds (timeout, zero_daily_counters, NULL);
+    time_t now = time(0);
+    time_t timeout = 3600 - (now % 3600);
+    g_timeout_add_seconds(timeout, zero_daily_counters, NULL);
 }
 
-gboolean
-timer_project_is_running (GttProject *prj)
+gboolean timer_project_is_running(GttProject *prj)
 {
-	return (prj == cur_proj);
+    return (prj == cur_proj);
 }
 
 /* ========================== END OF FILE ============================ */

--- a/src/timer.h
+++ b/src/timer.h
@@ -32,8 +32,8 @@
 #include "proj.h"
 
 void init_timer(void);
-gboolean timer_is_running (void);
-gboolean timer_project_is_running (GttProject *prj);
+gboolean timer_is_running(void);
+gboolean timer_project_is_running(GttProject *prj);
 /* The idle timeout is how long, in seconds, that the system seems idle
  * before the clock stops itself */
 extern int config_idle_timeout;
@@ -43,16 +43,16 @@ extern int config_no_project_timeout;
  * periodic save-thyself. */
 extern int config_autosave_period;
 
-gint zero_daily_counters (gpointer data);
-void set_last_reset (time_t last);
+gint zero_daily_counters(gpointer data);
+void set_last_reset(time_t last);
 
 void gen_start_timer(void);
 void gen_stop_timer(void);
 
-void start_no_project_timer ();
-void start_idle_timer ();
+void start_no_project_timer();
+void start_idle_timer();
 
-void start_main_timer ();
-void stop_main_timer ();
+void start_main_timer();
+void stop_main_timer();
 
 #endif /* __GTT_TIMER_H__ */

--- a/src/toolbar.c
+++ b/src/toolbar.c
@@ -36,22 +36,22 @@ typedef struct _MyToolbar MyToolbar;
 
 struct _MyToolbar
 {
-	GtkToolbar *tbar;
-	GtkToolbar *null_tbar;
-	GtkWidget *new_w;
-	GtkWidget *cut, *copy, *paste; /* to make them sensible as needed */
-	GtkWidget *journal_button;
-	GtkWidget *prop_w;
-	GtkWidget *timer_button;
-	GtkImage  *timer_button_image;
-	GtkWidget *calendar_w;
-	GtkWidget *pref;
-	GtkWidget *help;
-	GtkWidget *exit;
+    GtkToolbar *tbar;
+    GtkToolbar *null_tbar;
+    GtkWidget *new_w;
+    GtkWidget *cut, *copy, *paste; /* to make them sensible as needed */
+    GtkWidget *journal_button;
+    GtkWidget *prop_w;
+    GtkWidget *timer_button;
+    GtkImage *timer_button_image;
+    GtkWidget *calendar_w;
+    GtkWidget *pref;
+    GtkWidget *help;
+    GtkWidget *exit;
 
-	int spa;
-	int spb;
-	int spc;
+    int spa;
+    int spb;
+    int spc;
 };
 
 MyToolbar *mytbar = NULL;
@@ -63,69 +63,62 @@ MyToolbar *mytbar = NULL;
  * image when a project timer is started/stopped.
  */
 
-void
-toolbar_set_states(void)
+void toolbar_set_states(void)
 {
-	g_return_if_fail(mytbar != NULL);
-	g_return_if_fail(mytbar->tbar != NULL);
-	g_return_if_fail(GTK_IS_TOOLBAR(mytbar->tbar));
+    g_return_if_fail(mytbar != NULL);
+    g_return_if_fail(mytbar->tbar != NULL);
+    g_return_if_fail(GTK_IS_TOOLBAR(mytbar->tbar));
 
-	if (config_show_toolbar)
-	{
-		update_toolbar_sections();
-	}
-	else
-	{
-		/* Rebuild the toolbar so that it is really hidden. There should be
-		   a better way of doing this.
-		*/
-		update_toolbar_sections();
-		return;
-	}
+    if (config_show_toolbar)
+    {
+        update_toolbar_sections();
+    }
+    else
+    {
+        /* Rebuild the toolbar so that it is really hidden. There should be
+           a better way of doing this.
+        */
+        update_toolbar_sections();
+        return;
+    }
 
-	if (mytbar->tbar && mytbar->tbar->tooltips)
-	{
-		if (config_show_tb_tips)
-			gtk_tooltips_enable(mytbar->tbar->tooltips);
-		else
-			gtk_tooltips_disable(mytbar->tbar->tooltips);
-	}
+    if (mytbar->tbar && mytbar->tbar->tooltips)
+    {
+        if (config_show_tb_tips)
+            gtk_tooltips_enable(mytbar->tbar->tooltips);
+        else
+            gtk_tooltips_disable(mytbar->tbar->tooltips);
+    }
 
-	if (mytbar->paste)
-	{
-		gtk_widget_set_sensitive(mytbar->paste, have_cutted_project());
-	}
+    if (mytbar->paste)
+    {
+        gtk_widget_set_sensitive(mytbar->paste, have_cutted_project());
+    }
 
-	if (mytbar->timer_button_image)
-	{
-		gtk_image_set_from_stock (mytbar->timer_button_image,
-				 ((timer_is_running()) ?
-				     GNOME_STOCK_TIMER_STOP :
-				     GNOME_STOCK_TIMER),
-				 GTK_ICON_SIZE_LARGE_TOOLBAR);
-	}
+    if (mytbar->timer_button_image)
+    {
+        gtk_image_set_from_stock(
+            mytbar->timer_button_image,
+            ((timer_is_running()) ? GNOME_STOCK_TIMER_STOP : GNOME_STOCK_TIMER),
+            GTK_ICON_SIZE_LARGE_TOOLBAR
+        );
+    }
 }
 
 /* ================================================================= */
 /* A small utility routine to use a stock image with custom text,
  * and put the whole thing into the toolbar
  */
-static GtkWidget *
-toolbar_append_stock_button (GtkToolbar *toolbar,
-                             const gchar *text,
-                             const gchar *tooltip_text,
-                             const gchar *stock_icon_id,
-                             GtkSignalFunc callback,
-                             gpointer user_data)
+static GtkWidget *toolbar_append_stock_button(
+    GtkToolbar *toolbar, const gchar *text, const gchar *tooltip_text,
+    const gchar *stock_icon_id, GtkSignalFunc callback, gpointer user_data
+)
 {
-	GtkWidget *w, *image;
+    GtkWidget *w, *image;
 
-	image = gtk_image_new_from_stock (stock_icon_id,
-	                GTK_ICON_SIZE_LARGE_TOOLBAR);
-	w = gtk_toolbar_append_item(toolbar, text, tooltip_text,
-	                NULL, image,
-	                callback, user_data);
-	return w;
+    image = gtk_image_new_from_stock(stock_icon_id, GTK_ICON_SIZE_LARGE_TOOLBAR);
+    w = gtk_toolbar_append_item(toolbar, text, tooltip_text, NULL, image, callback, user_data);
+    return w;
 }
 
 /* ================================================================= */
@@ -134,182 +127,175 @@ toolbar_append_stock_button (GtkToolbar *toolbar,
  * Returns a pointer to the (still hidden) GtkToolbar
  */
 
-GtkWidget *
-build_toolbar(void)
+GtkWidget *build_toolbar(void)
 {
-	int position = 0;
-	if (!mytbar)
-	{
-		mytbar = g_malloc0(sizeof(MyToolbar));
-		mytbar->tbar = GTK_TOOLBAR(gtk_toolbar_new());
-		mytbar->null_tbar = GTK_TOOLBAR(gtk_toolbar_new());
-	}
+    int position = 0;
+    if (!mytbar)
+    {
+        mytbar = g_malloc0(sizeof(MyToolbar));
+        mytbar->tbar = GTK_TOOLBAR(gtk_toolbar_new());
+        mytbar->null_tbar = GTK_TOOLBAR(gtk_toolbar_new());
+    }
 
-	if (config_show_toolbar)
-	{
-		if (config_show_tb_new)
-		{
-			mytbar->new_w = gtk_toolbar_insert_stock (mytbar->tbar,
-													  GTK_STOCK_NEW,
-													  _("Create a New Project..."), NULL,
-													  (GtkSignalFunc)new_project, NULL,
-													  position++);
-			gtk_toolbar_append_space(mytbar->tbar);
-			mytbar->spa = position;
-			position ++;
-		}
-		if (config_show_tb_ccp)
-		{
-			mytbar->cut = gtk_toolbar_insert_stock (mytbar->tbar,
-													GTK_STOCK_CUT,
-													_("Cut Selected Project"), NULL,
-													(GtkSignalFunc)cut_project, NULL,
-													position ++);
-			mytbar->copy = gtk_toolbar_insert_stock (mytbar->tbar,
-													 GTK_STOCK_COPY,
-													 _("Copy Selected Project"), NULL,
-													 (GtkSignalFunc)copy_project, NULL,
-													 position ++);
-			mytbar->paste = gtk_toolbar_insert_stock (mytbar->tbar,
-													  GTK_STOCK_PASTE,
-													  _("Paste Project"), NULL,
-													  (GtkSignalFunc)paste_project, NULL,
-													  position ++);
-			gtk_toolbar_append_space(mytbar->tbar);
-			mytbar->spb = position;
-			if (mytbar->spa) mytbar->spb--;
-			position ++;
-		}
-		if (config_show_tb_journal)
-		{
-			/* There is no true 'stock' item for journal, so
-			 * instead we draw our own button, and use a stock
-			 * image. */
-			mytbar->journal_button = toolbar_append_stock_button(mytbar->tbar,
-																 _("Activity Journal"),
-																 _("View and Edit Timestamp Logs"),
-																 GNOME_STOCK_BOOK_OPEN,
-																 (GtkSignalFunc) show_report, ACTIVITY_REPORT);
-			position ++;
-		}
-		if (config_show_tb_prop)
-		{
-			mytbar->prop_w = gtk_toolbar_insert_stock (mytbar->tbar,
-													   GTK_STOCK_PROPERTIES,
-													   _("Edit Project Properties..."), NULL,
-													   (GtkSignalFunc) menu_properties, NULL,
-													   position ++);
-		}
-		if (config_show_tb_timer)
-		{
-			/* There is no true 'stock' item for timer, so
-			 * instead we draw our own button, and use a
-			 * pair of stock images to toggle between.
-			 */
-			mytbar->timer_button_image = GTK_IMAGE(gtk_image_new());
-			gtk_image_set_from_stock (mytbar->timer_button_image,
-									  GNOME_STOCK_TIMER, GTK_ICON_SIZE_LARGE_TOOLBAR);
-			
-			mytbar->timer_button =
-				gtk_toolbar_append_item(mytbar->tbar,
-										_("Timer"),
-										_("Start/Stop Timer"),
-										NULL,
-										GTK_WIDGET(mytbar->timer_button_image),
-										(GtkSignalFunc) menu_toggle_timer, NULL);
-			position ++;
-		}
-		if (config_show_tb_calendar)
-		{
-			mytbar->calendar_w = toolbar_append_stock_button(mytbar->tbar,
-															 _("Calendar"),
-															 _("View Calendar"),
-															 GNOME_STOCK_TEXT_BULLETED_LIST,
-															 (GtkSignalFunc)edit_calendar, NULL);
-			position ++;
-		}
-		if (((config_show_tb_timer)    ||
-			 (config_show_tb_journal)  ||
-			 (config_show_tb_calendar) ||
-			 (config_show_tb_prop)     ) &&
-			((config_show_tb_pref) ||
-			 (config_show_tb_help) ||
-			 (config_show_tb_exit)))
-		{
-			gtk_toolbar_append_space(mytbar->tbar);
-			mytbar->spc = position;
-			if (mytbar->spa) mytbar->spc--;
-			if (mytbar->spb) mytbar->spc--;
-			position ++;
-		}
-		if (config_show_tb_pref)
-		{
-			mytbar->pref = gtk_toolbar_insert_stock (mytbar->tbar,
-													 GTK_STOCK_PREFERENCES,
-													 _("Edit Preferences..."), NULL,
-													 (GtkSignalFunc)menu_options, NULL,
-													 position ++);
-		}
-		if (config_show_tb_help)
-		{
-			mytbar->help = gtk_toolbar_insert_stock (mytbar->tbar,
-													 GTK_STOCK_HELP,
-													 _("User's Guide and Manual"), NULL,
-													 (GtkSignalFunc)gtt_help_popup, NULL,
-													 position ++);
-		}
-		if (config_show_tb_exit)
-		{
-			mytbar->exit = gtk_toolbar_insert_stock (mytbar->tbar,
-													 GTK_STOCK_QUIT,
-													 _("Quit GnoTime"), NULL,
-													 (GtkSignalFunc)app_quit, NULL,
-													 position ++);
-		}
-	}
-	return GTK_WIDGET(mytbar->tbar);
+    if (config_show_toolbar)
+    {
+        if (config_show_tb_new)
+        {
+            mytbar->new_w = gtk_toolbar_insert_stock(
+                mytbar->tbar, GTK_STOCK_NEW, _("Create a New Project..."), NULL,
+                (GtkSignalFunc) new_project, NULL, position++
+            );
+            gtk_toolbar_append_space(mytbar->tbar);
+            mytbar->spa = position;
+            position++;
+        }
+        if (config_show_tb_ccp)
+        {
+            mytbar->cut = gtk_toolbar_insert_stock(
+                mytbar->tbar, GTK_STOCK_CUT, _("Cut Selected Project"), NULL,
+                (GtkSignalFunc) cut_project, NULL, position++
+            );
+            mytbar->copy = gtk_toolbar_insert_stock(
+                mytbar->tbar, GTK_STOCK_COPY, _("Copy Selected Project"), NULL,
+                (GtkSignalFunc) copy_project, NULL, position++
+            );
+            mytbar->paste = gtk_toolbar_insert_stock(
+                mytbar->tbar, GTK_STOCK_PASTE, _("Paste Project"), NULL,
+                (GtkSignalFunc) paste_project, NULL, position++
+            );
+            gtk_toolbar_append_space(mytbar->tbar);
+            mytbar->spb = position;
+            if (mytbar->spa)
+                mytbar->spb--;
+            position++;
+        }
+        if (config_show_tb_journal)
+        {
+            /* There is no true 'stock' item for journal, so
+             * instead we draw our own button, and use a stock
+             * image. */
+            mytbar->journal_button = toolbar_append_stock_button(
+                mytbar->tbar, _("Activity Journal"), _("View and Edit Timestamp Logs"),
+                GNOME_STOCK_BOOK_OPEN, (GtkSignalFunc) show_report, ACTIVITY_REPORT
+            );
+            position++;
+        }
+        if (config_show_tb_prop)
+        {
+            mytbar->prop_w = gtk_toolbar_insert_stock(
+                mytbar->tbar, GTK_STOCK_PROPERTIES, _("Edit Project Properties..."), NULL,
+                (GtkSignalFunc) menu_properties, NULL, position++
+            );
+        }
+        if (config_show_tb_timer)
+        {
+            /* There is no true 'stock' item for timer, so
+             * instead we draw our own button, and use a
+             * pair of stock images to toggle between.
+             */
+            mytbar->timer_button_image = GTK_IMAGE(gtk_image_new());
+            gtk_image_set_from_stock(
+                mytbar->timer_button_image, GNOME_STOCK_TIMER, GTK_ICON_SIZE_LARGE_TOOLBAR
+            );
+
+            mytbar->timer_button = gtk_toolbar_append_item(
+                mytbar->tbar, _("Timer"), _("Start/Stop Timer"), NULL,
+                GTK_WIDGET(mytbar->timer_button_image), (GtkSignalFunc) menu_toggle_timer, NULL
+            );
+            position++;
+        }
+        if (config_show_tb_calendar)
+        {
+            mytbar->calendar_w = toolbar_append_stock_button(
+                mytbar->tbar, _("Calendar"), _("View Calendar"), GNOME_STOCK_TEXT_BULLETED_LIST,
+                (GtkSignalFunc) edit_calendar, NULL
+            );
+            position++;
+        }
+        if (((config_show_tb_timer) || (config_show_tb_journal) || (config_show_tb_calendar)
+             || (config_show_tb_prop))
+            && ((config_show_tb_pref) || (config_show_tb_help) || (config_show_tb_exit)))
+        {
+            gtk_toolbar_append_space(mytbar->tbar);
+            mytbar->spc = position;
+            if (mytbar->spa)
+                mytbar->spc--;
+            if (mytbar->spb)
+                mytbar->spc--;
+            position++;
+        }
+        if (config_show_tb_pref)
+        {
+            mytbar->pref = gtk_toolbar_insert_stock(
+                mytbar->tbar, GTK_STOCK_PREFERENCES, _("Edit Preferences..."), NULL,
+                (GtkSignalFunc) menu_options, NULL, position++
+            );
+        }
+        if (config_show_tb_help)
+        {
+            mytbar->help = gtk_toolbar_insert_stock(
+                mytbar->tbar, GTK_STOCK_HELP, _("User's Guide and Manual"), NULL,
+                (GtkSignalFunc) gtt_help_popup, NULL, position++
+            );
+        }
+        if (config_show_tb_exit)
+        {
+            mytbar->exit = gtk_toolbar_insert_stock(
+                mytbar->tbar, GTK_STOCK_QUIT, _("Quit GnoTime"), NULL, (GtkSignalFunc) app_quit,
+                NULL, position++
+            );
+        }
+    }
+    return GTK_WIDGET(mytbar->tbar);
 }
-
-
 
 /* ================================================================= */
 /* TODO: I have to completely rebuild the toolbar, when I want to add or
    remove items. There should be a better way now */
 
-#define ZAP(w)                                      \
-   if (w) { gtk_container_remove(tbc, (w)); (w) = NULL; }
+#define ZAP(w)                          \
+    if (w)                              \
+    {                                   \
+        gtk_container_remove(tbc, (w)); \
+        (w) = NULL;                     \
+    }
 
-#define ZING(pos)                                   \
-   if (pos) { gtk_toolbar_remove_space (mytbar->tbar, (pos)); (pos)=0; }
+#define ZING(pos)                                      \
+    if (pos)                                           \
+    {                                                  \
+        gtk_toolbar_remove_space(mytbar->tbar, (pos)); \
+        (pos) = 0;                                     \
+    }
 
-void
-update_toolbar_sections(void)
+void update_toolbar_sections(void)
 {
-	GtkContainer *tbc;
-	GtkWidget *tb;
+    GtkContainer *tbc;
+    GtkWidget *tb;
 
-	if (!app_window) return;
-	if (!mytbar) return;
+    if (!app_window)
+        return;
+    if (!mytbar)
+        return;
 
-	tbc = GTK_CONTAINER(mytbar->tbar);
-	ZING (mytbar->spa);
-	ZING (mytbar->spb);
-	ZING (mytbar->spc);
+    tbc = GTK_CONTAINER(mytbar->tbar);
+    ZING(mytbar->spa);
+    ZING(mytbar->spb);
+    ZING(mytbar->spc);
 
-	ZAP (mytbar->new_w);
-	ZAP (mytbar->cut);
-	ZAP (mytbar->copy);
-	ZAP (mytbar->paste);
-	ZAP (mytbar->journal_button);
-	ZAP (mytbar->prop_w);
-	ZAP (mytbar->timer_button);
-	ZAP (mytbar->calendar_w);
-	ZAP (mytbar->pref);
-	ZAP (mytbar->help);
-	ZAP (mytbar->exit);
+    ZAP(mytbar->new_w);
+    ZAP(mytbar->cut);
+    ZAP(mytbar->copy);
+    ZAP(mytbar->paste);
+    ZAP(mytbar->journal_button);
+    ZAP(mytbar->prop_w);
+    ZAP(mytbar->timer_button);
+    ZAP(mytbar->calendar_w);
+    ZAP(mytbar->pref);
+    ZAP(mytbar->help);
+    ZAP(mytbar->exit);
 
-	tb = build_toolbar();
-	gtk_widget_show(tb);
+    tb = build_toolbar();
+    gtk_widget_show(tb);
 }
 
 /* ======================= END OF FILE ======================= */

--- a/src/util.c
+++ b/src/util.c
@@ -16,294 +16,273 @@
  *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-
 #include "config.h"
 
-#include <glib.h>
-#include <stdio.h>
-#include <string.h>
 #include <glade/glade.h>
+#include <glib.h>
 #include <gnome.h>
 #include <qof.h>
+#include <stdio.h>
+#include <string.h>
 
 #ifdef HAVE_LANGINFO_H
 #define HAVE_LANGINFO_D_FMT 1
 #include <langinfo.h>
 #endif
 #ifdef HAVE_LANGINFO_D_FMT
-#  define QOF_D_FMT (nl_langinfo (D_FMT))
-#  define QOF_D_T_FMT (nl_langinfo (D_T_FMT))
-#  define QOF_T_FMT (nl_langinfo (T_FMT))
+#define QOF_D_FMT (nl_langinfo(D_FMT))
+#define QOF_D_T_FMT (nl_langinfo(D_T_FMT))
+#define QOF_T_FMT (nl_langinfo(T_FMT))
 #else
-#  define QOF_D_FMT   "%F"
-#  define QOF_D_T_FMT "%F %r"
-#  define QOF_T_FMT   "%r"
+#define QOF_D_FMT "%F"
+#define QOF_D_T_FMT "%F %r"
+#define QOF_T_FMT "%r"
 #endif
 
 #include "util.h"
 
 /* ============================================================== */
 
-void
-xxxgtk_textview_set_text (GtkTextView *text, const char *str)
+void xxxgtk_textview_set_text(GtkTextView *text, const char *str)
 {
-	GtkTextBuffer *buff = gtk_text_view_get_buffer (text);
-	if (!str) str = "";
-	gtk_text_buffer_set_text (buff, str, strlen (str));
-
+    GtkTextBuffer *buff = gtk_text_view_get_buffer(text);
+    if (!str)
+        str = "";
+    gtk_text_buffer_set_text(buff, str, strlen(str));
 }
 
-char *
-xxxgtk_textview_get_text (GtkTextView *text)
+char *xxxgtk_textview_get_text(GtkTextView *text)
 {
-	GtkTextIter start, end;
-	GtkTextBuffer *buff = gtk_text_view_get_buffer (text);
-	gtk_text_buffer_get_start_iter (buff, &start);
-	gtk_text_buffer_get_end_iter (buff, &end);
-	return gtk_text_buffer_get_text(buff, &start, &end, TRUE);
+    GtkTextIter start, end;
+    GtkTextBuffer *buff = gtk_text_view_get_buffer(text);
+    gtk_text_buffer_get_start_iter(buff, &start);
+    gtk_text_buffer_get_end_iter(buff, &end);
+    return gtk_text_buffer_get_text(buff, &start, &end, TRUE);
 }
 
 /* ============================================================== */
 
 /* Glade loader, it will look in the right directories */
-GladeXML *
-gtt_glade_xml_new (const char *filename, const char *widget)
+GladeXML *gtt_glade_xml_new(const char *filename, const char *widget)
 {
-	GladeXML *xml = NULL;
+    GladeXML *xml = NULL;
 
-	g_return_val_if_fail (filename != NULL, NULL);
+    g_return_val_if_fail(filename != NULL, NULL);
 
-	if (g_file_test (filename, G_FILE_TEST_EXISTS))
-		xml = glade_xml_new (filename, widget, NULL);
+    if (g_file_test(filename, G_FILE_TEST_EXISTS))
+        xml = glade_xml_new(filename, widget, NULL);
 
-	if (xml == NULL) {
-		char *file = g_concat_dir_and_file (GTTGLADEDIR, filename);
-		xml = glade_xml_new (file, widget, NULL);
-		g_free (file);
-	}
-	return xml;
+    if (xml == NULL)
+    {
+        char *file = g_concat_dir_and_file(GTTGLADEDIR, filename);
+        xml = glade_xml_new(file, widget, NULL);
+        g_free(file);
+    }
+    return xml;
 }
 
 /* ============================================================== */
 /* Used to be in qof, but is now deprecated there. */
 
-size_t
-xxxqof_print_hours_elapsed_buff (char *buff, size_t len, int secs,
-	gboolean show_secs)
+size_t xxxqof_print_hours_elapsed_buff(char *buff, size_t len, int secs, gboolean show_secs)
 {
-	size_t flen;
-	if (0 <= secs)
-	{
-		if (show_secs)
-		{
-			flen = g_snprintf (buff, len,
-				"%02d:%02d:%02d", (int) (secs / 3600),
-				(int) ((secs % 3600) / 60), (int) (secs % 60));
-		}
-		else
-		{
-			flen = g_snprintf (buff, len,
-				"%02d:%02d", (int) (secs / 3600),
-				(int) ((secs % 3600) / 60));
-		}
-	}
-	else
-	{
-		if (show_secs)
-		{
-			flen = g_snprintf (buff, len,
-				"-%02d:%02d:%02d", (int) (-secs / 3600),
-				(int) ((-secs % 3600) / 60), (int) (-secs % 60));
-		}
-		else
-		{
-			flen = g_snprintf (buff, len,
-				"-%02d:%02d", (int) (-secs / 3600),
-				(int) ((-secs % 3600) / 60));
-		}
-	}
-	return flen;
+    size_t flen;
+    if (0 <= secs)
+    {
+        if (show_secs)
+        {
+            flen = g_snprintf(
+                buff, len, "%02d:%02d:%02d", (int) (secs / 3600), (int) ((secs % 3600) / 60),
+                (int) (secs % 60)
+            );
+        }
+        else
+        {
+            flen = g_snprintf(
+                buff, len, "%02d:%02d", (int) (secs / 3600), (int) ((secs % 3600) / 60)
+            );
+        }
+    }
+    else
+    {
+        if (show_secs)
+        {
+            flen = g_snprintf(
+                buff, len, "-%02d:%02d:%02d", (int) (-secs / 3600), (int) ((-secs % 3600) / 60),
+                (int) (-secs % 60)
+            );
+        }
+        else
+        {
+            flen = g_snprintf(
+                buff, len, "-%02d:%02d", (int) (-secs / 3600), (int) ((-secs % 3600) / 60)
+            );
+        }
+    }
+    return flen;
 }
 
-size_t
-xxxqof_print_date_time_buff (char *buff, size_t len, time_t secs)
+size_t xxxqof_print_date_time_buff(char *buff, size_t len, time_t secs)
 {
-	int flen;
-	int day, month, year, hour, min;
-	struct tm ltm, gtm;
+    int flen;
+    int day, month, year, hour, min;
+    struct tm ltm, gtm;
 
-	if (!buff)
-		return 0;
-	ltm = *localtime (&secs);
-	day = ltm.tm_mday;
-	month = ltm.tm_mon + 1;
-	year = ltm.tm_year + 1900;
-	hour = ltm.tm_hour;
-	min = ltm.tm_min;
-	// sec = ltm.tm_sec;
-	switch (qof_date_format_get_current ())
-	{
-	case QOF_DATE_FORMAT_UK:
-		flen =
-			g_snprintf (buff, len, "%2d/%2d/%-4d %2d:%02d", day, month,
-			year, hour, min);
-		break;
-	case QOF_DATE_FORMAT_CE:
-		flen =
-			g_snprintf (buff, len, "%2d.%2d.%-4d %2d:%02d", day, month,
-			year, hour, min);
-		break;
-	case QOF_DATE_FORMAT_ISO:
-		flen =
-			g_snprintf (buff, len, "%04d-%02d-%02d %02d:%02d", year, month,
-			day, hour, min);
-		break;
-	case QOF_DATE_FORMAT_UTC:
-		{
-			gtm = *gmtime (&secs);
-			flen = strftime (buff, len, QOF_UTC_DATE_FORMAT, &gtm);
-			break;
-		}
-	case QOF_DATE_FORMAT_LOCALE:
-		{
-			flen = strftime (buff, len, QOF_D_T_FMT, &ltm);
-		}
-		break;
+    if (!buff)
+        return 0;
+    ltm = *localtime(&secs);
+    day = ltm.tm_mday;
+    month = ltm.tm_mon + 1;
+    year = ltm.tm_year + 1900;
+    hour = ltm.tm_hour;
+    min = ltm.tm_min;
+    // sec = ltm.tm_sec;
+    switch (qof_date_format_get_current())
+    {
+    case QOF_DATE_FORMAT_UK:
+        flen = g_snprintf(buff, len, "%2d/%2d/%-4d %2d:%02d", day, month, year, hour, min);
+        break;
+    case QOF_DATE_FORMAT_CE:
+        flen = g_snprintf(buff, len, "%2d.%2d.%-4d %2d:%02d", day, month, year, hour, min);
+        break;
+    case QOF_DATE_FORMAT_ISO:
+        flen = g_snprintf(buff, len, "%04d-%02d-%02d %02d:%02d", year, month, day, hour, min);
+        break;
+    case QOF_DATE_FORMAT_UTC:
+    {
+        gtm = *gmtime(&secs);
+        flen = strftime(buff, len, QOF_UTC_DATE_FORMAT, &gtm);
+        break;
+    }
+    case QOF_DATE_FORMAT_LOCALE:
+    {
+        flen = strftime(buff, len, QOF_D_T_FMT, &ltm);
+    }
+    break;
 
-	case QOF_DATE_FORMAT_US:
-	default:
-		flen =
-			g_snprintf (buff, len, "%2d/%2d/%-4d %2d:%02d", month, day,
-			year, hour, min);
-		break;
-	}
-	return flen;
+    case QOF_DATE_FORMAT_US:
+    default:
+        flen = g_snprintf(buff, len, "%2d/%2d/%-4d %2d:%02d", month, day, year, hour, min);
+        break;
+    }
+    return flen;
 }
 
-size_t
-xxxqof_print_time_buff (gchar * buff, size_t len, time_t secs)
+size_t xxxqof_print_time_buff(gchar *buff, size_t len, time_t secs)
 {
-	gint flen;
-	struct tm ltm, gtm;
+    gint flen;
+    struct tm ltm, gtm;
 
-	if (!buff)
-		return 0;
-	if (qof_date_format_get_current () == QOF_DATE_FORMAT_UTC)
-	{
-		gtm = *gmtime (&secs);
-		flen = strftime (buff, len, QOF_UTC_DATE_FORMAT, &gtm);
-		return flen;
-	}
-	ltm = *localtime (&secs);
-	flen = strftime (buff, len, QOF_T_FMT, &ltm);
+    if (!buff)
+        return 0;
+    if (qof_date_format_get_current() == QOF_DATE_FORMAT_UTC)
+    {
+        gtm = *gmtime(&secs);
+        flen = strftime(buff, len, QOF_UTC_DATE_FORMAT, &gtm);
+        return flen;
+    }
+    ltm = *localtime(&secs);
+    flen = strftime(buff, len, QOF_T_FMT, &ltm);
 
-	return flen;
+    return flen;
 }
 
-static void
-xxxgnc_tm_set_day_start (struct tm *tm)
+static void xxxgnc_tm_set_day_start(struct tm *tm)
 {
-	tm->tm_hour = 0;
-	tm->tm_min = 0;
-	tm->tm_sec = 0;
-	tm->tm_isdst = -1;
+    tm->tm_hour = 0;
+    tm->tm_min = 0;
+    tm->tm_sec = 0;
+    tm->tm_isdst = -1;
 }
 
-size_t
-xxxqof_print_date_dmy_buff (char *buff, size_t len, int day, int month,
-	int year)
+size_t xxxqof_print_date_dmy_buff(char *buff, size_t len, int day, int month, int year)
 {
-	int flen;
-	if (!buff)
-		return 0;
-	switch (qof_date_format_get_current ())
-	{
-	case QOF_DATE_FORMAT_UK:
-		flen = g_snprintf (buff, len, "%2d/%2d/%-4d", day, month, year);
-		break;
-	case QOF_DATE_FORMAT_CE:
-		flen = g_snprintf (buff, len, "%2d.%2d.%-4d", day, month, year);
-		break;
-	case QOF_DATE_FORMAT_LOCALE:
-		{
-			struct tm tm_str;
-			time_t t;
-			tm_str.tm_mday = day;
-			tm_str.tm_mon = month - 1;
-			tm_str.tm_year = year - 1900;
-			xxxgnc_tm_set_day_start (&tm_str);
-			t = mktime (&tm_str);
-			localtime_r (&t, &tm_str);
-			flen = strftime (buff, len, QOF_D_FMT, &tm_str);
-			if (flen != 0)
-				break;
-		}
-	case QOF_DATE_FORMAT_ISO:
-	case QOF_DATE_FORMAT_UTC:
-		flen = g_snprintf (buff, len, "%04d-%02d-%02d", year, month, day);
-		break;
-	case QOF_DATE_FORMAT_US:
-	default:
-		flen = g_snprintf (buff, len, "%2d/%2d/%-4d", month, day, year);
-		break;
-	}
-	return flen;
+    int flen;
+    if (!buff)
+        return 0;
+    switch (qof_date_format_get_current())
+    {
+    case QOF_DATE_FORMAT_UK:
+        flen = g_snprintf(buff, len, "%2d/%2d/%-4d", day, month, year);
+        break;
+    case QOF_DATE_FORMAT_CE:
+        flen = g_snprintf(buff, len, "%2d.%2d.%-4d", day, month, year);
+        break;
+    case QOF_DATE_FORMAT_LOCALE:
+    {
+        struct tm tm_str;
+        time_t t;
+        tm_str.tm_mday = day;
+        tm_str.tm_mon = month - 1;
+        tm_str.tm_year = year - 1900;
+        xxxgnc_tm_set_day_start(&tm_str);
+        t = mktime(&tm_str);
+        localtime_r(&t, &tm_str);
+        flen = strftime(buff, len, QOF_D_FMT, &tm_str);
+        if (flen != 0)
+            break;
+    }
+    case QOF_DATE_FORMAT_ISO:
+    case QOF_DATE_FORMAT_UTC:
+        flen = g_snprintf(buff, len, "%04d-%02d-%02d", year, month, day);
+        break;
+    case QOF_DATE_FORMAT_US:
+    default:
+        flen = g_snprintf(buff, len, "%2d/%2d/%-4d", month, day, year);
+        break;
+    }
+    return flen;
 }
 
-size_t
-xxxqof_print_date_buff (char *buff, size_t len, time_t t)
+size_t xxxqof_print_date_buff(char *buff, size_t len, time_t t)
 {
-	struct tm *theTime;
-	if (!buff)
-		return 0;
-	theTime = localtime (&t);
-	return xxxqof_print_date_dmy_buff (buff, len,
-		theTime->tm_mday, theTime->tm_mon + 1, theTime->tm_year + 1900);
+    struct tm *theTime;
+    if (!buff)
+        return 0;
+    theTime = localtime(&t);
+    return xxxqof_print_date_dmy_buff(
+        buff, len, theTime->tm_mday, theTime->tm_mon + 1, theTime->tm_year + 1900
+    );
 }
 
-size_t
-xxxqof_print_minutes_elapsed_buff (char *buff, size_t len, int secs,
-	gboolean show_secs)
+size_t xxxqof_print_minutes_elapsed_buff(char *buff, size_t len, int secs, gboolean show_secs)
 {
-	size_t flen;
-	if (0 <= secs)
-	{
-		if (show_secs)
-		{
-			flen = g_snprintf (buff, len,
-				"%02d:%02d", (int) (secs / 60), (int) (secs % 60));
-		}
-		else
-		{
-			flen = g_snprintf (buff, len, "%02d", (int) (secs / 60));
-		}
-	}
-	else
-	{
-		if (show_secs)
-		{
-			flen = g_snprintf (buff, len,
-				"-%02d:%02d", (int) (-secs / 60), (int) (-secs % 60));
-		}
-		else
-		{
-			flen = g_snprintf (buff, len, "-%02d", (int) (-secs / 60));
-		}
-	}
-	return flen;
+    size_t flen;
+    if (0 <= secs)
+    {
+        if (show_secs)
+        {
+            flen = g_snprintf(buff, len, "%02d:%02d", (int) (secs / 60), (int) (secs % 60));
+        }
+        else
+        {
+            flen = g_snprintf(buff, len, "%02d", (int) (secs / 60));
+        }
+    }
+    else
+    {
+        if (show_secs)
+        {
+            flen = g_snprintf(buff, len, "-%02d:%02d", (int) (-secs / 60), (int) (-secs % 60));
+        }
+        else
+        {
+            flen = g_snprintf(buff, len, "-%02d", (int) (-secs / 60));
+        }
+    }
+    return flen;
 }
 
-gboolean
-xxxqof_is_same_day (time_t ta, time_t tb)
+gboolean xxxqof_is_same_day(time_t ta, time_t tb)
 {
-	struct tm lta, ltb;
-	lta = *localtime (&ta);
-	ltb = *localtime (&tb);
-	if (lta.tm_year == ltb.tm_year)
-	{
-	return (ltb.tm_yday - lta.tm_yday);
-	}
-	return (ltb.tm_year - lta.tm_year)*365;  /* very approximate */
+    struct tm lta, ltb;
+    lta = *localtime(&ta);
+    ltb = *localtime(&tb);
+    if (lta.tm_year == ltb.tm_year)
+    {
+        return (ltb.tm_yday - lta.tm_yday);
+    }
+    return (ltb.tm_year - lta.tm_year) * 365; /* very approximate */
 }
 
 /* ===================== END OF FILE ============================ */

--- a/src/util.h
+++ b/src/util.h
@@ -19,31 +19,28 @@
 #ifndef __GTT_UTIL_H__
 #define __GTT_UTIL_H__
 
-#include <gtk/gtktext.h>
 #include <glade/glade.h>
+#include <gtk/gtktext.h>
 
 /* ------------------------------------------------------------------ */
 /* some gtk-like utilities */
-void xxxgtk_textview_set_text (GtkTextView *text, const char *str);
-char * xxxgtk_textview_get_text (GtkTextView *text);
+void xxxgtk_textview_set_text(GtkTextView *text, const char *str);
+char *xxxgtk_textview_get_text(GtkTextView *text);
 
 /* Glade loader, it will look in the right directories */
-GladeXML *gtt_glade_xml_new (const char *filename, const char *widget);
+GladeXML *gtt_glade_xml_new(const char *filename, const char *widget);
 
 /* ------------------------------------------------------------------ */
 /* Functions that used to be in qof,m but are not there any longer. */
-size_t xxxqof_print_hours_elapsed_buff (char *buff, size_t len, int secs,
-                                        gboolean show_secs);
+size_t xxxqof_print_hours_elapsed_buff(char *buff, size_t len, int secs, gboolean show_secs);
 
-size_t xxxqof_print_date_time_buff (char *buff, size_t len, time_t secs);
-size_t xxxqof_print_date_buff (char *buff, size_t len, time_t t);
-size_t xxxqof_print_time_buff (gchar * buff, size_t len, time_t secs);
-gboolean xxxqof_is_same_day (time_t ta, time_t tb);
+size_t xxxqof_print_date_time_buff(char *buff, size_t len, time_t secs);
+size_t xxxqof_print_date_buff(char *buff, size_t len, time_t t);
+size_t xxxqof_print_time_buff(gchar *buff, size_t len, time_t secs);
+gboolean xxxqof_is_same_day(time_t ta, time_t tb);
 
-size_t xxxqof_print_minutes_elapsed_buff (char *buff, size_t len, int secs,
-	                                       gboolean show_secs);
+size_t xxxqof_print_minutes_elapsed_buff(char *buff, size_t len, int secs, gboolean show_secs);
 
-size_t xxxqof_print_date_dmy_buff (char *buff, size_t len, int day, int month,
-	                                int year);
+size_t xxxqof_print_date_dmy_buff(char *buff, size_t len, int day, int month, int year);
 
 #endif /* __GTT_UTIL_H__ */

--- a/src/xml-gtt.h
+++ b/src/xml-gtt.h
@@ -35,9 +35,9 @@
  *    that gtt maintains.
  */
 
-void gtt_xml_read_file (const char * filename);
-void gtt_xml_write_file (const char * filename);
+void gtt_xml_read_file(const char *filename);
+void gtt_xml_write_file(const char *filename);
 
-GList * gtt_xml_read_projects (const char * filename);
+GList *gtt_xml_read_projects(const char *filename);
 
 #endif /* __XML_GTT_H__ */

--- a/src/xml-read.c
+++ b/src/xml-read.c
@@ -31,7 +31,6 @@
 #include "proj_p.h"
 #include "xml-gtt.h"
 
-
 /* Note: most of this code is a tediously boring cut-n-paste
  * of the same thing over & over again, and could//should be
  * auto-generated.  Diatribe: If the creators and true
@@ -44,352 +43,397 @@
 
 /* =========================================================== */
 
+#define GET_TEXT(node)                                \
+    ({                                                \
+        char *sstr = NULL;                            \
+        xmlNodePtr text;                              \
+        text = node->xmlChildrenNode;                 \
+        if (!text)                                    \
+        {                                             \
+            gtt_err_set_code(GTT_FILE_CORRUPT);       \
+        }                                             \
+        else if (strcmp("text", (char *) text->name)) \
+        {                                             \
+            gtt_err_set_code(GTT_FILE_CORRUPT);       \
+        }                                             \
+        else                                          \
+            sstr = (char *) text->content;            \
+        sstr;                                         \
+    })
 
-#define GET_TEXT(node)  ({                                   \
-   char * sstr = NULL;                                       \
-   xmlNodePtr text;                                          \
-   text = node->xmlChildrenNode;                             \
-   if (!text) {                                              \
-      gtt_err_set_code (GTT_FILE_CORRUPT);                   \
-   }                                                         \
-   else if (strcmp ("text", (char *) text->name)) {			 \
-      gtt_err_set_code (GTT_FILE_CORRUPT);                   \
-   }                                                         \
-   else sstr = (char *)text->content;						 \
-   sstr;                                                     \
-})
+#define GET_STR(SELF, FN, TOK)                           \
+    if (0 == strcmp(TOK, (char *) node->name))           \
+    {                                                    \
+        const char *str = (const char *) GET_TEXT(node); \
+        FN(SELF, str);                                   \
+    }                                                    \
+    else
 
-#define GET_STR(SELF,FN,TOK)                                 \
-	if (0 == strcmp (TOK, (char *)node->name))				 \
-   {                                                         \
-	   const char *str = (const char *)GET_TEXT (node);		 \
-      FN (SELF, str);                                        \
-   }                                                         \
-   else
+#define GET_DBL(SELF, FN, TOK)                           \
+    if (0 == strcmp(TOK, (char *) node->name))           \
+    {                                                    \
+        const char *str = (const char *) GET_TEXT(node); \
+        double rate = atof(str);                         \
+        FN(SELF, rate);                                  \
+    }                                                    \
+    else
 
+#define GET_INT(SELF, FN, TOK)                           \
+    if (0 == strcmp(TOK, (char *) node->name))           \
+    {                                                    \
+        const char *str = (const char *) GET_TEXT(node); \
+        int ival = atoi(str);                            \
+        FN(SELF, ival);                                  \
+    }                                                    \
+    else
 
-#define GET_DBL(SELF,FN,TOK)                                 \
-	if (0 == strcmp (TOK, (char *)node->name))				 \
-   {                                                         \
-	   const char *str = (const char *)GET_TEXT (node);	\
-      double rate = atof (str);                              \
-      FN (SELF, rate);                                       \
-   }                                                         \
-   else
+#define GET_TIM(SELF, FN, TOK)                           \
+    if (0 == strcmp(TOK, (char *) node->name))           \
+    {                                                    \
+        const char *str = (const char *) GET_TEXT(node); \
+        time_t tval = atol(str);                         \
+        FN(SELF, tval);                                  \
+    }                                                    \
+    else
 
-#define GET_INT(SELF,FN,TOK)                                 \
-	if (0 == strcmp (TOK, (char *)node->name))				 \
-   {                                                         \
-	   const char *str = (const char *)GET_TEXT (node);		 \
-      int ival = atoi (str);                                 \
-      FN (SELF, ival);                                       \
-   }                                                         \
-   else
+#define GET_BOL(SELF, FN, TOK)                           \
+    if (0 == strcmp(TOK, (char *) node->name))           \
+    {                                                    \
+        const char *str = (const char *) GET_TEXT(node); \
+        gboolean bval = atol(str);                       \
+        FN(SELF, bval);                                  \
+    }                                                    \
+    else
 
-#define GET_TIM(SELF,FN,TOK)                                 \
-	if (0 == strcmp (TOK, (char *)node->name))				 \
-   {                                                         \
-	   const char *str = (const char *)GET_TEXT (node);		 \
-      time_t tval = atol (str);                              \
-      FN (SELF, tval);                                       \
-   }                                                         \
-   else
+#define GET_GUID(SELF, FN, TOK)                          \
+    if (0 == strcmp(TOK, (char *) node->name))           \
+    {                                                    \
+        const char *str = (const char *) GET_TEXT(node); \
+        GUID guid;                                       \
+        string_to_guid(str, &guid);                      \
+        FN(SELF, &guid);                                 \
+    }                                                    \
+    else
 
-#define GET_BOL(SELF,FN,TOK)                                 \
-	if (0 == strcmp (TOK, (char *)node->name))				 \
-   {                                                         \
-	   const char *str = (const char *)GET_TEXT (node);	\
-      gboolean bval = atol (str);                            \
-      FN (SELF, bval);                                       \
-   }                                                         \
-   else
+#define GET_ENUM_3(SELF, FN, TOK, A, B, C)               \
+    if (0 == strcmp(TOK, (char *) node->name))           \
+    {                                                    \
+        const char *str = (const char *) GET_TEXT(node); \
+        int ival = GTT_##A;                              \
+        if (!strcmp(#A, str))                            \
+            ival = GTT_##A;                              \
+        else if (!strcmp(#B, str))                       \
+            ival = GTT_##B;                              \
+        else if (!strcmp(#C, str))                       \
+            ival = GTT_##C;                              \
+        else                                             \
+            gtt_err_set_code(GTT_UNKNOWN_VALUE);         \
+        FN(SELF, ival);                                  \
+    }                                                    \
+    else
 
-#define GET_GUID(SELF,FN,TOK)                                \
-	if (0 == strcmp (TOK, (char *)node->name))				 \
-   {                                                         \
-	   const char *str = (const char *)GET_TEXT (node);		 \
-      GUID guid;                                             \
-      string_to_guid (str, &guid);                           \
-      FN (SELF, &guid);                                      \
-   }                                                         \
-   else
+#define GET_ENUM_4(SELF, FN, TOK, A, B, C, D)            \
+    if (0 == strcmp(TOK, (char *) node->name))           \
+    {                                                    \
+        const char *str = (const char *) GET_TEXT(node); \
+        int ival = GTT_##A;                              \
+        if (!strcmp(#A, str))                            \
+            ival = GTT_##A;                              \
+        else if (!strcmp(#B, str))                       \
+            ival = GTT_##B;                              \
+        else if (!strcmp(#C, str))                       \
+            ival = GTT_##C;                              \
+        else if (!strcmp(#D, str))                       \
+            ival = GTT_##D;                              \
+        else                                             \
+            gtt_err_set_code(GTT_UNKNOWN_VALUE);         \
+        FN(SELF, ival);                                  \
+    }                                                    \
+    else
 
-#define GET_ENUM_3(SELF,FN,TOK,A,B,C)                        \
-	if (0 == strcmp (TOK, (char *)node->name))				 \
-   {                                                         \
-	   const char *str = (const char *)GET_TEXT (node);	\
-      int ival = GTT_##A;                                    \
-      if (!strcmp (#A, str)) ival = GTT_##A;                 \
-      else if (!strcmp (#B, str)) ival = GTT_##B;            \
-      else if (!strcmp (#C, str)) ival = GTT_##C;            \
-      else gtt_err_set_code (GTT_UNKNOWN_VALUE);             \
-      FN (SELF, ival);                                       \
-   }                                                         \
-   else
-
-#define GET_ENUM_4(SELF,FN,TOK,A,B,C,D)                      \
-	if (0 == strcmp (TOK, (char *)node->name))				 \
-   {                                                         \
-	   const char *str = (const char *)GET_TEXT (node);		 \
-      int ival = GTT_##A;                                    \
-      if (!strcmp (#A, str)) ival = GTT_##A;                 \
-      else if (!strcmp (#B, str)) ival = GTT_##B;            \
-      else if (!strcmp (#C, str)) ival = GTT_##C;            \
-      else if (!strcmp (#D, str)) ival = GTT_##D;            \
-      else gtt_err_set_code (GTT_UNKNOWN_VALUE);             \
-      FN (SELF, ival);                                       \
-   }                                                         \
-   else
-
-#define GET_ENUM_6(SELF,FN,TOK,A,B,C,D,E,F)                  \
-	if (0 == strcmp (TOK, (char *)node->name))				 \
-   {                                                         \
-	   const char *str = (const char *)GET_TEXT (node);	\
-      int ival = GTT_##A;                                    \
-      if (!strcmp (#A, str)) ival = GTT_##A;                 \
-      else if (!strcmp (#B, str)) ival = GTT_##B;            \
-      else if (!strcmp (#C, str)) ival = GTT_##C;            \
-      else if (!strcmp (#D, str)) ival = GTT_##D;            \
-      else if (!strcmp (#E, str)) ival = GTT_##E;            \
-      else if (!strcmp (#F, str)) ival = GTT_##F;            \
-      else gtt_err_set_code (GTT_UNKNOWN_VALUE);             \
-      FN (SELF, ival);                                       \
-   }                                                         \
-   else
+#define GET_ENUM_6(SELF, FN, TOK, A, B, C, D, E, F)      \
+    if (0 == strcmp(TOK, (char *) node->name))           \
+    {                                                    \
+        const char *str = (const char *) GET_TEXT(node); \
+        int ival = GTT_##A;                              \
+        if (!strcmp(#A, str))                            \
+            ival = GTT_##A;                              \
+        else if (!strcmp(#B, str))                       \
+            ival = GTT_##B;                              \
+        else if (!strcmp(#C, str))                       \
+            ival = GTT_##C;                              \
+        else if (!strcmp(#D, str))                       \
+            ival = GTT_##D;                              \
+        else if (!strcmp(#E, str))                       \
+            ival = GTT_##E;                              \
+        else if (!strcmp(#F, str))                       \
+            ival = GTT_##F;                              \
+        else                                             \
+            gtt_err_set_code(GTT_UNKNOWN_VALUE);         \
+        FN(SELF, ival);                                  \
+    }                                                    \
+    else
 
 /* =========================================================== */
 
-static GttInterval *
-parse_interval (xmlNodePtr interval)
+static GttInterval *parse_interval(xmlNodePtr interval)
 {
-	xmlNodePtr node;
-	GttInterval *ivl = NULL;
+    xmlNodePtr node;
+    GttInterval *ivl = NULL;
 
-	if (!interval) { gtt_err_set_code (GTT_FILE_CORRUPT); return ivl; }
+    if (!interval)
+    {
+        gtt_err_set_code(GTT_FILE_CORRUPT);
+        return ivl;
+    }
 
-	if (strcmp ("interval", (char *)interval->name)) {
-		gtt_err_set_code (GTT_FILE_CORRUPT); return ivl; }
+    if (strcmp("interval", (char *) interval->name))
+    {
+        gtt_err_set_code(GTT_FILE_CORRUPT);
+        return ivl;
+    }
 
-	ivl = gtt_interval_new ();
-	for (node=interval->xmlChildrenNode; node; node=node->next)
-	{
-		if (node->type != XML_ELEMENT_NODE) continue;
+    ivl = gtt_interval_new();
+    for (node = interval->xmlChildrenNode; node; node = node->next)
+    {
+        if (node->type != XML_ELEMENT_NODE)
+            continue;
 
-		GET_TIM (ivl, gtt_interval_set_start, "start")
-		GET_TIM (ivl, gtt_interval_set_stop, "stop")
-		GET_TIM (ivl, gtt_interval_set_fuzz, "fuzz")
-		GET_BOL (ivl, gtt_interval_set_running, "running")
-		{
-			gtt_err_set_code (GTT_UNKNOWN_TOKEN);
-		}
-	}
-	return ivl;
+        GET_TIM(ivl, gtt_interval_set_start, "start")
+        GET_TIM(ivl, gtt_interval_set_stop, "stop")
+        GET_TIM(ivl, gtt_interval_set_fuzz, "fuzz")
+        GET_BOL(ivl, gtt_interval_set_running, "running")
+        {
+            gtt_err_set_code(GTT_UNKNOWN_TOKEN);
+        }
+    }
+    return ivl;
 }
 
 /* =========================================================== */
 
-static GttTask *
-parse_task (xmlNodePtr task)
+static GttTask *parse_task(xmlNodePtr task)
 {
-	xmlNodePtr node;
-	GttTask *tsk = NULL;
+    xmlNodePtr node;
+    GttTask *tsk = NULL;
 
-	if (!task) { gtt_err_set_code (GTT_FILE_CORRUPT); return tsk; }
+    if (!task)
+    {
+        gtt_err_set_code(GTT_FILE_CORRUPT);
+        return tsk;
+    }
 
-	if (strcmp ("task", (char *)task->name)) {
-		gtt_err_set_code (GTT_FILE_CORRUPT); return tsk; }
+    if (strcmp("task", (char *) task->name))
+    {
+        gtt_err_set_code(GTT_FILE_CORRUPT);
+        return tsk;
+    }
 
-	tsk = gtt_task_new ();
-	for (node=task->xmlChildrenNode; node; node=node->next)
-	{
-		if (node->type != XML_ELEMENT_NODE) continue;
+    tsk = gtt_task_new();
+    for (node = task->xmlChildrenNode; node; node = node->next)
+    {
+        if (node->type != XML_ELEMENT_NODE)
+            continue;
 
-		GET_GUID (tsk, gtt_task_set_guid, "guid")
-		GET_STR (tsk, gtt_task_set_memo, "memo")
-		GET_STR (tsk, gtt_task_set_notes, "notes")
-		GET_INT (tsk, gtt_task_set_bill_unit, "bill_unit")
+        GET_GUID(tsk, gtt_task_set_guid, "guid")
+        GET_STR(tsk, gtt_task_set_memo, "memo")
+        GET_STR(tsk, gtt_task_set_notes, "notes")
+        GET_INT(tsk, gtt_task_set_bill_unit, "bill_unit")
 
-		GET_ENUM_3 (tsk, gtt_task_set_billable, "billable",
-			NOT_BILLABLE, BILLABLE, NO_CHARGE)
-		GET_ENUM_3 (tsk, gtt_task_set_billstatus, "billstatus",
-			HOLD, BILL, PAID)
-		GET_ENUM_4 (tsk, gtt_task_set_billrate, "billrate",
-			REGULAR, OVERTIME, OVEROVER, FLAT_FEE)
-			if (0 == strcmp ("interval-list", (char *)node->name))
-		{
-			xmlNodePtr tn;
-			for (tn=node->xmlChildrenNode; tn; tn=tn->next)
-			{
-				GttInterval *ival;
-				if (tn->type != XML_ELEMENT_NODE) continue;
+        GET_ENUM_3(tsk, gtt_task_set_billable, "billable", NOT_BILLABLE, BILLABLE, NO_CHARGE)
+        GET_ENUM_3(tsk, gtt_task_set_billstatus, "billstatus", HOLD, BILL, PAID)
+        GET_ENUM_4(
+            tsk, gtt_task_set_billrate, "billrate", REGULAR, OVERTIME, OVEROVER, FLAT_FEE
+        )
+        if (0 == strcmp("interval-list", (char *) node->name))
+        {
+            xmlNodePtr tn;
+            for (tn = node->xmlChildrenNode; tn; tn = tn->next)
+            {
+                GttInterval *ival;
+                if (tn->type != XML_ELEMENT_NODE)
+                    continue;
 
-				ival = parse_interval (tn);
-				gtt_task_append_interval (tsk, ival);
-			}
-		}
-		else
-		{
-			gtt_err_set_code (GTT_UNKNOWN_TOKEN);
-		}
-	}
-	return tsk;
+                ival = parse_interval(tn);
+                gtt_task_append_interval(tsk, ival);
+            }
+        }
+        else
+        {
+            gtt_err_set_code(GTT_UNKNOWN_TOKEN);
+        }
+    }
+    return tsk;
 }
 
 /* =========================================================== */
 
-
-static GttProject *
-parse_project (xmlNodePtr project)
+static GttProject *parse_project(xmlNodePtr project)
 {
-	xmlNodePtr node;
-	GttProject *prj = NULL;
+    xmlNodePtr node;
+    GttProject *prj = NULL;
 
-	if (!project) { gtt_err_set_code (GTT_FILE_CORRUPT); return prj; }
+    if (!project)
+    {
+        gtt_err_set_code(GTT_FILE_CORRUPT);
+        return prj;
+    }
 
-	if (strcmp ("project", (char *)project->name)) {
-		gtt_err_set_code (GTT_FILE_CORRUPT); return prj; }
+    if (strcmp("project", (char *) project->name))
+    {
+        gtt_err_set_code(GTT_FILE_CORRUPT);
+        return prj;
+    }
 
-	prj = gtt_project_new ();
-	gtt_project_freeze (prj);
-	for (node=project->xmlChildrenNode; node; node=node->next)
-	{
-		if (node->type != XML_ELEMENT_NODE) continue;
+    prj = gtt_project_new();
+    gtt_project_freeze(prj);
+    for (node = project->xmlChildrenNode; node; node = node->next)
+    {
+        if (node->type != XML_ELEMENT_NODE)
+            continue;
 
-		GET_GUID (prj, gtt_project_set_guid, "guid")
-		GET_STR (prj, gtt_project_set_title, "title")
-		GET_STR (prj, gtt_project_set_desc, "desc")
-		GET_STR (prj, gtt_project_set_notes, "notes")
-		GET_STR (prj, gtt_project_set_custid, "custid")
+        GET_GUID(prj, gtt_project_set_guid, "guid")
+        GET_STR(prj, gtt_project_set_title, "title")
+        GET_STR(prj, gtt_project_set_desc, "desc")
+        GET_STR(prj, gtt_project_set_notes, "notes")
+        GET_STR(prj, gtt_project_set_custid, "custid")
 
-		GET_DBL (prj, gtt_project_set_billrate, "billrate")
-		GET_DBL (prj, gtt_project_set_overtime_rate, "overtime_rate")
-		GET_DBL (prj, gtt_project_set_overover_rate, "overover_rate")
-		GET_DBL (prj, gtt_project_set_flat_fee, "flat_fee")
+        GET_DBL(prj, gtt_project_set_billrate, "billrate")
+        GET_DBL(prj, gtt_project_set_overtime_rate, "overtime_rate")
+        GET_DBL(prj, gtt_project_set_overover_rate, "overover_rate")
+        GET_DBL(prj, gtt_project_set_flat_fee, "flat_fee")
 
-		GET_INT (prj, gtt_project_set_min_interval, "min_interval")
-		GET_INT (prj, gtt_project_set_auto_merge_interval, "auto_merge_interval")
-		GET_INT (prj, gtt_project_set_auto_merge_gap, "auto_merge_gap")
+        GET_INT(prj, gtt_project_set_min_interval, "min_interval")
+        GET_INT(prj, gtt_project_set_auto_merge_interval, "auto_merge_interval")
+        GET_INT(prj, gtt_project_set_auto_merge_gap, "auto_merge_gap")
 
-		GET_INT (prj, gtt_project_set_id, "id")
+        GET_INT(prj, gtt_project_set_id, "id")
 
-		GET_TIM (prj, gtt_project_set_estimated_start, "estimated_start")
-		GET_TIM (prj, gtt_project_set_estimated_end, "estimated_end")
-		GET_TIM (prj, gtt_project_set_due_date, "due_date")
-		GET_INT (prj, gtt_project_set_sizing, "sizing")
-		GET_INT (prj, gtt_project_set_percent_complete, "percent_complete")
+        GET_TIM(prj, gtt_project_set_estimated_start, "estimated_start")
+        GET_TIM(prj, gtt_project_set_estimated_end, "estimated_end")
+        GET_TIM(prj, gtt_project_set_due_date, "due_date")
+        GET_INT(prj, gtt_project_set_sizing, "sizing")
+        GET_INT(prj, gtt_project_set_percent_complete, "percent_complete")
 
-		GET_ENUM_4 (prj, gtt_project_set_urgency, "urgency",
-			UNDEFINED, LOW, MEDIUM, HIGH)
-		GET_ENUM_4 (prj, gtt_project_set_importance, "importance",
-			UNDEFINED, LOW, MEDIUM, HIGH)
-		GET_ENUM_6 (prj, gtt_project_set_status, "status",
-			NO_STATUS, NOT_STARTED, IN_PROGRESS, ON_HOLD, CANCELLED, COMPLETED)
+        GET_ENUM_4(prj, gtt_project_set_urgency, "urgency", UNDEFINED, LOW, MEDIUM, HIGH)
+        GET_ENUM_4(prj, gtt_project_set_importance, "importance", UNDEFINED, LOW, MEDIUM, HIGH)
+        GET_ENUM_6(
+            prj, gtt_project_set_status, "status", NO_STATUS, NOT_STARTED, IN_PROGRESS, ON_HOLD,
+            CANCELLED, COMPLETED
+        )
 
-			if (0 == strcmp ("task-list", (char *)node->name))
-		{
-			xmlNodePtr tn;
-			for (tn=node->xmlChildrenNode; tn; tn=tn->next)
-			{
-				GttTask *tsk;
-				tsk = parse_task (tn);
-				gtt_project_append_task (prj, tsk);
-			}
-		}
-		else
-			if (0 == strcmp ("project-list", (char *)node->name))
-		{
-			xmlNodePtr tn;
-			for (tn=node->xmlChildrenNode; tn; tn=tn->next)
-			{
-				GttProject *child;
-				if (tn->type != XML_ELEMENT_NODE) continue;
-				child = parse_project (tn);
-				gtt_project_append_project (prj, child);
-			}
-		}
-		else
-		{
-			g_warning ("unexpected node %s", node->name);
-			gtt_err_set_code (GTT_UNKNOWN_TOKEN);
-		}
-	}
-	gtt_project_thaw (prj);
-	return prj;
+        if (0 == strcmp("task-list", (char *) node->name))
+        {
+            xmlNodePtr tn;
+            for (tn = node->xmlChildrenNode; tn; tn = tn->next)
+            {
+                GttTask *tsk;
+                tsk = parse_task(tn);
+                gtt_project_append_task(prj, tsk);
+            }
+        }
+        else if (0 == strcmp("project-list", (char *) node->name))
+        {
+            xmlNodePtr tn;
+            for (tn = node->xmlChildrenNode; tn; tn = tn->next)
+            {
+                GttProject *child;
+                if (tn->type != XML_ELEMENT_NODE)
+                    continue;
+                child = parse_project(tn);
+                gtt_project_append_project(prj, child);
+            }
+        }
+        else
+        {
+            g_warning("unexpected node %s", node->name);
+            gtt_err_set_code(GTT_UNKNOWN_TOKEN);
+        }
+    }
+    gtt_project_thaw(prj);
+    return prj;
 }
 
 /* =========================================================== */
 
-GList *
-gtt_xml_read_projects (const char * filename)
+GList *gtt_xml_read_projects(const char *filename)
 {
-	GList *prjs = NULL;
-	xmlDocPtr doc;
-	xmlNodePtr root, project_list, project;
-	// xmlChar *version;
+    GList *prjs = NULL;
+    xmlDocPtr doc;
+    xmlNodePtr root, project_list, project;
+    // xmlChar *version;
 
-	LIBXML_TEST_VERSION;
-	xmlKeepBlanksDefault(0);
-	doc = xmlParseFile (filename);
+    LIBXML_TEST_VERSION;
+    xmlKeepBlanksDefault(0);
+    doc = xmlParseFile(filename);
 
-	if (!doc) { gtt_err_set_code (GTT_CANT_OPEN_FILE); return NULL; }
-	root = xmlDocGetRootElement(doc);
+    if (!doc)
+    {
+        gtt_err_set_code(GTT_CANT_OPEN_FILE);
+        return NULL;
+    }
+    root = xmlDocGetRootElement(doc);
 
-	/* The doc may be null if the file is valid but empty */
-	if (!root)
-	{
-		xmlFreeDoc(doc);
-		return NULL;
-	}
+    /* The doc may be null if the file is valid but empty */
+    if (!root)
+    {
+        xmlFreeDoc(doc);
+        return NULL;
+    }
 
-	// version = xmlGetProp(root, (unsigned char *)"version");
-	if (!root->name || strcmp ("gtt", (char *)root->name))
-	{
-		xmlFreeDoc(doc);
-		gtt_err_set_code (GTT_NOT_A_GTT_FILE);
-		return NULL;
-	}
+    // version = xmlGetProp(root, (unsigned char *)"version");
+    if (!root->name || strcmp("gtt", (char *) root->name))
+    {
+        xmlFreeDoc(doc);
+        gtt_err_set_code(GTT_NOT_A_GTT_FILE);
+        return NULL;
+    }
 
-	project_list = root->xmlChildrenNode;
+    project_list = root->xmlChildrenNode;
 
-	/* If no children, then no projects -- a clean slate */
-	if (!project_list) {
-		xmlFreeDoc(doc);
-		return NULL;
-	}
+    /* If no children, then no projects -- a clean slate */
+    if (!project_list)
+    {
+        xmlFreeDoc(doc);
+        return NULL;
+    }
 
-	if (strcmp ("project-list", (char *)project_list->name)) {
-		xmlFreeDoc(doc);
-		gtt_err_set_code (GTT_FILE_CORRUPT); return NULL; }
+    if (strcmp("project-list", (char *) project_list->name))
+    {
+        xmlFreeDoc(doc);
+        gtt_err_set_code(GTT_FILE_CORRUPT);
+        return NULL;
+    }
 
-	for (project=project_list->xmlChildrenNode; project; project=project->next)
-	{
-		GttProject *prj;
-		if (project->type != XML_ELEMENT_NODE) continue;
-		prj = parse_project (project);
-		prjs = g_list_append (prjs, prj);
-	}
+    for (project = project_list->xmlChildrenNode; project; project = project->next)
+    {
+        GttProject *prj;
+        if (project->type != XML_ELEMENT_NODE)
+            continue;
+        prj = parse_project(project);
+        prjs = g_list_append(prjs, prj);
+    }
 
-	xmlFreeDoc(doc);
-	return prjs;
+    xmlFreeDoc(doc);
+    return prjs;
 }
 
 /* =========================================================== */
 
-void
-gtt_xml_read_file (const char * filename)
+void gtt_xml_read_file(const char *filename)
 {
-	GList *node, *prjs = NULL;
+    GList *node, *prjs = NULL;
 
-	prjs = gtt_xml_read_projects (filename);
+    prjs = gtt_xml_read_projects(filename);
 
-	for (node=prjs; node; node=node->next)
-	{
-		GttProject *prj = node->data;
-		gtt_project_list_append (master_list, prj);
-	}
+    for (node = prjs; node; node = node->next)
+    {
+        GttProject *prj = node->data;
+        gtt_project_list_append(master_list, prj);
+    }
 
-	/* recompute the cached counters */
-	gtt_project_list_compute_secs ();
+    /* recompute the cached counters */
+    gtt_project_list_compute_secs();
 }
 
 /* ====================== END OF FILE =============== */

--- a/src/xml-write.c
+++ b/src/xml-write.c
@@ -28,7 +28,7 @@
 #include "proj.h"
 #include "xml-gtt.h"
 
-static xmlNodePtr gtt_project_list_to_dom_tree (GList *list);
+static xmlNodePtr gtt_project_list_to_dom_tree(GList *list);
 
 /* Note: most of this code is a tediously boring cut-n-paste
  * of the same thing over & over again, and could//should be
@@ -42,363 +42,409 @@ static xmlNodePtr gtt_project_list_to_dom_tree (GList *list);
 
 /* ======================================================= */
 
-#define PUT_STR(TOK,VAL) {                           \
-   const char * str = (VAL);                         \
-   if (str && 0 != str[0])                           \
-   {                                                 \
-      node = xmlNewNode (NULL, BAD_CAST TOK);                 \
-      xmlNodeAddContent(node, BAD_CAST str);                  \
-      xmlAddChild (topnode, node);                   \
-   }                                                 \
-}
+#define PUT_STR(TOK, VAL)                          \
+    {                                              \
+        const char *str = (VAL);                   \
+        if (str && 0 != str[0])                    \
+        {                                          \
+            node = xmlNewNode(NULL, BAD_CAST TOK); \
+            xmlNodeAddContent(node, BAD_CAST str); \
+            xmlAddChild(topnode, node);            \
+        }                                          \
+    }
 
-#define PUT_INT(TOK,VAL) {                           \
-   char buff[80];                                    \
-   g_snprintf (buff, sizeof(buff), "%d", (VAL));     \
-   node = xmlNewNode (NULL, BAD_CAST TOK);                    \
-   xmlNodeAddContent(node, BAD_CAST buff);                    \
-   xmlAddChild (topnode, node);                      \
-}
+#define PUT_INT(TOK, VAL)                            \
+    {                                                \
+        char buff[80];                               \
+        g_snprintf(buff, sizeof(buff), "%d", (VAL)); \
+        node = xmlNewNode(NULL, BAD_CAST TOK);       \
+        xmlNodeAddContent(node, BAD_CAST buff);      \
+        xmlAddChild(topnode, node);                  \
+    }
 
-#define PUT_LONG(TOK,VAL) {                          \
-   char buff[80];                                    \
-   g_snprintf (buff, sizeof(buff), "%ld", (VAL));    \
-   node = xmlNewNode (NULL, BAD_CAST TOK);                    \
-   xmlNodeAddContent(node, BAD_CAST buff);                    \
-   xmlAddChild (topnode, node);                      \
-}
+#define PUT_LONG(TOK, VAL)                            \
+    {                                                 \
+        char buff[80];                                \
+        g_snprintf(buff, sizeof(buff), "%ld", (VAL)); \
+        node = xmlNewNode(NULL, BAD_CAST TOK);        \
+        xmlNodeAddContent(node, BAD_CAST buff);       \
+        xmlAddChild(topnode, node);                   \
+    }
 
+#define PUT_DBL(TOK, VAL)                               \
+    {                                                   \
+        char buff[80];                                  \
+        g_snprintf(buff, sizeof(buff), "%.18g", (VAL)); \
+        node = xmlNewNode(NULL, BAD_CAST TOK);          \
+        xmlNodeAddContent(node, BAD_CAST buff);         \
+        xmlAddChild(topnode, node);                     \
+    }
 
-#define PUT_DBL(TOK,VAL) {                           \
-   char buff[80];                                    \
-   g_snprintf (buff, sizeof(buff), "%.18g", (VAL));  \
-   node = xmlNewNode (NULL, BAD_CAST TOK);                    \
-   xmlNodeAddContent(node, BAD_CAST buff);                    \
-   xmlAddChild (topnode, node);                      \
-}
+#define PUT_GUID(TOK, VAL)                      \
+    {                                           \
+        char buff[80];                          \
+        guid_to_string_buff((VAL), buff);       \
+        node = xmlNewNode(NULL, BAD_CAST TOK);  \
+        xmlNodeAddContent(node, BAD_CAST buff); \
+        xmlAddChild(topnode, node);             \
+    }
 
-#define PUT_GUID(TOK,VAL) {                          \
-   char buff[80];                                    \
-   guid_to_string_buff ((VAL), buff);                \
-   node = xmlNewNode (NULL, BAD_CAST TOK);                    \
-   xmlNodeAddContent(node, BAD_CAST buff);                    \
-   xmlAddChild (topnode, node);                      \
-}
+#define PUT_BOOL(TOK, VAL)                         \
+    {                                              \
+        gboolean boll = (VAL);                     \
+        node = xmlNewNode(NULL, BAD_CAST TOK);     \
+        if (boll)                                  \
+        {                                          \
+            xmlNodeAddContent(node, BAD_CAST "T"); \
+        }                                          \
+        else                                       \
+        {                                          \
+            xmlNodeAddContent(node, BAD_CAST "F"); \
+        }                                          \
+        xmlAddChild(topnode, node);                \
+    }
 
-#define PUT_BOOL(TOK,VAL) {                          \
-   gboolean boll = (VAL);                            \
-   node = xmlNewNode (NULL, BAD_CAST TOK);                    \
-   if (boll) {                                       \
-      xmlNodeAddContent(node, BAD_CAST "T");                  \
-   } else {                                          \
-      xmlNodeAddContent(node, BAD_CAST "F");                  \
-   }                                                 \
-   xmlAddChild (topnode, node);                      \
-}
+#define PUT_ENUM_3(TOK, VAL, A, B, C)          \
+    {                                          \
+        const char *str = #A;                  \
+        switch (VAL)                           \
+        {                                      \
+        case GTT_##A:                          \
+            str = #A;                          \
+            break;                             \
+        case GTT_##B:                          \
+            str = #B;                          \
+            break;                             \
+        case GTT_##C:                          \
+            str = #C;                          \
+            break;                             \
+        }                                      \
+        node = xmlNewNode(NULL, BAD_CAST TOK); \
+        xmlNodeAddContent(node, BAD_CAST str); \
+        xmlAddChild(topnode, node);            \
+    }
 
-#define PUT_ENUM_3(TOK,VAL,A,B,C) {                  \
-   const char * str = #A;                            \
-   switch (VAL)                                      \
-   {                                                 \
-      case GTT_##A: str = #A; break;                 \
-      case GTT_##B: str = #B; break;                 \
-      case GTT_##C: str = #C; break;                 \
-   }                                                 \
-   node = xmlNewNode (NULL, BAD_CAST TOK);                    \
-   xmlNodeAddContent(node, BAD_CAST str);                     \
-   xmlAddChild (topnode, node);                      \
-}
+#define PUT_ENUM_4(TOK, VAL, A, B, C, D)       \
+    {                                          \
+        const char *str = #A;                  \
+        switch (VAL)                           \
+        {                                      \
+        case GTT_##A:                          \
+            str = #A;                          \
+            break;                             \
+        case GTT_##B:                          \
+            str = #B;                          \
+            break;                             \
+        case GTT_##C:                          \
+            str = #C;                          \
+            break;                             \
+        case GTT_##D:                          \
+            str = #D;                          \
+            break;                             \
+        }                                      \
+        node = xmlNewNode(NULL, BAD_CAST TOK); \
+        xmlNodeAddContent(node, BAD_CAST str); \
+        xmlAddChild(topnode, node);            \
+    }
 
-#define PUT_ENUM_4(TOK,VAL,A,B,C, D) {               \
-   const char * str = #A;                            \
-   switch (VAL)                                      \
-   {                                                 \
-      case GTT_##A: str = #A; break;                 \
-      case GTT_##B: str = #B; break;                 \
-      case GTT_##C: str = #C; break;                 \
-      case GTT_##D: str = #D; break;                 \
-   }                                                 \
-   node = xmlNewNode (NULL, BAD_CAST TOK);                    \
-   xmlNodeAddContent(node, BAD_CAST str);                     \
-   xmlAddChild (topnode, node);                      \
-}
-
-#define PUT_ENUM_6(TOK,VAL,A,B,C,D,E,F) {            \
-   const char * str = #A;                            \
-   switch (VAL)                                      \
-   {                                                 \
-      case GTT_##A: str = #A; break;                 \
-      case GTT_##B: str = #B; break;                 \
-      case GTT_##C: str = #C; break;                 \
-      case GTT_##D: str = #D; break;                 \
-      case GTT_##E: str = #E; break;                 \
-      case GTT_##F: str = #F; break;                 \
-   }                                                 \
-   node = xmlNewNode (NULL, BAD_CAST TOK);                    \
-   xmlNodeAddContent(node, BAD_CAST str);                     \
-   xmlAddChild (topnode, node);                      \
-}
+#define PUT_ENUM_6(TOK, VAL, A, B, C, D, E, F) \
+    {                                          \
+        const char *str = #A;                  \
+        switch (VAL)                           \
+        {                                      \
+        case GTT_##A:                          \
+            str = #A;                          \
+            break;                             \
+        case GTT_##B:                          \
+            str = #B;                          \
+            break;                             \
+        case GTT_##C:                          \
+            str = #C;                          \
+            break;                             \
+        case GTT_##D:                          \
+            str = #D;                          \
+            break;                             \
+        case GTT_##E:                          \
+            str = #E;                          \
+            break;                             \
+        case GTT_##F:                          \
+            str = #F;                          \
+            break;                             \
+        }                                      \
+        node = xmlNewNode(NULL, BAD_CAST TOK); \
+        xmlNodeAddContent(node, BAD_CAST str); \
+        xmlAddChild(topnode, node);            \
+    }
 
 /* ======================================================= */
 
 /* convert one interval to a dom tree */
 
-static xmlNodePtr
-gtt_xml_interval_to_dom_tree (GttInterval *ivl)
+static xmlNodePtr gtt_xml_interval_to_dom_tree(GttInterval *ivl)
 {
-	xmlNodePtr node, topnode;
+    xmlNodePtr node, topnode;
 
-	if (!ivl) return NULL;
+    if (!ivl)
+        return NULL;
 
-	topnode = xmlNewNode (NULL, BAD_CAST "gtt:interval");
+    topnode = xmlNewNode(NULL, BAD_CAST "gtt:interval");
 
-	PUT_LONG("start", gtt_interval_get_start(ivl));
-	PUT_LONG("stop", gtt_interval_get_stop(ivl));
-	PUT_INT("fuzz", gtt_interval_get_fuzz(ivl));
-	PUT_BOOL("running", gtt_interval_is_running(ivl));
+    PUT_LONG("start", gtt_interval_get_start(ivl));
+    PUT_LONG("stop", gtt_interval_get_stop(ivl));
+    PUT_INT("fuzz", gtt_interval_get_fuzz(ivl));
+    PUT_BOOL("running", gtt_interval_is_running(ivl));
 
-	return topnode;
+    return topnode;
 }
 
 /* convert a list of gtt tasks into a DOM tree */
-static xmlNodePtr
-gtt_interval_list_to_dom_tree (GList *list)
+static xmlNodePtr gtt_interval_list_to_dom_tree(GList *list)
 {
-	GList *p;
-	xmlNodePtr topnode;
-	xmlNodePtr node;
+    GList *p;
+    xmlNodePtr topnode;
+    xmlNodePtr node;
 
-	if (!list) return NULL;
+    if (!list)
+        return NULL;
 
-	topnode = xmlNewNode (NULL, BAD_CAST "gtt:interval-list");
+    topnode = xmlNewNode(NULL, BAD_CAST "gtt:interval-list");
 
-	for (p=list; p; p=p->next)
-	{
-		GttInterval *ivl = p->data;
-		node = gtt_xml_interval_to_dom_tree (ivl);
-		xmlAddChild (topnode, node);
-	}
+    for (p = list; p; p = p->next)
+    {
+        GttInterval *ivl = p->data;
+        node = gtt_xml_interval_to_dom_tree(ivl);
+        xmlAddChild(topnode, node);
+    }
 
-	return topnode;
+    return topnode;
 }
 
 /* ======================================================= */
 
 /* convert one task to a dom tree */
 
-static xmlNodePtr
-gtt_xml_task_to_dom_tree (GttTask *task)
+static xmlNodePtr gtt_xml_task_to_dom_tree(GttTask *task)
 {
-	GList *p;
-	xmlNodePtr node, topnode;
+    GList *p;
+    xmlNodePtr node, topnode;
 
-	if (!task) return NULL;
+    if (!task)
+        return NULL;
 
-	topnode = xmlNewNode (NULL, BAD_CAST "gtt:task");
+    topnode = xmlNewNode(NULL, BAD_CAST "gtt:task");
 
-	PUT_GUID ("guid", gtt_task_get_guid(task));
-	PUT_STR ("memo", gtt_task_get_memo(task));
-	PUT_STR ("notes", gtt_task_get_notes(task));
-	PUT_INT ("bill_unit", gtt_task_get_bill_unit(task));
+    PUT_GUID("guid", gtt_task_get_guid(task));
+    PUT_STR("memo", gtt_task_get_memo(task));
+    PUT_STR("notes", gtt_task_get_notes(task));
+    PUT_INT("bill_unit", gtt_task_get_bill_unit(task));
 
-	PUT_ENUM_3 ("billable", gtt_task_get_billable(task),
-		BILLABLE, NOT_BILLABLE, NO_CHARGE);
-	PUT_ENUM_4 ("billrate", gtt_task_get_billrate(task),
-		REGULAR, OVERTIME, OVEROVER, FLAT_FEE);
-	PUT_ENUM_3 ("billstatus", gtt_task_get_billstatus(task),
-		HOLD, BILL, PAID);
+    PUT_ENUM_3("billable", gtt_task_get_billable(task), BILLABLE, NOT_BILLABLE, NO_CHARGE);
+    PUT_ENUM_4("billrate", gtt_task_get_billrate(task), REGULAR, OVERTIME, OVEROVER, FLAT_FEE);
+    PUT_ENUM_3("billstatus", gtt_task_get_billstatus(task), HOLD, BILL, PAID);
 
+    /* add list of intervals */
+    p = gtt_task_get_intervals(task);
+    node = gtt_interval_list_to_dom_tree(p);
+    xmlAddChild(topnode, node);
 
-	/* add list of intervals */
-	p = gtt_task_get_intervals (task);
-	node = gtt_interval_list_to_dom_tree (p);
-	xmlAddChild (topnode, node);
-
-	return topnode;
+    return topnode;
 }
 
 /* convert a list of gtt tasks into a DOM tree */
-static xmlNodePtr
-gtt_task_list_to_dom_tree (GList *list)
+static xmlNodePtr gtt_task_list_to_dom_tree(GList *list)
 {
-	GList *p;
-	xmlNodePtr topnode;
-	xmlNodePtr node;
+    GList *p;
+    xmlNodePtr topnode;
+    xmlNodePtr node;
 
-	if (!list) return NULL;
+    if (!list)
+        return NULL;
 
-	topnode = xmlNewNode (NULL, BAD_CAST "gtt:task-list");
+    topnode = xmlNewNode(NULL, BAD_CAST "gtt:task-list");
 
-	for (p=list; p; p=p->next)
-	{
-		GttTask *task = p->data;
-		node = gtt_xml_task_to_dom_tree (task);
-		xmlAddChild (topnode, node);
-	}
+    for (p = list; p; p = p->next)
+    {
+        GttTask *task = p->data;
+        node = gtt_xml_task_to_dom_tree(task);
+        xmlAddChild(topnode, node);
+    }
 
-	return topnode;
+    return topnode;
 }
 
 /* ======================================================= */
 
-
 /* convert one project into a dom tree */
-static xmlNodePtr
-gtt_xml_project_to_dom_tree (GttProject *prj)
+static xmlNodePtr gtt_xml_project_to_dom_tree(GttProject *prj)
 {
-	GList *children, *tasks;
-	xmlNodePtr node, topnode;
+    GList *children, *tasks;
+    xmlNodePtr node, topnode;
 
-	if (!prj) return NULL;
-	topnode = xmlNewNode (NULL, BAD_CAST "gtt:project");
+    if (!prj)
+        return NULL;
+    topnode = xmlNewNode(NULL, BAD_CAST "gtt:project");
 
-	node = xmlNewNode (NULL, BAD_CAST "title");
-	xmlNodeAddContent(node, BAD_CAST gtt_project_get_title(prj));
-	xmlAddChild (topnode, node);
+    node = xmlNewNode(NULL, BAD_CAST "title");
+    xmlNodeAddContent(node, BAD_CAST gtt_project_get_title(prj));
+    xmlAddChild(topnode, node);
 
-	PUT_GUID ("guid", gtt_project_get_guid(prj));
-	PUT_STR ("desc", gtt_project_get_desc(prj));
-	PUT_STR ("notes", gtt_project_get_notes(prj));
-	PUT_STR ("custid", gtt_project_get_custid(prj));
+    PUT_GUID("guid", gtt_project_get_guid(prj));
+    PUT_STR("desc", gtt_project_get_desc(prj));
+    PUT_STR("notes", gtt_project_get_notes(prj));
+    PUT_STR("custid", gtt_project_get_custid(prj));
 
-	PUT_INT ("id", gtt_project_get_id(prj));
+    PUT_INT("id", gtt_project_get_id(prj));
 
-	PUT_DBL ("billrate", gtt_project_get_billrate(prj));
-	PUT_DBL ("overtime_rate", gtt_project_get_overtime_rate(prj));
-	PUT_DBL ("overover_rate", gtt_project_get_overover_rate(prj));
-	PUT_DBL ("flat_fee", gtt_project_get_flat_fee(prj));
+    PUT_DBL("billrate", gtt_project_get_billrate(prj));
+    PUT_DBL("overtime_rate", gtt_project_get_overtime_rate(prj));
+    PUT_DBL("overover_rate", gtt_project_get_overover_rate(prj));
+    PUT_DBL("flat_fee", gtt_project_get_flat_fee(prj));
 
-	PUT_INT ("min_interval", gtt_project_get_min_interval(prj));
-	PUT_INT ("auto_merge_interval", gtt_project_get_auto_merge_interval(prj));
-	PUT_INT ("auto_merge_gap", gtt_project_get_auto_merge_gap(prj));
+    PUT_INT("min_interval", gtt_project_get_min_interval(prj));
+    PUT_INT("auto_merge_interval", gtt_project_get_auto_merge_interval(prj));
+    PUT_INT("auto_merge_gap", gtt_project_get_auto_merge_gap(prj));
 
-	PUT_LONG ("estimated_start", gtt_project_get_estimated_start(prj));
-	PUT_LONG ("estimated_end", gtt_project_get_estimated_end(prj));
-	PUT_LONG ("due_date", gtt_project_get_due_date(prj));
+    PUT_LONG("estimated_start", gtt_project_get_estimated_start(prj));
+    PUT_LONG("estimated_end", gtt_project_get_estimated_end(prj));
+    PUT_LONG("due_date", gtt_project_get_due_date(prj));
 
-	PUT_INT ("sizing", gtt_project_get_sizing(prj));
-	PUT_INT ("percent_complete", gtt_project_get_percent_complete(prj));
+    PUT_INT("sizing", gtt_project_get_sizing(prj));
+    PUT_INT("percent_complete", gtt_project_get_percent_complete(prj));
 
-	PUT_ENUM_4 ("urgency", gtt_project_get_urgency(prj),
-		UNDEFINED, LOW, MEDIUM, HIGH);
-	PUT_ENUM_4 ("importance", gtt_project_get_importance(prj),
-		UNDEFINED, LOW, MEDIUM, HIGH);
-	PUT_ENUM_6 ("status", gtt_project_get_status(prj),
-		NO_STATUS, NOT_STARTED, IN_PROGRESS, ON_HOLD, CANCELLED, COMPLETED);
+    PUT_ENUM_4("urgency", gtt_project_get_urgency(prj), UNDEFINED, LOW, MEDIUM, HIGH);
+    PUT_ENUM_4("importance", gtt_project_get_importance(prj), UNDEFINED, LOW, MEDIUM, HIGH);
+    PUT_ENUM_6(
+        "status", gtt_project_get_status(prj), NO_STATUS, NOT_STARTED, IN_PROGRESS, ON_HOLD,
+        CANCELLED, COMPLETED
+    );
 
-	/* handle tasks */
-	tasks = gtt_project_get_tasks(prj);
-	node = gtt_task_list_to_dom_tree (tasks);
-	xmlAddChild (topnode, node);
+    /* handle tasks */
+    tasks = gtt_project_get_tasks(prj);
+    node = gtt_task_list_to_dom_tree(tasks);
+    xmlAddChild(topnode, node);
 
-	/* handle sub-projects */
-	children = gtt_project_get_children (prj);
-	if (children)
-	{
-		node = gtt_project_list_to_dom_tree (children);
-		xmlAddChild (topnode, node);
-	}
+    /* handle sub-projects */
+    children = gtt_project_get_children(prj);
+    if (children)
+    {
+        node = gtt_project_list_to_dom_tree(children);
+        xmlAddChild(topnode, node);
+    }
 
-	return topnode;
+    return topnode;
 }
 
 /* convert a list of gtt projects into a DOM tree */
-static xmlNodePtr
-gtt_project_list_to_dom_tree (GList *list)
+static xmlNodePtr gtt_project_list_to_dom_tree(GList *list)
 {
-	GList *p;
-	xmlNodePtr topnode;
-	xmlNodePtr node;
+    GList *p;
+    xmlNodePtr topnode;
+    xmlNodePtr node;
 
-	if (!list) return NULL;
+    if (!list)
+        return NULL;
 
-	topnode = xmlNewNode (NULL, BAD_CAST "gtt:project-list");
+    topnode = xmlNewNode(NULL, BAD_CAST "gtt:project-list");
 
-	for (p=list; p; p=p->next)
-	{
-		GttProject *prj = p->data;
-		node = gtt_xml_project_to_dom_tree (prj);
-		xmlAddChild (topnode, node);
-	}
+    for (p = list; p; p = p->next)
+    {
+        GttProject *prj = p->data;
+        node = gtt_xml_project_to_dom_tree(prj);
+        xmlAddChild(topnode, node);
+    }
 
-	return topnode;
+    return topnode;
 }
 
 /* ======================================================= */
 
 /* convert all gtt state into a DOM tree */
-static xmlNodePtr
-gtt_to_dom_tree (void)
+static xmlNodePtr gtt_to_dom_tree(void)
 {
-	xmlNodePtr topnode;
-	xmlNodePtr node;
-	// xmlNsPtr   ns;
+    xmlNodePtr topnode;
+    xmlNodePtr node;
+    // xmlNsPtr   ns;
 
-	topnode = xmlNewNode(NULL, BAD_CAST "gtt:gtt");
-	xmlSetProp(topnode, BAD_CAST "version", BAD_CAST "1.0.1");
+    topnode = xmlNewNode(NULL, BAD_CAST "gtt:gtt");
+    xmlSetProp(topnode, BAD_CAST "version", BAD_CAST "1.0.1");
 
+    // XXX TODO do we even need to call this?
+    // ns = xmlNewNs (topnode, BAD_CAST "file:" GTTDATADIR "/gtt.dtd", BAD_CAST "gtt");
+    xmlNewNs(topnode, BAD_CAST "file:" GTTDATADIR "/gtt.dtd", BAD_CAST "gtt");
 
-	// XXX TODO do we even need to call this?
-	// ns = xmlNewNs (topnode, BAD_CAST "file:" GTTDATADIR "/gtt.dtd", BAD_CAST "gtt");
-	xmlNewNs (topnode, BAD_CAST "file:" GTTDATADIR "/gtt.dtd", BAD_CAST "gtt");
+    node = gtt_project_list_to_dom_tree(gtt_project_list_get_list(master_list));
+    if (node)
+        xmlAddChild(topnode, node);
 
-	node = gtt_project_list_to_dom_tree (gtt_project_list_get_list(master_list));
-	if (node) xmlAddChild (topnode, node);
-
-	return topnode;
+    return topnode;
 }
 
 /* Write all gtt data to xml file */
 
-void
-gtt_xml_write_file (const char * filename)
+void gtt_xml_write_file(const char *filename)
 {
-	char * tmpfilename;
-	xmlNodePtr topnode;
-	FILE *fh;
-	int rc;
+    char *tmpfilename;
+    xmlNodePtr topnode;
+    FILE *fh;
+    int rc;
 
-	tmpfilename = g_strconcat (filename, ".tmp", NULL);
-	fh = fopen (tmpfilename, "w");
-	g_free (tmpfilename);
-	if (!fh) { gtt_err_set_code (GTT_CANT_OPEN_FILE); return; }
+    tmpfilename = g_strconcat(filename, ".tmp", NULL);
+    fh = fopen(tmpfilename, "w");
+    g_free(tmpfilename);
+    if (!fh)
+    {
+        gtt_err_set_code(GTT_CANT_OPEN_FILE);
+        return;
+    }
 
-	topnode = gtt_to_dom_tree();
+    topnode = gtt_to_dom_tree();
 
-	fprintf(fh, "<?xml version=\"1.0\"?>\n");
-	xmlElemDump (fh, NULL, topnode);
-	xmlFreeNode (topnode);
+    fprintf(fh, "<?xml version=\"1.0\"?>\n");
+    xmlElemDump(fh, NULL, topnode);
+    xmlFreeNode(topnode);
 
-	fprintf(fh, "\n");
+    fprintf(fh, "\n");
 
-	/* The algorithm we use here is to write to a tmp file,
-	 * make sure that the write succeeded, and only then
-	 * rename the temp file to the real file name.  Note that
-	 * certain errors (e.g. no room on disk) are not reported
-	 * until the fclose, which makes this an important code
-	 * to check.
-	 * Sure wish there was a way of finding out if xmlElemDump
-	 * suceeded ...
-	 */
-	rc = fflush (fh);
-	if (rc) { gtt_err_set_code (GTT_CANT_WRITE_FILE); return; }
+    /* The algorithm we use here is to write to a tmp file,
+     * make sure that the write succeeded, and only then
+     * rename the temp file to the real file name.  Note that
+     * certain errors (e.g. no room on disk) are not reported
+     * until the fclose, which makes this an important code
+     * to check.
+     * Sure wish there was a way of finding out if xmlElemDump
+     * suceeded ...
+     */
+    rc = fflush(fh);
+    if (rc)
+    {
+        gtt_err_set_code(GTT_CANT_WRITE_FILE);
+        return;
+    }
 
-	rc = fclose (fh);
-	if (rc) { gtt_err_set_code (GTT_CANT_WRITE_FILE); return; }
+    rc = fclose(fh);
+    if (rc)
+    {
+        gtt_err_set_code(GTT_CANT_WRITE_FILE);
+        return;
+    }
 
-	/* If we were truly paranoid, we could, at this point, try
-	 * to re-open and re-read the data file, and then match what
-	 * we read to the existing gtt data.   I'm not sure if
-	 * I should be that paranoid.  However, once upon a time,
-	 * I did loose all my data during a gnome-desktop-shutdown,
-	 * which freaked me out, but I cannot reproduce this loss.
-	 * What to do, what to do ...
-	 */
+    /* If we were truly paranoid, we could, at this point, try
+     * to re-open and re-read the data file, and then match what
+     * we read to the existing gtt data.   I'm not sure if
+     * I should be that paranoid.  However, once upon a time,
+     * I did loose all my data during a gnome-desktop-shutdown,
+     * which freaked me out, but I cannot reproduce this loss.
+     * What to do, what to do ...
+     */
 
-	tmpfilename = g_strconcat (filename, ".tmp", NULL);
-	rc = rename (tmpfilename, filename);
-	g_free (tmpfilename);
-	if (rc) { gtt_err_set_code (GTT_CANT_WRITE_FILE); return; }
+    tmpfilename = g_strconcat(filename, ".tmp", NULL);
+    rc = rename(tmpfilename, filename);
+    g_free(tmpfilename);
+    if (rc)
+    {
+        gtt_err_set_code(GTT_CANT_WRITE_FILE);
+        return;
+    }
 }
 
 /* ===================== END OF FILE ================== */


### PR DESCRIPTION
This pull request splits the adjustment of the formatting out of #7. The style is different than in #7 though.

Since Gnome seems to prefer _GNU_ style generally and this clearly being in the realm of Gnome I decided to start off with the default "GNU" style of clang-format and adjust it to better fit to the codebase. Honestly I'm not really satisfied with the solution, but I hope to have reached a viable compromise. Since the existing codebase is not formatted coherently too (there are spots indented with spaces, some intends are off, sometimes there are breaks after the return types, sometimes not) I guess that's as best as it gets.

@oskarb Feel welcome to comment if you have ideas to match the existing coding style even better or if some of my choices seem odd to you.