### PR TITLE
Add Meson as additional (future?) build system

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,16 +41,19 @@ dnl *****************************************
 dnl pkg-config check time
 dnl *****************************************
 
-LIBGNOME_REQUIRED=2.0.0
-LIBGNOMEUI_REQUIRED=2.0.3
-GLIB_REQUIRED=2.40
-GTK_REQUIRED=2.24
-LIBGLADE_REQUIRED=2.0.0
-LIBGTKHTML_REQUIRED=3.0.0
-LIBXML2_REQUIRED=2.0.0
-SCROLLKEEPER_BUILD_REQUIRED=0.3.5
-LIBQOF_REQUIRED_MIN=0.6.0
-LIBDBUS_REQUIRED_MIN=0.74
+GCONF_REQUIRED=3.2.6
+LIBGNOME_REQUIRED=2.32.1
+LIBGNOMEUI_REQUIRED=2.24.5
+GLIB_REQUIRED=2.40.2
+GTK_REQUIRED=2.24.23
+LIBGLADE_REQUIRED=2.6.4
+LIBGTKHTML_REQUIRED=3.32.2
+LIBXML2_REQUIRED=2.9.1
+SCROLLKEEPER_BUILD_REQUIRED=0.8.1
+LIBQOF_REQUIRED_MIN=0.8.6
+LIBDBUS_REQUIRED_MIN=0.100.2
+X11_REQUIRED=1.6.2
+XSCRNSAVER_REQUIRED=1.2.2
 
 dnl *****************************************
 dnl Check for guile
@@ -100,7 +103,7 @@ AC_SUBST(LIBGNOMEUI_LIBS)
 dnl *****************************************
 dnl Check for X11
 dnl *****************************************
-PKG_CHECK_MODULES(X11, x11)
+PKG_CHECK_MODULES(X11, x11 >= $X11_REQUIRED)
 AC_SUBST(X11_CFLAGS)
 AC_SUBST(X11_LIBS)
 
@@ -123,7 +126,7 @@ fi
 dnl *****************************************
 dnl Check for gconf
 dnl *****************************************
-PKG_CHECK_MODULES(GCONF, gconf-2.0)
+PKG_CHECK_MODULES(GCONF, gconf-2.0 >= $GCONF_REQUIRED)
 AC_SUBST(GCONF_CFLAGS)
 AC_SUBST(GCONF_LIBS)
 
@@ -140,7 +143,7 @@ dnl packaged in unexpected ways for different OS'es:
 dnl called xscrnsaver in RedHat/SuSE
 dnl called libxss, libxss-dev in Debian/Ubuntu
 dnl **************************************************************
-PKG_CHECK_MODULES(XSS_EXTENSION, xscrnsaver)
+PKG_CHECK_MODULES(XSS_EXTENSION, xscrnsaver >= $XSCRNSAVER_REQUIRED)
 AC_SUBST(XSS_EXTENSION_CFLAGS)
 AC_SUBST(XSS_EXTENSION_LIBS)
 

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,47 @@
+# Meson is intended as the future build system of the GnoTime project. For now
+# this file serves for IDE integration only and does nothing more than just
+# building the application.
+
+project(
+  'GnoTime',
+  'c',
+  license: 'GPL-2.0-or-later',
+  meson_version: '>= 1.0.0',
+  version: '3.0.0',
+)
+gtt_version_suffix = '_dev'
+
+add_project_link_arguments(
+  '-lm',
+  language: 'c',
+)
+
+dbus_glib_req = '>= 0.100.2'
+gconf_req = '>= 3.2.6'
+glib_req = '>= 2.40.2'
+gtk_req = '>= 2.24.23'
+gtk_html_req = '>= 3.32.2'
+guile_req = '>= 2.0.9'
+libglade_req = '>= 2.6.4'
+libgnome_req = '>= 2.32.1'
+libgnomeui_req = '>= 2.24.5'
+libxml_req = '>= 2.9.1'
+qof_req = '>= 0.8.7'
+x11_req = '>= 1.6.2'
+xscrnsaver_req = '>= 1.2.2'
+
+dbus_glib_dep = dependency('dbus-glib-1', required: false, version: dbus_glib_req)
+gconf_dep = dependency('gconf-2.0', version: gconf_req)
+glib_dep = dependency('glib-2.0', version: glib_req)
+gtk_dep = dependency('gtk+-2.0', version: gtk_req)
+gtk_html_dep = dependency('libgtkhtml-3.14', version: gtk_html_req)
+guile_dep = dependency('guile-2.0', version: guile_req)
+libglade_dep = dependency('libglade-2.0', version: libglade_req)
+libgnome_dep = dependency('libgnome-2.0', version: libgnome_req)
+libgnomeui_dep = dependency('libgnomeui-2.0', version: libgnomeui_req)
+libxml_dep = dependency('libxml-2.0', version: libxml_req)
+qof_dep = dependency('qof', version: qof_req)
+x11_dep = dependency('x11', version: x11_req)
+xscrnsaver_dep = dependency('xscrnsaver', version: xscrnsaver_req)
+
+subdir('src')

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,6 +26,7 @@ gnotime_SOURCES =     \
 	gtt-gsettings-io-p.c \
 	gtt-gsettings-io.c \
 	idle-dialog.c      \
+	idle-timer.c       \
 	journal.c          \
 	log.c              \
 	main.c             \
@@ -71,6 +72,7 @@ noinst_HEADERS =      \
 	gtt-gsettings-io.h \
 	gtt.h              \
 	idle-dialog.h      \
+	idle-timer.h       \
 	journal.h          \
 	log.h              \
 	menucmd.h          \

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,88 @@
+gnotime_cfg_data = configuration_data()
+gnotime_cfg_data.set_quoted('DATADIR', get_option('prefix') / get_option('datadir') / 'gnotime')
+gnotime_cfg_data.set_quoted('GETTEXT_PACKAGE', 'gnotime-2.0')
+gnotime_cfg_data.set_quoted('GNOME_ICONDIR', 'NONE' / get_option('datadir') / 'pixmaps')
+gnotime_cfg_data.set_quoted('GNOMELOCALEDIR', get_option('prefix') / get_option('localedir'))
+gnotime_cfg_data.set_quoted('GTTDATADIR', get_option('prefix') / get_option('datadir') / 'gnotime')
+gnotime_cfg_data.set_quoted('GTTGLADEDIR', get_option('prefix') / get_option('datadir') / 'gnotime')
+gnotime_cfg_data.set_quoted('LIBDIR', get_option('prefix') / get_option('libdir'))
+gnotime_cfg_data.set_quoted('PACKAGE', 'gnotime')
+gnotime_cfg_data.set_quoted('PREFIX', get_option('prefix'))
+gnotime_cfg_data.set_quoted('SYSCONFDIR', get_option('sysconfdir'))
+gnotime_cfg_data.set_quoted('VERSION', meson.project_version() + gtt_version_suffix)
+configure_file(
+  configuration: gnotime_cfg_data,
+  output: 'config.h',
+)
+
+gnotime_deps = [
+  gconf_dep,
+  glib_dep,
+  gtk_dep,
+  gtk_html_dep,
+  guile_dep,
+  libglade_dep,
+  libgnome_dep,
+  libgnomeui_dep,
+  libxml_dep,
+  qof_dep,
+  x11_dep,
+  xscrnsaver_dep,
+]
+if dbus_glib_dep.found()
+  dbus_glib_arg = '-DWITH_DBUS=1'
+  gnotime_deps += dbus_glib_dep
+else
+  dbus_glib_arg = '-DWITH_DBUS=0'
+endif
+
+gnotime_srcs = files(
+  'active-dialog.c',
+  'app.c',
+  'dbus.c',
+  'dialog.c',
+  'err.c',
+  'err-throw.c',
+  'export.c',
+  'file-io.c',
+  'gconf-gnomeui.c',
+  'gconf-io.c',
+  'ghtml.c',
+  'ghtml-deprecated.c',
+  'gtt-date-edit.c',
+  'gtt-gsettings-gnomeui.c',
+  'gtt-gsettings-io.c',
+  'gtt-gsettings-io-p.c',
+  'gtt-select-list.c',
+  'idle-dialog.c',
+  'idle-timer.c',
+  'journal.c',
+  'log.c',
+  'main.c',
+  'menucmd.c',
+  'menus.c',
+  'notes-area.c',
+  'plug-edit.c',
+  'plug-in.c',
+  'prefs.c',
+  'proj.c',
+  'projects-tree.c',
+  'proj-query.c',
+  'props-invl.c',
+  'props-proj.c',
+  'props-task.c',
+  'query.c',
+  'status-icon.c',
+  'timer.c',
+  'toolbar.c',
+  'util.c',
+  'xml-read.c',
+  'xml-write.c',
+)
+
+executable(
+  'gnotime',
+  gnotime_srcs,
+  cpp_args: dbus_glib_arg,
+  dependencies: gnotime_deps,
+)


### PR DESCRIPTION
This pull request introduces Meson as additional build system. Since I'm from the "CMake camp" this is a best effort try only, but it compiles a working binary. The Gnome ecosystem seems to be strongly invested in Meson, so I guess this is the right way to go for GnoTime. Right now I do not intend to replace Autotools by Meson, it's more a prototype to allow early integration and testing.