### PR TITLE
Replace gconf by gsettings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,7 @@
 # main makeile am for GnoTime
 # 
 
-SUBDIRS = doc gconf glade ghtml po redhat fedora src scripts
+SUBDIRS = data doc gconf glade ghtml po redhat fedora src scripts
 
 # old, obsolete location ??
 # Productivitydir = $(datadir)/gnome/apps/Applications

--- a/configure.in
+++ b/configure.in
@@ -22,6 +22,7 @@ AC_PROG_LN_S
 AC_PROG_MAKE_SET
 
 GNOME_COMPILE_WARNINGS
+GLIB_GSETTINGS
 
 AC_PATH_XTRA
 
@@ -292,6 +293,7 @@ AC_SUBST(LDFLAGS)
 
 AC_OUTPUT([
 Makefile
+data/Makefile
 doc/C/Makefile
 doc/C/man/Makefile
 doc/Makefile

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,0 +1,3 @@
+gsettings_SCHEMAS = org.gnotime.app.gschema.xml
+
+@GSETTINGS_RULES@

--- a/data/org.gnotime.app.gschema.xml
+++ b/data/org.gnotime.app.gschema.xml
@@ -1,5 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist gettext-domain="gnotime-2.0">
   <schema id="org.gnotime.app" path="/org/gnotime/app/">
+    <child name="geometry" schema="org.gnotime.app.geometry"/>
+  </schema>
+
+  <schema id="org.gnotime.app.geometry" path="/org/gnotime/app/geometry/">
+    <key name="h-paned" type="i">
+      <default>220</default>
+      <summary>TODO</summary>
+      <description>TODO</description>
+    </key>
+    <key name="height" type="i">
+      <default>272</default>
+      <summary>TODO</summary>
+      <description>TODO</description>
+    </key>
+    <key name="v-paned" type="i">
+      <default>250</default>
+      <summary>TODO</summary>
+      <description>TODO</description>
+    </key>
+    <key name="width" type="i">
+      <default>442</default>
+      <summary>TODO</summary>
+      <description>TODO</description>
+    </key>
+    <key name="x" type="i">
+      <default>10</default>
+      <summary>TODO</summary>
+      <description>TODO</description>
+    </key>
+    <key name="y" type="i">
+      <default>10</default>
+      <summary>TODO</summary>
+      <description>TODO</description>
+    </key>
   </schema>
 </schemalist>

--- a/data/org.gnotime.app.gschema.xml
+++ b/data/org.gnotime.app.gschema.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist gettext-domain="gnotime-2.0">
+  <schema id="org.gnotime.app" path="/org/gnotime/app/">
+  </schema>
+</schemalist>

--- a/data/org.gnotime.app.gschema.xml
+++ b/data/org.gnotime.app.gschema.xml
@@ -2,6 +2,7 @@
 <schemalist gettext-domain="gnotime-2.0">
   <schema id="org.gnotime.app" path="/org/gnotime/app/">
     <child name="geometry" schema="org.gnotime.app.geometry"/>
+    <child name="toolbar" schema="org.gnotime.app.toolbar"/>
   </schema>
 
   <schema id="org.gnotime.app.geometry" path="/org/gnotime/app/geometry/">
@@ -32,6 +33,59 @@
     </key>
     <key name="y" type="i">
       <default>10</default>
+      <summary>TODO</summary>
+      <description>TODO</description>
+    </key>
+  </schema>
+
+  <schema id="org.gnotime.app.toolbar" path="/org/gnotime/app/toolbar/">
+    <key name="show-ccp" type="b">
+      <default>false</default>
+      <summary>TODO</summary>
+      <description>TODO</description>
+    </key>
+    <key name="show-exit" type="b">
+      <default>true</default>
+      <summary>TODO</summary>
+      <description>TODO</description>
+    </key>
+    <key name="show-help" type="b">
+      <default>true</default>
+      <summary>TODO</summary>
+      <description>TODO</description>
+    </key>
+    <key name="show-journal" type="b">
+      <default>true</default>
+      <summary>TODO</summary>
+      <description>TODO</description>
+    </key>
+    <key name="show-new" type="b">
+      <default>true</default>
+      <summary>TODO</summary>
+      <description>TODO</description>
+    </key>
+    <key name="show-pref" type="b">
+      <default>false</default>
+      <summary>TODO</summary>
+      <description>TODO</description>
+    </key>
+    <key name="show-prop" type="b">
+      <default>true</default>
+      <summary>TODO</summary>
+      <description>TODO</description>
+    </key>
+    <key name="show-timer" type="b">
+      <default>true</default>
+      <summary>TODO</summary>
+      <description>TODO</description>
+    </key>
+    <key name="show-tips" type="b">
+      <default>true</default>
+      <summary>TODO</summary>
+      <description>TODO</description>
+    </key>
+    <key name="show-toolbar" type="b">
+      <default>true</default>
       <summary>TODO</summary>
       <description>TODO</description>
     </key>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(${PROJECT_NAME}
     gconf-io.c
     ghtml.c
     ghtml-deprecated.c
+    gtt-gsettings-io.c
     idle-dialog.c
     idle-timer.c
     journal.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(${PROJECT_NAME}
     ghtml.c
     ghtml-deprecated.c
     gtt-gsettings-io.c
+    gtt-gsettings-io-p.c
     idle-dialog.c
     idle-timer.c
     journal.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,6 +21,7 @@ gnotime_SOURCES =     \
 	gconf-io.c         \
 	ghtml.c            \
 	ghtml-deprecated.c \
+	gtt-gsettings-io.c \
 	idle-dialog.c      \
 	journal.c          \
 	log.c              \
@@ -60,6 +61,7 @@ noinst_HEADERS =      \
 	gconf-io-p.h       \
 	ghtml.h            \
 	ghtml-deprecated.h \
+	gtt-gsettings-io.h \
 	gtt.h              \
 	idle-dialog.h      \
 	journal.h          \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,6 +22,7 @@ gnotime_SOURCES =     \
 	ghtml.c            \
 	ghtml-deprecated.c \
 	gtt-gsettings-io.c \
+	gtt-gsettings-io-p.c \
 	idle-dialog.c      \
 	journal.c          \
 	log.c              \
@@ -62,6 +63,7 @@ noinst_HEADERS =      \
 	ghtml.h            \
 	ghtml-deprecated.h \
 	gtt-gsettings-io.h \
+	gtt-gsettings-io-p.h \
 	gtt.h              \
 	idle-dialog.h      \
 	journal.h          \

--- a/src/app.c
+++ b/src/app.c
@@ -18,6 +18,8 @@
  */
 #include "config.h"
 
+#include "gtt-gsettings-io.h"
+
 #include <gnome.h>
 #include <sched.h>
 #include <stdio.h>
@@ -559,6 +561,7 @@ void app_quit(GtkWidget *w, gpointer data)
 {
     save_properties();
     save_projects();
+    gtt_gsettings_deinit();
     gtt_status_icon_destroy();
     gtk_main_quit();
 }

--- a/src/file-io.c
+++ b/src/file-io.c
@@ -19,6 +19,8 @@
 
 #include "config.h"
 
+#include "gtt-gsettings-io.h"
+
 #include <errno.h>
 #include <glib.h>
 #include <gnome.h>
@@ -564,6 +566,8 @@ void gtt_load_config(void)
     const char *h;
     char *s;
 
+    gtt_gsettings_load();
+
     /* Check for gconf2, and use that if it exists */
     if (gtt_gconf_exists())
     {
@@ -689,6 +693,8 @@ void gtt_post_ctree_config(void)
 void gtt_save_config(void)
 {
     gtt_gconf_save();
+
+    gtt_gsettings_save();
 }
 
 /* ======================================================= */

--- a/src/gconf-io.c
+++ b/src/gconf-io.c
@@ -89,7 +89,6 @@ void gtt_save_reports_menu(void)
 void gtt_gconf_save(void)
 {
     char s[120];
-    int x, y, w, h;
     const char *xpn;
 
     GConfEngine *gengine;
@@ -99,21 +98,6 @@ void gtt_gconf_save(void)
     client = gconf_client_get_for_engine(gengine);
     SETINT("/dir_exists", 1);
 
-    /* ------------- */
-    /* save the window location and size */
-    gdk_window_get_origin(app_window->window, &x, &y);
-    gdk_window_get_size(app_window->window, &w, &h);
-    SETINT("/Geometry/Width", w);
-    SETINT("/Geometry/Height", h);
-    SETINT("/Geometry/X", x);
-    SETINT("/Geometry/Y", y);
-
-    {
-        int vp, hp;
-        notes_area_get_pane_sizes(global_na, &vp, &hp);
-        SETINT("/Geometry/VPaned", vp);
-        SETINT("/Geometry/HPaned", hp);
-    }
     /* ------------- */
     /* save the configure dialog values */
     SETBOOL("/Display/ShowSecs", config_show_secs);
@@ -377,33 +361,6 @@ void gtt_gconf_load(void)
     config_autosave_period = GETINT("/Misc/AutosavePeriod", 60);
     config_daystart_offset = GETINT("/Misc/DayStartOffset", 0);
     config_weekstart_offset = GETINT("/Misc/WeekStartOffset", 0);
-
-    /* Reset the main window width and height to the values
-     * last stored in the config file.  Note that if the user
-     * specified command-line flags, then the command line
-     * over-rides the config file. */
-    if (!geom_place_override)
-    {
-        int x, y;
-        x = GETINT("/Geometry/X", 10);
-        y = GETINT("/Geometry/Y", 10);
-        gtk_widget_set_uposition(GTK_WIDGET(app_window), x, y);
-    }
-    if (!geom_size_override)
-    {
-        int w, h;
-        w = GETINT("/Geometry/Width", 442);
-        h = GETINT("/Geometry/Height", 272);
-
-        gtk_window_set_default_size(GTK_WINDOW(app_window), w, h);
-    }
-
-    {
-        int vp, hp;
-        vp = GETINT("/Geometry/VPaned", 250);
-        hp = GETINT("/Geometry/HPaned", 220);
-        notes_area_set_pane_sizes(global_na, vp, hp);
-    }
 
     config_show_secs = GETBOOL("/Display/ShowSecs", FALSE);
 

--- a/src/gconf-io.c
+++ b/src/gconf-io.c
@@ -127,18 +127,6 @@ void gtt_gconf_save(void)
     SETSTR("/Display/ExpanderState", xpn);
 
     /* ------------- */
-    SETBOOL("/Toolbar/ShowToolbar", config_show_toolbar);
-    SETBOOL("/Toolbar/ShowTips", config_show_tb_tips);
-    SETBOOL("/Toolbar/ShowNew", config_show_tb_new);
-    SETBOOL("/Toolbar/ShowCCP", config_show_tb_ccp);
-    SETBOOL("/Toolbar/ShowJournal", config_show_tb_journal);
-    SETBOOL("/Toolbar/ShowProp", config_show_tb_prop);
-    SETBOOL("/Toolbar/ShowTimer", config_show_tb_timer);
-    SETBOOL("/Toolbar/ShowPref", config_show_tb_pref);
-    SETBOOL("/Toolbar/ShowHelp", config_show_tb_help);
-    SETBOOL("/Toolbar/ShowExit", config_show_tb_exit);
-
-    /* ------------- */
     if (config_shell_start)
     {
         SETSTR("/Actions/StartCommand", config_shell_start);
@@ -328,7 +316,6 @@ void gtt_restore_reports_menu(GnomeApp *app)
 void gtt_gconf_load(void)
 {
     int i, num;
-    int _n, _c, _j, _p, _t, _o, _h, _e;
     GConfClient *client;
 
     client = gconf_client_get_default();
@@ -343,15 +330,6 @@ void gtt_gconf_load(void)
          * the project list is destroyed ... */
         first_proj_title = g_strdup(gtt_project_get_title(cur_proj));
     }
-
-    _n = config_show_tb_new;
-    _c = config_show_tb_ccp;
-    _j = config_show_tb_journal;
-    _p = config_show_tb_prop;
-    _t = config_show_tb_timer;
-    _o = config_show_tb_pref;
-    _h = config_show_tb_help;
-    _e = config_show_tb_exit;
 
     /* Get last running project */
     cur_proj_id = GETINT("/Misc/CurrProject", -1);
@@ -390,18 +368,6 @@ void gtt_gconf_load(void)
     config_show_title_status = GETBOOL("/Display/ShowStatus", FALSE);
 
     prefs_update_projects_view();
-
-    /* ------------ */
-    config_show_toolbar = GETBOOL("/Toolbar/ShowToolbar", TRUE);
-    config_show_tb_tips = GETBOOL("/Toolbar/ShowTips", TRUE);
-    config_show_tb_new = GETBOOL("/Toolbar/ShowNew", TRUE);
-    config_show_tb_ccp = GETBOOL("/Toolbar/ShowCCP", FALSE);
-    config_show_tb_journal = GETBOOL("/Toolbar/ShowJournal", TRUE);
-    config_show_tb_prop = GETBOOL("/Toolbar/ShowProp", TRUE);
-    config_show_tb_timer = GETBOOL("/Toolbar/ShowTimer", TRUE);
-    config_show_tb_pref = GETBOOL("/Toolbar/ShowPref", FALSE);
-    config_show_tb_help = GETBOOL("/Toolbar/ShowHelp", TRUE);
-    config_show_tb_exit = GETBOOL("/Toolbar/ShowExit", TRUE);
 
     /* ------------ */
     config_shell_start = GETSTR(
@@ -460,13 +426,6 @@ void gtt_gconf_load(void)
     }
 
     update_status_bar();
-    if ((_n != config_show_tb_new) || (_c != config_show_tb_ccp)
-        || (_j != config_show_tb_journal) || (_p != config_show_tb_prop)
-        || (_t != config_show_tb_timer) || (_o != config_show_tb_pref)
-        || (_h != config_show_tb_help) || (_e != config_show_tb_exit))
-    {
-        update_toolbar_sections();
-    }
 }
 
 gchar *gtt_gconf_get_expander(void)

--- a/src/gtt-gsettings-io-p.c
+++ b/src/gtt-gsettings-io-p.c
@@ -14,15 +14,18 @@
  * 02111-1307  USA
  */
 
-#ifndef GTT_GSETTINGS_IO_H
-#define GTT_GSETTINGS_IO_H
+#include "gtt-gsettings-io-p.h"
 
-void gtt_gsettings_init(void);
-
-void gtt_gsettings_deinit(void);
-
-void gtt_gsettings_load(void);
-
-void gtt_gsettings_save(void);
-
-#endif // GTT_GSETTINGS_IO_H
+/**
+ * @brief Set an integer GSettings option and log a message on error
+ * @param settings The GSettings object to set the value on
+ * @param key The key of the value to be set
+ * @param value The actual value to be set
+ */
+void gtt_gsettings_set_int(GSettings *const settings, const gchar *const key, const gint value)
+{
+    if (FALSE == g_settings_set_int(settings, key, value))
+    {
+        g_warning("Failed to set integer option \"%s\" to value: %d", key, value);
+    }
+}

--- a/src/gtt-gsettings-io-p.c
+++ b/src/gtt-gsettings-io-p.c
@@ -17,6 +17,25 @@
 #include "gtt-gsettings-io-p.h"
 
 /**
+ * @brief Set a boolean GSettings option and log a message on error
+ * @param settings The GSettings object to set the value on
+ * @param key The key of the value to be set
+ * @param value The actual value to be set
+ */
+void gtt_gsettings_set_bool(
+    GSettings *const settings, const gchar *const key, const gboolean value
+)
+{
+    if (FALSE == g_settings_set_boolean(settings, key, value))
+    {
+        g_warning(
+            "Failed to set boolean option \"%s\" to value: %s", key,
+            (TRUE == value) ? "true" : "false"
+        );
+    }
+}
+
+/**
  * @brief Set an integer GSettings option and log a message on error
  * @param settings The GSettings object to set the value on
  * @param key The key of the value to be set

--- a/src/gtt-gsettings-io-p.h
+++ b/src/gtt-gsettings-io-p.h
@@ -19,6 +19,8 @@
 
 #include <gio/gio.h>
 
+void gtt_gsettings_set_bool(GSettings *settings, const gchar *key, gboolean value);
+
 void gtt_gsettings_set_int(GSettings *settings, const gchar *key, gint value);
 
 #endif // GTT_GSETTINGS_IO_P_H

--- a/src/gtt-gsettings-io-p.h
+++ b/src/gtt-gsettings-io-p.h
@@ -14,15 +14,11 @@
  * 02111-1307  USA
  */
 
-#ifndef GTT_GSETTINGS_IO_H
-#define GTT_GSETTINGS_IO_H
+#ifndef GTT_GSETTINGS_IO_P_H
+#define GTT_GSETTINGS_IO_P_H
 
-void gtt_gsettings_init(void);
+#include <gio/gio.h>
 
-void gtt_gsettings_deinit(void);
+void gtt_gsettings_set_int(GSettings *settings, const gchar *key, gint value);
 
-void gtt_gsettings_load(void);
-
-void gtt_gsettings_save(void);
-
-#endif // GTT_GSETTINGS_IO_H
+#endif // GTT_GSETTINGS_IO_P_H

--- a/src/gtt-gsettings-io.c
+++ b/src/gtt-gsettings-io.c
@@ -16,6 +16,9 @@
 
 #include "gtt-gsettings-io.h"
 
+#include "app.h"
+#include "gtt-gsettings-io-p.h"
+
 #include <gio/gio.h>
 
 static GSettings *settings_obj = NULL;
@@ -52,4 +55,64 @@ void gtt_gsettings_init(void)
     }
 
     settings_obj = g_settings_new("org.gnotime.app");
+}
+
+void gtt_gsettings_load(void)
+{
+    // Geometry ----------------------------------------------------------------
+    {
+        GSettings *geometry = g_settings_get_child(settings_obj, "geometry");
+
+        // Reset the main window width and height to the values last stored in the config file.
+        // Note that if the user specified commandline flags, then the command line over-rides
+        // the config file.
+        if (FALSE == geom_place_override)
+        {
+            const gint x = g_settings_get_int(geometry, "x");
+            const gint y = g_settings_get_int(geometry, "y");
+            gtk_widget_set_uposition(GTK_WIDGET(app_window), x, y);
+        }
+
+        if (FALSE == geom_size_override)
+        {
+            const gint w = g_settings_get_int(geometry, "width");
+            const gint h = g_settings_get_int(geometry, "height");
+            gtk_window_set_default_size(GTK_WINDOW(app_window), w, h);
+        }
+
+        const gint vp = g_settings_get_int(geometry, "v-paned");
+        const gint hp = g_settings_get_int(geometry, "h-paned");
+        notes_area_set_pane_sizes(global_na, vp, hp);
+
+        g_object_unref(geometry);
+        geometry = NULL;
+    }
+}
+
+void gtt_gsettings_save(void)
+{
+    // Geometry ----------------------------------------------------------------
+    {
+        GSettings *geometry = g_settings_get_child(settings_obj, "geometry");
+
+        // Save the window location and size
+        gint x, y;
+        gdk_window_get_origin(app_window->window, &x, &y);
+        gint w, h;
+        gdk_window_get_size(app_window->window, &w, &h);
+        gtt_gsettings_set_int(geometry, "width", w);
+        gtt_gsettings_set_int(geometry, "height", h);
+        gtt_gsettings_set_int(geometry, "x", x);
+        gtt_gsettings_set_int(geometry, "y", y);
+
+        {
+            int vp, hp;
+            notes_area_get_pane_sizes(global_na, &vp, &hp);
+            gtt_gsettings_set_int(geometry, "v-paned", vp);
+            gtt_gsettings_set_int(geometry, "h-paned", hp);
+        }
+
+        g_object_unref(geometry);
+        geometry = NULL;
+    }
 }

--- a/src/gtt-gsettings-io.c
+++ b/src/gtt-gsettings-io.c
@@ -27,6 +27,14 @@ static GSettings *settings_obj = NULL;
  */
 void gtt_gsettings_deinit(void)
 {
+    if (G_UNLIKELY(NULL == settings_obj))
+    {
+        g_warning("GSettings object is not initialized unexpectedly");
+
+        return;
+    }
+
+    g_clear_object(&settings_obj);
 }
 
 /**
@@ -36,4 +44,12 @@ void gtt_gsettings_deinit(void)
  */
 void gtt_gsettings_init(void)
 {
+    if (G_UNLIKELY(NULL != settings_obj))
+    {
+        g_warning("GSettings object is initialized unexpectedly");
+
+        return;
+    }
+
+    settings_obj = g_settings_new("org.gnotime.app");
 }

--- a/src/gtt-gsettings-io.c
+++ b/src/gtt-gsettings-io.c
@@ -1,0 +1,39 @@
+/* GSettings configuration handling for GnoTime - a time tracker
+ * Copyright (C) 2023      Markus Prasser
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ */
+
+#include "gtt-gsettings-io.h"
+
+#include <gio/gio.h>
+
+static GSettings *settings_obj = NULL;
+
+/**
+ * @brief Free the internally held GSettings object
+ *
+ * This should be called once on application shutdown AFTER all settings have been stored.
+ */
+void gtt_gsettings_deinit(void)
+{
+}
+
+/**
+ * @brief Initialize the primary GSettings object of GnoTime
+ *
+ * This should be called once on application startup BEFORE any settings can be queried.
+ */
+void gtt_gsettings_init(void)
+{
+}

--- a/src/gtt-gsettings-io.c
+++ b/src/gtt-gsettings-io.c
@@ -18,6 +18,8 @@
 
 #include "app.h"
 #include "gtt-gsettings-io-p.h"
+#include "prefs.h"
+#include "toolbar.h"
 
 #include <gio/gio.h>
 
@@ -87,6 +89,42 @@ void gtt_gsettings_load(void)
         g_object_unref(geometry);
         geometry = NULL;
     }
+
+    const gboolean _c = config_show_tb_ccp;
+    const gboolean _e = config_show_tb_exit;
+    const gboolean _h = config_show_tb_help;
+    const gboolean _j = config_show_tb_journal;
+    const gboolean _n = config_show_tb_new;
+    const gboolean _o = config_show_tb_pref;
+    const gboolean _p = config_show_tb_prop;
+    const gboolean _t = config_show_tb_timer;
+
+    // Toolbar -----------------------------------------------------------------
+    {
+        GSettings *toolbar = g_settings_get_child(settings_obj, "toolbar");
+
+        config_show_tb_ccp = g_settings_get_boolean(toolbar, "show-ccp");
+        config_show_tb_exit = g_settings_get_boolean(toolbar, "show-exit");
+        config_show_tb_help = g_settings_get_boolean(toolbar, "show-help");
+        config_show_tb_journal = g_settings_get_boolean(toolbar, "show-journal");
+        config_show_tb_new = g_settings_get_boolean(toolbar, "show-new");
+        config_show_tb_pref = g_settings_get_boolean(toolbar, "show-pref");
+        config_show_tb_prop = g_settings_get_boolean(toolbar, "show-prop");
+        config_show_tb_tips = g_settings_get_boolean(toolbar, "show-tips");
+        config_show_tb_timer = g_settings_get_boolean(toolbar, "show-timer");
+        config_show_toolbar = g_settings_get_boolean(toolbar, "show-toolbar");
+
+        g_object_unref(toolbar);
+        toolbar = NULL;
+    }
+
+    if ((_n != config_show_tb_new) || (_c != config_show_tb_ccp)
+        || (_j != config_show_tb_journal) || (_p != config_show_tb_prop)
+        || (_t != config_show_tb_timer) || (_o != config_show_tb_pref)
+        || (_h != config_show_tb_help) || (_e != config_show_tb_exit))
+    {
+        update_toolbar_sections();
+    }
 }
 
 void gtt_gsettings_save(void)
@@ -114,5 +152,24 @@ void gtt_gsettings_save(void)
 
         g_object_unref(geometry);
         geometry = NULL;
+    }
+
+    // Toolbar -----------------------------------------------------------------
+    {
+        GSettings *toolbar = g_settings_get_child(settings_obj, "toolbar");
+
+        gtt_gsettings_set_bool(toolbar, "show-ccp", config_show_tb_ccp);
+        gtt_gsettings_set_bool(toolbar, "show-exit", config_show_tb_exit);
+        gtt_gsettings_set_bool(toolbar, "show-help", config_show_tb_help);
+        gtt_gsettings_set_bool(toolbar, "show-journal", config_show_tb_journal);
+        gtt_gsettings_set_bool(toolbar, "show-new", config_show_tb_new);
+        gtt_gsettings_set_bool(toolbar, "show-pref", config_show_tb_pref);
+        gtt_gsettings_set_bool(toolbar, "show-prop", config_show_tb_prop);
+        gtt_gsettings_set_bool(toolbar, "show-timer", config_show_tb_timer);
+        gtt_gsettings_set_bool(toolbar, "show-tips", config_show_tb_tips);
+        gtt_gsettings_set_bool(toolbar, "show-toolbar", config_show_toolbar);
+
+        g_object_unref(toolbar);
+        toolbar = NULL;
     }
 }

--- a/src/gtt-gsettings-io.h
+++ b/src/gtt-gsettings-io.h
@@ -1,0 +1,24 @@
+/* GSettings configuration handling for GnoTime - a time tracker
+ * Copyright (C) 2023      Markus Prasser
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ */
+
+#ifndef GTT_GSETTINGS_IO_H
+#define GTT_GSETTINGS_IO_H
+
+void gtt_gsettings_init(void);
+
+void gtt_gsettings_deinit(void);
+
+#endif // GTT_GSETTINGS_IO_H

--- a/src/main.c
+++ b/src/main.c
@@ -20,6 +20,8 @@
 
 #include "config.h"
 
+#include "gtt-gsettings-io.h"
+
 #include <errno.h>
 #include <gconf/gconf.h>
 #include <gio/gio.h>
@@ -503,6 +505,8 @@ static void read_config_err_run_or_abort(GtkDialog *w, gint response_id)
 static void read_config(void)
 {
     GttErrCode conf_errcode;
+
+    gtt_gsettings_init();
 
     /* Try ... */
     gtt_err_set_code(GTT_NO_ERR);


### PR DESCRIPTION
This is an initial step of replacing _GConf_ by _GSettings_. The two categories "Geometry" and "Toolbar" have been chosen for this spike due to the simplicity of their data types.

If this approach seems fine I can realize all the other categories in this pull request or in a follow-up one (I'd propose the latter to keep the diff in a manageable size).

If anyone knows how to integrate this cleanly with Autotools, I'd take suggestions gladly. Just adding the respective lines to `Makefile.am` as suggested by the old Gnome documentation ([link](https://developer-old.gnome.org/GSettings)) was without effect on my tries.

Hint for the review: I tried to conduct the changes in small reviewable chunks, so having a look at the `git log` should make the review more plain.