### PR TITLE
src/util.c: Provide helper methods to load GtkBuilder files

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -81,6 +81,41 @@ GladeXML *gtt_glade_xml_new(const char *filename, const char *widget)
     return xml;
 }
 
+static GtkBuilder *gtt_builder_new_from_exact_file(const char *filename)
+{
+    GtkBuilder *builder = NULL;
+    GError *error = NULL;
+
+    builder = gtk_builder_new();
+    if (!gtk_builder_add_from_file(builder, filename, &error))
+    {
+        g_error ("failed to add UI from file %s: %s", filename, error->message);
+    }
+
+    return builder;
+}
+
+/* GtkBuilder loader, it will look in the right directories */
+GtkBuilder *gtt_builder_new_from_file(const char *filename)
+{
+    GtkBuilder *builder = NULL;
+
+    g_return_val_if_fail(filename != NULL, NULL);
+
+    if (g_file_test(filename, G_FILE_TEST_EXISTS))
+    {
+        builder = gtt_builder_new_from_exact_file(filename);
+    }
+    else
+    {
+        char *file = g_concat_dir_and_file(GTTGLADEDIR, filename);
+        builder = gtt_builder_new_from_exact_file(file);
+        g_free(file);
+    }
+
+    return builder;
+}
+
 /* ============================================================== */
 /* Used to be in qof, but is now deprecated there. */
 

--- a/src/util.h
+++ b/src/util.h
@@ -20,7 +20,7 @@
 #define __GTT_UTIL_H__
 
 #include <glade/glade.h>
-#include <gtk/gtktext.h>
+#include <gtk/gtk.h>
 
 /* ------------------------------------------------------------------ */
 /* some gtk-like utilities */
@@ -29,6 +29,9 @@ char *xxxgtk_textview_get_text(GtkTextView *text);
 
 /* Glade loader, it will look in the right directories */
 GladeXML *gtt_glade_xml_new(const char *filename, const char *widget);
+
+/* GtkBuilder loader, it will look in the right directories */
+GtkBuilder *gtt_builder_new_from_file(const char *filename);
 
 /* ------------------------------------------------------------------ */
 /* Functions that used to be in qof,m but are not there any longer. */


### PR DESCRIPTION
These mirror existing helpers for loading Glade files.

It should hopefully be an easy merge.