### PR TITLE
Drop libgnome pt1

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -18,7 +18,6 @@
 
 #include <config.h>
 #include <glib.h>
-#include <gnome.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -28,6 +27,7 @@
 #include "proj.h"
 
 #include <gio/gio.h>
+#include <glib/gi18n.h>
 
 #define CAN_LOG ((config_logfile_name != NULL) && (config_logfile_use))
 
@@ -45,7 +45,7 @@ static gboolean log_write(time_t t, const char *logstr)
     if ((config_logfile_name[0] == '~') && (config_logfile_name[1] == '/')
         && (config_logfile_name[2] != 0))
     {
-        filename = gnome_util_prepend_user_home(&config_logfile_name[2]);
+        filename = g_build_filename(g_get_home_dir(), &config_logfile_name[2], NULL);
 
         log_file = g_file_new_for_path(filename);
         g_free(filename);

--- a/src/main.c
+++ b/src/main.c
@@ -119,13 +119,17 @@ static void lock_gtt(void)
 
     if (warn)
     {
-        GtkWidget *warning;
-        warning = gnome_message_box_new(
-            _("There seems to be another GnoTime running.\n"
-              "Press OK to start GnoTime anyway, or press Cancel to quit."),
-            GNOME_MESSAGE_BOX_WARNING, GTK_STOCK_OK, GTK_STOCK_CANCEL, NULL
+        GtkWidget *warning = gtk_message_dialog_new(
+            NULL, GTK_DIALOG_MODAL, GTK_MESSAGE_WARNING, GTK_BUTTONS_OK_CANCEL,
+            _("There seems to be another GnoTime running.\nPress OK to start GnoTime anyway, "
+              "or press Cancel to quit.")
         );
-        if (gnome_dialog_run_and_close(GNOME_DIALOG(warning)) != 0)
+        const gint response = gtk_dialog_run(GTK_DIALOG(warning));
+
+        gtk_widget_destroy(warning);
+        warning = NULL;
+
+        if (GTK_RESPONSE_OK != response)
         {
             exit(0);
         }

--- a/src/plug-in.c
+++ b/src/plug-in.c
@@ -120,7 +120,7 @@ static void new_plugin_create_cb(GtkWidget *w, gpointer data)
         gchar *msg;
         GtkWidget *mb;
         msg = g_strdup_printf(_("Unable to open the report file %s\n"), path);
-        mb = gnome_message_box_new(msg, GNOME_MESSAGE_BOX_ERROR, GTK_STOCK_CLOSE, NULL);
+        mb = gtk_message_dialog_new(NULL, 0, GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE, "%s", msg);
         gtk_widget_show(mb);
         /* g_free (msg);   XXX memory leak needs fixing. */
     }


### PR DESCRIPTION
These are two really low hanging fruits in the process of getting rid of `libgnome(ui)`.