### PR TITLE
Task properties: use GtkComboBox instead of GtkOptionMenu

### DIFF
--- a/glade/task_properties.glade
+++ b/glade/task_properties.glade
@@ -348,41 +348,11 @@
 	      </child>
 
 	      <child>
-		<widget class="GtkOptionMenu" id="billstatus menu">
+		<widget class="GtkComboBox" id="billstatus menu">
 		  <property name="visible">True</property>
 		  <property name="tooltip" translatable="yes">Is this task ready to be billed to the customer? &quot;Hold&quot; means maybe, but not yet, needs review.   &quot;Bill&quot; means print this on the next invoice.   &quot;Paid&quot; means that it should no longer be included on invoices.</property>
-		  <property name="can_focus">True</property>
-		  <property name="history">0</property>
-
-		  <child internal-child="menu">
-		    <widget class="GtkMenu" id="convertwidget12">
-		      <property name="visible">True</property>
-
-		      <child>
-			<widget class="GtkMenuItem" id="convertwidget13">
-			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">Hold</property>
-			  <property name="use_underline">True</property>
-			</widget>
-		      </child>
-
-		      <child>
-			<widget class="GtkMenuItem" id="convertwidget14">
-			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">Bill</property>
-			  <property name="use_underline">True</property>
-			</widget>
-		      </child>
-
-		      <child>
-			<widget class="GtkMenuItem" id="convertwidget15">
-			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">Paid</property>
-			  <property name="use_underline">True</property>
-			</widget>
-		      </child>
-		    </widget>
-		  </child>
+		  <property name="can_focus">False</property>
+		  <property name="items" translatable="yes"/>
 		</widget>
 		<packing>
 		  <property name="left_attach">1</property>
@@ -395,41 +365,11 @@
 	      </child>
 
 	      <child>
-		<widget class="GtkOptionMenu" id="billable menu">
+		<widget class="GtkComboBox" id="billable menu">
 		  <property name="visible">True</property>
 		  <property name="tooltip" translatable="yes">How should this task be billed?  &quot;Billable&quot; means bill to the customer in the normal fashion.   &quot;Not Billable&quot; means we can't ask for money for this, don't print on the invoice.   &quot;No Charge&quot; means print on the invoice as 'free/no-charge'.</property>
-		  <property name="can_focus">True</property>
-		  <property name="history">0</property>
-
-		  <child internal-child="menu">
-		    <widget class="GtkMenu" id="convertwidget8">
-		      <property name="visible">True</property>
-
-		      <child>
-			<widget class="GtkMenuItem" id="convertwidget9">
-			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">Billable</property>
-			  <property name="use_underline">True</property>
-			</widget>
-		      </child>
-
-		      <child>
-			<widget class="GtkMenuItem" id="convertwidget10">
-			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">Not Billable</property>
-			  <property name="use_underline">True</property>
-			</widget>
-		      </child>
-
-		      <child>
-			<widget class="GtkMenuItem" id="convertwidget11">
-			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">No Charge</property>
-			  <property name="use_underline">True</property>
-			</widget>
-		      </child>
-		    </widget>
-		  </child>
+		  <property name="can_focus">False</property>
+		  <property name="items" translatable="yes"/>
 		</widget>
 		<packing>
 		  <property name="left_attach">1</property>
@@ -442,49 +382,11 @@
 	      </child>
 
 	      <child>
-		<widget class="GtkOptionMenu" id="billrate menu">
+		<widget class="GtkComboBox" id="billrate menu">
 		  <property name="visible">True</property>
 		  <property name="tooltip" translatable="yes">Fee rate to be charged for this task.</property>
-		  <property name="can_focus">True</property>
-		  <property name="history">0</property>
-
-		  <child internal-child="menu">
-		    <widget class="GtkMenu" id="convertwidget3">
-		      <property name="visible">True</property>
-
-		      <child>
-			<widget class="GtkMenuItem" id="convertwidget4">
-			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">Regular</property>
-			  <property name="use_underline">True</property>
-			</widget>
-		      </child>
-
-		      <child>
-			<widget class="GtkMenuItem" id="convertwidget5">
-			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">Overtime</property>
-			  <property name="use_underline">True</property>
-			</widget>
-		      </child>
-
-		      <child>
-			<widget class="GtkMenuItem" id="convertwidget6">
-			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">OverOver</property>
-			  <property name="use_underline">True</property>
-			</widget>
-		      </child>
-
-		      <child>
-			<widget class="GtkMenuItem" id="convertwidget7">
-			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">Flat Fee</property>
-			  <property name="use_underline">True</property>
-			</widget>
-		      </child>
-		    </widget>
-		  </child>
+		  <property name="can_focus">False</property>
+		  <property name="items" translatable="yes"/>
 		</widget>
 		<packing>
 		  <property name="left_attach">1</property>
@@ -562,3 +464,4 @@
 </widget>
 
 </glade-interface>
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(${PROJECT_NAME}
     props-proj.c
     props-task.c
     query.c
+    gtt-select-list.c
     status-icon.c
     timer.c
     toolbar.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -38,6 +38,7 @@ gnotime_SOURCES =     \
 	props-proj.c       \
 	props-task.c       \
 	query.c            \
+	gtt-select-list.c  \
 	status-icon.c      \
 	timer.c            \
 	toolbar.c          \
@@ -78,6 +79,7 @@ noinst_HEADERS =      \
 	props-proj.h       \
 	props-task.h       \
 	query.h            \
+	gtt-select-list.h  \
 	status-icon.h      \
 	timer.h            \
 	toolbar.h          \

--- a/src/gtt-select-list.c
+++ b/src/gtt-select-list.c
@@ -1,0 +1,153 @@
+/*   string/int GtkListStore for GtkComboBox (display name plus value)
+ *   Copyright (C) 2023 Oskar Berggren
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include "config.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "gtt-select-list.h"
+
+#define TEXT_COLUMN_ID 0
+#define VALUE_COLUMN_ID 1
+
+/************************************************************
+ * A "select-list" is a specialized GtkListStore holding
+ * a (display) text in the first column and some arbitrary
+ * integer identifying key in the second column.
+ *
+ * It can be used with GtkComboBox to display user-friendly
+ * strings, while allowing the program to directly set and
+ * retrieve a numerical constant (e.g. an enum value).
+ *
+ * Several convenience methods that operate directly on a
+ * GtkComboBox are offered.
+ ************************************************************/
+
+/**
+ * @brief Create a new select-list GtkListStore
+ */
+GtkListStore *gtt_select_list_new()
+{
+    GtkListStore *store;
+
+    store = gtk_list_store_new(2, G_TYPE_STRING, G_TYPE_INT);
+
+    return store;
+}
+
+/**
+ * @brief Append an item to a select-list GtkListStore
+ * @param text The display text for the item
+ * @param value An identifying value associated with the item
+ */
+void gtt_select_list_append(GtkListStore *store, const gchar *text, gint value)
+{
+    gtk_list_store_insert_with_values(
+        store, NULL, G_MAXINT, TEXT_COLUMN_ID, text, VALUE_COLUMN_ID, value, -1
+    );
+}
+
+/**
+ * @brief Find a select-list item based on the value property
+ * @param store The select-list GtkListStore
+ * @param iter A GtkTreeIter that will be set to the matching item, if found.
+ * @param value The value to search for.
+ */
+gboolean gtt_select_list_find_value(GtkListStore *store, GtkTreeIter *iter, gint value)
+{
+    GtkTreeModel *model = GTK_TREE_MODEL(store);
+    gint candidate;
+
+    if (!gtk_tree_model_get_iter_first(model, iter))
+    {
+        return FALSE;
+    }
+
+    do
+    {
+        gtk_tree_model_get(model, iter, 1, &candidate, -1);
+
+        if (candidate == value)
+            return TRUE;
+    }
+    while (gtk_tree_model_iter_next(model, iter));
+
+    return FALSE;
+}
+
+/**
+ * @brief Initialize a GtkComboBox with a new select-list GtkListStore
+ */
+void gtt_combo_select_list_init(GtkComboBox *combo_box)
+{
+    GtkListStore *store = gtt_select_list_new();
+    gtk_combo_box_set_model(combo_box, GTK_TREE_MODEL(store));
+
+    // Currently, we assume that the combo box is already set up
+    // with a text cell rendered for column 0. It would appear
+    // that Gtk (or glade?) does this by default.
+}
+
+/**
+ * @brief Append an item to the select-list GtkListStore use by the combo box
+ * @param text The display text for the item
+ * @param value An identifying value associated with the item
+ */
+void gtt_combo_select_list_append(GtkComboBox *combo_box, const gchar *text, gint value)
+{
+    GtkListStore *store;
+
+    store = GTK_LIST_STORE(gtk_combo_box_get_model(combo_box));
+
+    gtt_select_list_append(store, text, value);
+}
+
+/**
+ * @brief Set the active item of the combo box based on item value
+ */
+void gtt_combo_select_list_set_active_by_value(GtkComboBox *combo_box, gint value)
+{
+    GtkListStore *store;
+    GtkTreeIter iter;
+
+    store = GTK_LIST_STORE(gtk_combo_box_get_model(combo_box));
+
+    if (gtt_select_list_find_value(store, &iter, value))
+        gtk_combo_box_set_active_iter(combo_box, &iter);
+}
+
+/**
+ * @brief Get the value of the currently selected item
+ * @return The identifier value associated with the current item, or -1 if no item was active
+ */
+gint gtt_combo_select_list_get_value(GtkComboBox *combo_box)
+{
+    GtkListStore *store;
+    GtkTreeIter iter;
+    int value = -1;
+
+    store = GTK_LIST_STORE(gtk_combo_box_get_model(combo_box));
+
+    if (gtk_combo_box_get_active_iter(combo_box, &iter))
+    {
+        gtk_tree_model_get(GTK_TREE_MODEL(store), &iter, VALUE_COLUMN_ID, &value, -1);
+    }
+
+    return value;
+}

--- a/src/gtt-select-list.h
+++ b/src/gtt-select-list.h
@@ -1,0 +1,34 @@
+/*   string/int GtkListStore for GtkComboBox (display name plus value)
+ *   Copyright (C) 2023 Oskar Berggren
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef GTT_SELECT_LIST_H
+#define GTT_SELECT_LIST_H
+
+#include <gtk/gtk.h>
+
+GtkListStore *gtt_select_list_new();
+
+void gtt_select_list_append(GtkListStore *store, const gchar *text, gint value);
+gboolean gtt_select_list_find_value(GtkListStore *store, GtkTreeIter *iter, gint value);
+
+void gtt_combo_select_list_init(GtkComboBox *combo_box);
+void gtt_combo_select_list_append(GtkComboBox *combo_box, const gchar *text, gint value);
+void gtt_combo_select_list_set_active_by_value(GtkComboBox *combo_box, gint value);
+gint gtt_combo_select_list_get_value(GtkComboBox *combo_box);
+
+#endif /* GTT_SELECT_LIST_H */


### PR DESCRIPTION
GtkOptionMenu has been deprecated since forever. This replaces it with GtkComboBox in props-task.c.

The existing code attached the numeric values to the menu items. In the *save* code path, it grabbed the numeric value from the current selection. On the other hand, in the *load* code path, it assumed that the menu items appeared in a certain order.

The new code uses a GtkListStore with two columns, of which only one is visible. The first column is the display text, while the second column is the numeric value that will be stored in the task.

Various helper methods are introduced to work with this style of GtkListStore.
