### PR TITLE
Active dialog - convert from GtkOptionMenu to GtkComboBox

### DIFF
--- a/glade/active.glade
+++ b/glade/active.glade
@@ -149,15 +149,10 @@
 	      </child>
 
 	      <child>
-		<widget class="GtkOptionMenu" id="project option menu">
+		<widget class="GtkComboBox" id="project option menu">
 		  <property name="visible">True</property>
-		  <property name="can_focus">True</property>
-		  <property name="history">-1</property>
-
-		  <child>
-		    <widget class="GtkMenu" id="project menu">
-		    </widget>
-		  </child>
+		  <property name="can_focus">False</property>
+		  <property name="items"/>
 		</widget>
 		<packing>
 		  <property name="padding">5</property>


### PR DESCRIPTION
GtkOptionMenu has been deprecated since forever. This replaces it with GtkComboBox in active-dialog.c.

It's the final piece to resolve #12.