### PR TITLE
Reduce gnome.h include usage

### DIFF
--- a/src/active-dialog.c
+++ b/src/active-dialog.c
@@ -19,7 +19,7 @@
 #include "config.h"
 
 #include <glade/glade.h>
-#include <gnome.h>
+
 #include <string.h>
 
 #include <qof.h>
@@ -30,6 +30,8 @@
 #include "proj-query.h"
 #include "proj.h"
 #include "util.h"
+
+#include <glib/gi18n.h>
 
 int config_no_project_timeout;
 

--- a/src/app.h
+++ b/src/app.h
@@ -23,7 +23,6 @@
 #include "notes-area.h"
 #include "proj.h"
 #include "status-icon.h"
-#include <gnome.h>
 
 extern NotesArea *global_na; /* global ptr to notes GUI area */
 extern GttProjectsTree *projects_tree;

--- a/src/err-throw.c
+++ b/src/err-throw.c
@@ -18,10 +18,9 @@
 
 #include "config.h"
 
-#include <glib.h>
-#include <gnome.h> /* needed only to define the _() macro */
-
 #include "err-throw.h"
+
+#include <glib/gi18n.h>
 
 static GttErrCode err = GTT_NO_ERR;
 

--- a/src/err.c
+++ b/src/err.c
@@ -18,12 +18,13 @@
  */
 
 #include <config.h>
-#include <gnome.h>
 
 #include "gtt.h"
 
 #include <X11/Xlib.h>
 #include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 #undef DIE_ON_NORMAL_ERROR
 

--- a/src/export.c
+++ b/src/export.c
@@ -18,7 +18,7 @@
  */
 
 #include <config.h>
-#include <gnome.h>
+
 #include <string.h>
 
 #include "app.h"
@@ -27,6 +27,7 @@
 #include "proj.h"
 
 #include <gio/gio.h>
+#include <glib/gi18n.h>
 
 /* Project data export */
 

--- a/src/gconf-gnomeui.c
+++ b/src/gconf-gnomeui.c
@@ -19,7 +19,6 @@
 #include "config.h"
 
 #include <gconf/gconf-client.h>
-#include <gnome.h>
 
 #include "gconf-gnomeui.h"
 #include "gconf-io-p.h"

--- a/src/gconf-io.c
+++ b/src/gconf-io.c
@@ -21,7 +21,6 @@
 #include <gconf/gconf-client.h>
 #include <gconf/gconf.h>
 #include <glib.h>
-#include <gnome.h>
 
 #include "app.h"
 #include "cur-proj.h"

--- a/src/ghtml-deprecated.c
+++ b/src/ghtml-deprecated.c
@@ -19,7 +19,6 @@
 #include "config.h"
 
 #define _GNU_SOURCE
-#include <glib.h>
 #include <libguile.h>
 #include <stdio.h>
 #include <string.h>
@@ -32,6 +31,8 @@
 #include "gtt.h"
 #include "proj.h"
 #include "util.h"
+
+#include <glib/gi18n.h>
 
 /* This file contains deprecated routines, which should go away
  * sometime in 2004 or 2005, around gnotime version 3.0 or so

--- a/src/ghtml.c
+++ b/src/ghtml.c
@@ -19,7 +19,6 @@
 #include "config.h"
 
 #define _GNU_SOURCE
-#include <glib.h>
 #include <libguile.h>
 #include <libguile/backtrace.h>
 #include <limits.h>
@@ -43,6 +42,7 @@
 #include "util.h"
 
 #include <gio/gio.h>
+#include <glib/gi18n.h>
 
 /* Design problems:
  * The way this is currently defined, there is no type safety, and

--- a/src/gtt.h
+++ b/src/gtt.h
@@ -19,7 +19,7 @@
 #ifndef GTT_H
 #define GTT_H
 
-#include <gnome.h>
+#include <glib.h>
 
 #define GTT_APP_TITLE "Gnome Time Tracker"
 #define GTT_APP_PROPER_NAME "GnoTime"

--- a/src/idle-dialog.c
+++ b/src/idle-dialog.c
@@ -21,8 +21,7 @@
 
 #include <gdk/gdkx.h>
 #include <glade/glade.h>
-#include <glib.h>
-#include <gnome.h>
+
 #include <string.h>
 
 #include <X11/Xlib.h>
@@ -36,6 +35,8 @@
 #include "idle-dialog.h"
 #include "proj.h"
 #include "util.h"
+
+#include <glib/gi18n.h>
 
 int config_idle_timeout = -1;
 

--- a/src/notes-area.c
+++ b/src/notes-area.c
@@ -20,7 +20,6 @@
 #include <glib-object.h>
 
 #include <glade/glade.h>
-#include <gnome.h>
 
 #include "menus.h"
 #include "notes-area.h"

--- a/src/notes-area.h
+++ b/src/notes-area.h
@@ -20,7 +20,6 @@
 #define GTT_NOTES_AREA_H
 
 #include "projects-tree.h"
-#include <gnome.h>
 
 typedef struct NotesArea_s NotesArea;
 

--- a/src/plug-edit.c
+++ b/src/plug-edit.c
@@ -21,7 +21,6 @@
 #include "gtt-gsettings-io.h"
 
 #include <glade/glade.h>
-#include <gnome.h>
 
 #include "app.h"
 #include "dialog.h"

--- a/src/plug-in.c
+++ b/src/plug-in.c
@@ -21,7 +21,6 @@
 #include "gtt-gsettings-io.h"
 
 #include <glade/glade.h>
-#include <gnome.h>
 
 #include "app.h"
 #include "journal.h"

--- a/src/props-task.c
+++ b/src/props-task.c
@@ -19,14 +19,18 @@
 #include "config.h"
 
 #include <glade/glade.h>
-#include <gnome.h>
+
 #include <string.h>
 
 #include "dialog.h"
+#include "gtt-select-list.h"
 #include "proj.h"
 #include "props-task.h"
 #include "util.h"
-#include "gtt-select-list.h"
+
+#include <glib/gi18n.h>
+
+#include <stdlib.h>
 
 typedef struct PropTaskDlg_s
 {

--- a/src/status-icon.c
+++ b/src/status-icon.c
@@ -28,8 +28,10 @@
 
 #include "status-icon.h"
 #include "timer.h"
-#include <gnome.h>
+
 #include <gtk/gtk.h>
+
+#include <glib/gi18n.h>
 
 extern GtkWidget *app_window; /* global top-level window */
 

--- a/src/timer.c
+++ b/src/timer.c
@@ -18,7 +18,7 @@
  */
 
 #include <config.h>
-#include <gnome.h>
+
 #include <string.h>
 
 #include "active-dialog.h"

--- a/src/toolbar.c
+++ b/src/toolbar.c
@@ -18,7 +18,7 @@
  */
 
 #include <config.h>
-#include <gnome.h>
+
 #include <string.h>
 
 #include "app.h"

--- a/src/util.c
+++ b/src/util.c
@@ -20,7 +20,6 @@
 
 #include <glade/glade.h>
 #include <glib.h>
-#include <gnome.h>
 #include <qof.h>
 #include <stdio.h>
 #include <string.h>
@@ -74,7 +73,7 @@ GladeXML *gtt_glade_xml_new(const char *filename, const char *widget)
 
     if (xml == NULL)
     {
-        char *file = g_concat_dir_and_file(GTTGLADEDIR, filename);
+        char *file = g_build_filename(GTTGLADEDIR, filename, NULL);
         xml = glade_xml_new(file, widget, NULL);
         g_free(file);
     }
@@ -108,7 +107,7 @@ GtkBuilder *gtt_builder_new_from_file(const char *filename)
     }
     else
     {
-        char *file = g_concat_dir_and_file(GTTGLADEDIR, filename);
+        char *file = g_build_filename(GTTGLADEDIR, filename, NULL);
         builder = gtt_builder_new_from_exact_file(file);
         g_free(file);
     }


### PR DESCRIPTION
One intermediate goal on the way to migrate to GTK 3 is to get rid of `libgnome(ui)`. To make code needing adjustment stand out more prominent, trivially replaceable  `#include <gnome.h>` occurrences have been removed.