### PR TITLE
menucmd.c: Prevent infinite recursion in menu_toogle_timer()

### DIFF
--- a/src/menucmd.c
+++ b/src/menucmd.c
@@ -361,13 +361,22 @@ void menu_toggle_timer(GtkWidget *w, gpointer data)
     GttProject *prj;
     prj = gtt_projects_tree_get_selected_project(projects_tree);
 
-    if (timer_is_running())
+    gboolean run_currently = timer_is_running();
+
+    if (GTK_IS_CHECK_MENU_ITEM(w))
     {
-        cur_proj_set(NULL);
+        // Only attempt to change the timer state if it's not already in the desired state.
+        // Necessary to prevent infinite recursion since this handler is also called
+        // in response to code updating menu state.
+
+        gboolean run_desired = gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(w));
+
+        if (run_desired != run_currently)
+            cur_proj_set(run_desired ? prj : NULL);
     }
-    else
+    else  // toggled from (stateless) toolbar button
     {
-        cur_proj_set(prj);
+        cur_proj_set(run_currently ? NULL : prj);
     }
 }
 

--- a/src/menus.c
+++ b/src/menus.c
@@ -282,16 +282,21 @@ void menu_set_states(void)
         return;
     gtk_widget_set_sensitive(menu_main_timer[MENU_TIMER_TOGGLE_POS].widget, 1);
     mi = GTK_CHECK_MENU_ITEM(menu_main_timer[MENU_TIMER_TOGGLE_POS].widget);
-    /* Can't call the 'set_active' directly, as that issues an
-     * event which puts us in an infinite loop.  Instead,
-     * just set the value.
-     * gtk_check_menu_item_set_active (mi, timer_is_running());
-     */
     gtk_check_menu_item_set_active(mi, timer_is_running());
 
     /* XXX would be nice to change this menu entry to say
      * 'timer stopped' when the timer is stopped.  But don't
      * know how to change the menu label in gtk */
+    /* Note (Oskar): The proposed "timer stopped" is not ideal.
+     * The common pattern for a check menu item is that the label describes the state
+     * that would apply if the item is active. "timer running" is not good either,
+     * as the label makes it sound like the timer is running even if it isn't. Especially
+     * if the theme designer didn't feel the need to visualize a non-active check mark.
+     * The label "Run timer" would work better and match common patterns such
+     * as e.g. "Show toolbar".
+     *
+     * But also - why do we have Start, Stop, and a toogle as three separate menu items?
+     * Probably at least one too many. */
 
     gtk_widget_set_sensitive(
         menu_main_timer[MENU_TIMER_START_POS].widget, (FALSE == timer_is_running())


### PR DESCRIPTION
menu_toogle_timer() now considers the current (new) state of the check menu item as the desired state, and will only trigger a timer state change if the current state is wrong. This makes it a no-op if the state is already correct, preventing infinite recursion when the handler is called in response to code setting the menu item state.

Fixes #43.