### PR TITLE
Replace deprecated GDK functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ project(gnotime
     DESCRIPTION "A to-do list organizer, diary and billing system"
     HOMEPAGE_URL "https://gttr.sourceforge.net"
     LANGUAGES C)
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DGSEAL_ENABLE")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DGSEAL_ENABLE -DGDK_DISABLE_DEPRECATED")
 set(GTT_VERSION_SUFFIX "_dev")
 
 find_package(PkgConfig)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -112,7 +112,8 @@ AM_CFLAGS = -g -Wall     \
 	${LIBXML2_CFLAGS} \
 	${GUILE_CFLAGS} \
 	${X11_CFLAGS} \
-	-DGSEAL_ENABLE
+	-DGSEAL_ENABLE \
+	-DGDK_DISABLE_DEPRECATED
 
 AM_CPPFLAGS =                                   \
 	$(LIBQOF_CFLAGS)                          \

--- a/src/gtt-gsettings-io.c
+++ b/src/gtt-gsettings-io.c
@@ -103,10 +103,8 @@ void gtt_gsettings_save(void)
         GdkWindow *const win = gtk_widget_get_window(app_window);
 
         // Save the window location and size
-        gint w, h;
-        gdk_window_get_size(win, &w, &h);
-        gtt_gsettings_set_int(geometry, "width", w);
-        gtt_gsettings_set_int(geometry, "height", h);
+        gtt_gsettings_set_int(geometry, "width", gdk_window_get_width(win));
+        gtt_gsettings_set_int(geometry, "height", gdk_window_get_height(win));
 
         gint x, y;
         gdk_window_get_origin(win, &x, &y);

--- a/src/idle-timer.c
+++ b/src/idle-timer.c
@@ -162,7 +162,7 @@ static void notice_events(IdleTimeout *si, Window window, Bool top_p)
     unsigned int nkids;
     GdkWindow *gwin;
 
-    gwin = gdk_window_lookup(window);
+    gwin = gdk_x11_window_lookup_for_display(gdk_display_get_default(), (window));
     if (gwin && (window != DefaultRootWindow(si->dpy)))
     {
         /* If it's one of ours, don't mess up its event mask. */
@@ -826,7 +826,7 @@ IdleTimeout *idle_timeout_new(void)
     IdleTimeout *si;
 
     si = g_new0(IdleTimeout, 1);
-    si->dpy = GDK_DISPLAY();
+    si->dpy = gdk_x11_display_get_xdisplay(gdk_display_get_default());
 
     /* hack alert XXXX we should grep all screens */
     si->nscreens = 1;

--- a/src/main.c
+++ b/src/main.c
@@ -754,7 +754,7 @@ static int save_state(
     // const char *sess_id;
     char *argv[5];
     int argc;
-    int x, y, w, h;
+    int x, y;
     int rc;
 
     // sess_id  = gnome_client_get_id(client);
@@ -764,10 +764,11 @@ static int save_state(
     GdkWindow *const win = gtk_widget_get_window(app_window);
 
     gdk_window_get_origin(win, &x, &y);
-    gdk_window_get_size(win, &w, &h);
     argv[0] = (char *) data;
     argv[1] = "--geometry";
-    argv[2] = g_strdup_printf("%dx%d+%d+%d", w, h, x, y);
+    argv[2] = g_strdup_printf(
+        "%dx%d+%d+%d", gdk_window_get_width(win), gdk_window_get_height(win), x, y
+    );
     if ((cur_proj) && (gtt_project_get_title(cur_proj)))
     {
         argc = 5;


### PR DESCRIPTION
This enables building with `GDK_DISABLE_DEPRECATED` being set. Next I would take a shot at `GTK_DISABLE_DEPRECATED`.