### PR TITLE
Introduce GSettings-based history helpers for GtkComboBox, and use in task properties

### DIFF
--- a/data/org.gnotime.app.gschema.xml
+++ b/data/org.gnotime.app.gschema.xml
@@ -6,6 +6,7 @@
     <child name="data" schema="org.gnotime.app.data"/>
     <child name="display" schema="org.gnotime.app.display"/>
     <child name="geometry" schema="org.gnotime.app.geometry"/>
+    <child name="gtt-entry-histories" schema="org.gnotime.app.gtt-entry-histories"/>
     <child name="log-file" schema="org.gnotime.app.log-file"/>
     <child name="misc" schema="org.gnotime.app.misc"/>
     <child name="report" schema="org.gnotime.app.report"/>
@@ -204,6 +205,14 @@
     </key>
     <key name="y" type="i">
       <default>10</default>
+      <summary>TODO</summary>
+      <description>TODO</description>
+    </key>
+  </schema>
+
+  <schema id="org.gnotime.app.gtt-entry-histories">
+    <key name="history" type="as">
+      <default>[]</default>
       <summary>TODO</summary>
       <description>TODO</description>
     </key>

--- a/glade/task_properties.glade
+++ b/glade/task_properties.glade
@@ -1,467 +1,360 @@
-<?xml version="1.0" standalone="no"?> <!--*- mode: xml -*-->
-<!DOCTYPE glade-interface SYSTEM "http://glade.gnome.org/glade-2.0.dtd">
-
+<?xml version="1.0" encoding="UTF-8"?>
 <glade-interface>
-<requires lib="gnome"/>
-
-<widget class="GtkDialog" id="Task Properties">
-  <property name="visible">True</property>
-  <property name="title" translatable="yes">Diary Notes</property>
-  <property name="type">GTK_WINDOW_TOPLEVEL</property>
-  <property name="window_position">GTK_WIN_POS_NONE</property>
-  <property name="modal">False</property>
-  <property name="resizable">True</property>
-  <property name="destroy_with_parent">False</property>
-  <property name="has_separator">True</property>
-
-  <child internal-child="vbox">
-    <widget class="GtkVBox" id="dialog-vbox1">
-      <property name="visible">True</property>
-      <property name="homogeneous">False</property>
-      <property name="spacing">0</property>
-
-      <child internal-child="action_area">
-	<widget class="GtkHButtonBox" id="dialog-action_area1">
-	  <property name="visible">True</property>
-	  <property name="layout_style">GTK_BUTTONBOX_END</property>
-
-	  <child>
-	    <widget class="GtkButton" id="help button">
-	      <property name="visible">True</property>
-	      <property name="can_default">True</property>
-	      <property name="can_focus">True</property>
-	      <property name="label">gtk-help</property>
-	      <property name="use_stock">True</property>
-	      <property name="relief">GTK_RELIEF_NORMAL</property>
-	      <property name="response_id">-11</property>
-	      <signal name="clicked" handler="on_help_button_clicked" last_modification_time="Wed, 28 Apr 2004 05:01:16 GMT"/>
-	    </widget>
-	  </child>
-
-	  <child>
-	    <widget class="GtkButton" id="okbutton1">
-	      <property name="visible">True</property>
-	      <property name="can_default">True</property>
-	      <property name="can_focus">True</property>
-	      <property name="label">gtk-ok</property>
-	      <property name="use_stock">True</property>
-	      <property name="relief">GTK_RELIEF_NORMAL</property>
-	      <property name="response_id">-5</property>
-	      <signal name="clicked" handler="on_ok_button_clicked" last_modification_time="Wed, 28 Apr 2004 05:03:19 GMT"/>
-	    </widget>
-	  </child>
-	</widget>
-	<packing>
-	  <property name="padding">0</property>
-	  <property name="expand">False</property>
-	  <property name="fill">True</property>
-	  <property name="pack_type">GTK_PACK_END</property>
-	</packing>
-      </child>
-
-      <child>
-	<widget class="GtkNotebook" id="notebook">
-	  <property name="visible">True</property>
-	  <property name="can_focus">True</property>
-	  <property name="show_tabs">True</property>
-	  <property name="show_border">True</property>
-	  <property name="tab_pos">GTK_POS_TOP</property>
-	  <property name="scrollable">False</property>
-	  <property name="enable_popup">False</property>
-
-	  <child>
-	    <widget class="GtkTable" id="task table">
-	      <property name="border_width">7</property>
-	      <property name="visible">True</property>
-	      <property name="n_rows">2</property>
-	      <property name="n_columns">2</property>
-	      <property name="homogeneous">False</property>
-	      <property name="row_spacing">7</property>
-	      <property name="column_spacing">7</property>
-
-	      <child>
-		<widget class="GtkLabel" id="label1">
-		  <property name="visible">True</property>
-		  <property name="label" translatable="yes">Diary Entry:</property>
-		  <property name="use_underline">False</property>
-		  <property name="use_markup">False</property>
-		  <property name="justify">GTK_JUSTIFY_CENTER</property>
-		  <property name="wrap">False</property>
-		  <property name="selectable">False</property>
-		  <property name="xalign">0</property>
-		  <property name="yalign">0.5</property>
-		  <property name="xpad">0</property>
-		  <property name="ypad">0</property>
-		</widget>
-		<packing>
-		  <property name="left_attach">0</property>
-		  <property name="right_attach">1</property>
-		  <property name="top_attach">0</property>
-		  <property name="bottom_attach">1</property>
-		  <property name="x_options">fill</property>
-		  <property name="y_options"></property>
-		</packing>
-	      </child>
-
-	      <child>
-		<widget class="GnomeEntry" id="entry3">
-		  <property name="visible">True</property>
-		  <property name="history_id">task_memo</property>
-		  <property name="max_saved">10</property>
-
-		  <child internal-child="entry">
-		    <widget class="GtkEntry" id="memo box">
-		      <property name="visible">True</property>
-		      <property name="tooltip" translatable="yes">A short description to attach to this block of time.</property>
-		      <property name="can_focus">True</property>
-		      <property name="editable">True</property>
-		      <property name="visibility">True</property>
-		      <property name="max_length">0</property>
-		      <property name="text" translatable="yes"></property>
-		      <property name="has_frame">True</property>
-		      <property name="invisible_char" translatable="yes">*</property>
-		      <property name="activates_default">False</property>
-		    </widget>
-		  </child>
-		</widget>
-		<packing>
-		  <property name="left_attach">1</property>
-		  <property name="right_attach">2</property>
-		  <property name="top_attach">0</property>
-		  <property name="bottom_attach">1</property>
-		  <property name="y_options"></property>
-		</packing>
-	      </child>
-
-	      <child>
-		<widget class="GtkLabel" id="label2">
-		  <property name="visible">True</property>
-		  <property name="label" translatable="yes">Notes:</property>
-		  <property name="use_underline">False</property>
-		  <property name="use_markup">False</property>
-		  <property name="justify">GTK_JUSTIFY_LEFT</property>
-		  <property name="wrap">False</property>
-		  <property name="selectable">False</property>
-		  <property name="xalign">0</property>
-		  <property name="yalign">0</property>
-		  <property name="xpad">0</property>
-		  <property name="ypad">0</property>
-		</widget>
-		<packing>
-		  <property name="left_attach">0</property>
-		  <property name="right_attach">1</property>
-		  <property name="top_attach">1</property>
-		  <property name="bottom_attach">2</property>
-		  <property name="x_options">fill</property>
-		  <property name="y_options"></property>
-		</packing>
-	      </child>
-
-	      <child>
-		<widget class="GtkScrolledWindow" id="scrolledwindow1">
-		  <property name="visible">True</property>
-		  <property name="hscrollbar_policy">GTK_POLICY_NEVER</property>
-		  <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-		  <property name="shadow_type">GTK_SHADOW_IN</property>
-		  <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
-
-		  <child>
-		    <widget class="GtkTextView" id="notes box">
-		      <property name="visible">True</property>
-		      <property name="tooltip" translatable="yes">Type detailed diary entry notes here.</property>
-		      <property name="can_focus">True</property>
-		      <property name="editable">True</property>
-		      <property name="justification">GTK_JUSTIFY_LEFT</property>
-		      <property name="wrap_mode">GTK_WRAP_WORD</property>
-		      <property name="cursor_visible">True</property>
-		      <property name="pixels_above_lines">0</property>
-		      <property name="pixels_below_lines">0</property>
-		      <property name="pixels_inside_wrap">0</property>
-		      <property name="left_margin">0</property>
-		      <property name="right_margin">0</property>
-		      <property name="indent">0</property>
-		      <property name="text" translatable="yes"></property>
-		    </widget>
-		  </child>
-		</widget>
-		<packing>
-		  <property name="left_attach">1</property>
-		  <property name="right_attach">2</property>
-		  <property name="top_attach">1</property>
-		  <property name="bottom_attach">2</property>
-		</packing>
-	      </child>
-	    </widget>
-	    <packing>
-	      <property name="tab_expand">False</property>
-	      <property name="tab_fill">True</property>
-	    </packing>
-	  </child>
-
-	  <child>
-	    <widget class="GtkLabel" id="label5">
-	      <property name="visible">True</property>
-	      <property name="label" translatable="yes">Diary Notes</property>
-	      <property name="use_underline">False</property>
-	      <property name="use_markup">False</property>
-	      <property name="justify">GTK_JUSTIFY_CENTER</property>
-	      <property name="wrap">False</property>
-	      <property name="selectable">False</property>
-	      <property name="xalign">0.5</property>
-	      <property name="yalign">0.5</property>
-	      <property name="xpad">0</property>
-	      <property name="ypad">0</property>
-	    </widget>
-	    <packing>
-	      <property name="type">tab</property>
-	    </packing>
-	  </child>
-
-	  <child>
-	    <widget class="GtkTable" id="table1">
-	      <property name="border_width">7</property>
-	      <property name="visible">True</property>
-	      <property name="n_rows">4</property>
-	      <property name="n_columns">3</property>
-	      <property name="homogeneous">False</property>
-	      <property name="row_spacing">7</property>
-	      <property name="column_spacing">7</property>
-
-	      <child>
-		<widget class="GtkLabel" id="label16">
-		  <property name="visible">True</property>
-		  <property name="label" translatable="yes">Billing Status:</property>
-		  <property name="use_underline">False</property>
-		  <property name="use_markup">False</property>
-		  <property name="justify">GTK_JUSTIFY_CENTER</property>
-		  <property name="wrap">False</property>
-		  <property name="selectable">False</property>
-		  <property name="xalign">0</property>
-		  <property name="yalign">0.5</property>
-		  <property name="xpad">0</property>
-		  <property name="ypad">0</property>
-		</widget>
-		<packing>
-		  <property name="left_attach">0</property>
-		  <property name="right_attach">1</property>
-		  <property name="top_attach">0</property>
-		  <property name="bottom_attach">1</property>
-		  <property name="x_options">fill</property>
-		  <property name="y_options"></property>
-		</packing>
-	      </child>
-
-	      <child>
-		<widget class="GtkLabel" id="label15">
-		  <property name="visible">True</property>
-		  <property name="label" translatable="yes">Billable:</property>
-		  <property name="use_underline">False</property>
-		  <property name="use_markup">False</property>
-		  <property name="justify">GTK_JUSTIFY_CENTER</property>
-		  <property name="wrap">False</property>
-		  <property name="selectable">False</property>
-		  <property name="xalign">0</property>
-		  <property name="yalign">0.5</property>
-		  <property name="xpad">0</property>
-		  <property name="ypad">0</property>
-		</widget>
-		<packing>
-		  <property name="left_attach">0</property>
-		  <property name="right_attach">1</property>
-		  <property name="top_attach">1</property>
-		  <property name="bottom_attach">2</property>
-		  <property name="x_options">fill</property>
-		  <property name="y_options"></property>
-		</packing>
-	      </child>
-
-	      <child>
-		<widget class="GtkLabel" id="label14">
-		  <property name="visible">True</property>
-		  <property name="label" translatable="yes">Billing Rate:</property>
-		  <property name="use_underline">False</property>
-		  <property name="use_markup">False</property>
-		  <property name="justify">GTK_JUSTIFY_CENTER</property>
-		  <property name="wrap">False</property>
-		  <property name="selectable">False</property>
-		  <property name="xalign">0</property>
-		  <property name="yalign">0.5</property>
-		  <property name="xpad">0</property>
-		  <property name="ypad">0</property>
-		</widget>
-		<packing>
-		  <property name="left_attach">0</property>
-		  <property name="right_attach">1</property>
-		  <property name="top_attach">2</property>
-		  <property name="bottom_attach">3</property>
-		  <property name="x_options">fill</property>
-		  <property name="y_options"></property>
-		</packing>
-	      </child>
-
-	      <child>
-		<widget class="GtkLabel" id="label12">
-		  <property name="visible">True</property>
-		  <property name="label" translatable="yes">Billing Block:</property>
-		  <property name="use_underline">False</property>
-		  <property name="use_markup">False</property>
-		  <property name="justify">GTK_JUSTIFY_CENTER</property>
-		  <property name="wrap">False</property>
-		  <property name="selectable">False</property>
-		  <property name="xalign">0</property>
-		  <property name="yalign">0.5</property>
-		  <property name="xpad">0</property>
-		  <property name="ypad">0</property>
-		</widget>
-		<packing>
-		  <property name="left_attach">0</property>
-		  <property name="right_attach">1</property>
-		  <property name="top_attach">3</property>
-		  <property name="bottom_attach">4</property>
-		  <property name="x_options">fill</property>
-		  <property name="y_options"></property>
-		</packing>
-	      </child>
-
-	      <child>
-		<widget class="GtkLabel" id="label13">
-		  <property name="visible">True</property>
-		  <property name="label" translatable="yes">minutes</property>
-		  <property name="use_underline">False</property>
-		  <property name="use_markup">False</property>
-		  <property name="justify">GTK_JUSTIFY_CENTER</property>
-		  <property name="wrap">False</property>
-		  <property name="selectable">False</property>
-		  <property name="xalign">0</property>
-		  <property name="yalign">0.5</property>
-		  <property name="xpad">0</property>
-		  <property name="ypad">0</property>
-		</widget>
-		<packing>
-		  <property name="left_attach">2</property>
-		  <property name="right_attach">3</property>
-		  <property name="top_attach">3</property>
-		  <property name="bottom_attach">4</property>
-		  <property name="x_options">fill</property>
-		  <property name="y_options"></property>
-		</packing>
-	      </child>
-
-	      <child>
-		<widget class="GtkComboBox" id="billstatus menu">
-		  <property name="visible">True</property>
-		  <property name="tooltip" translatable="yes">Is this task ready to be billed to the customer? &quot;Hold&quot; means maybe, but not yet, needs review.   &quot;Bill&quot; means print this on the next invoice.   &quot;Paid&quot; means that it should no longer be included on invoices.</property>
-		  <property name="can_focus">False</property>
-		  <property name="items" translatable="yes"/>
-		</widget>
-		<packing>
-		  <property name="left_attach">1</property>
-		  <property name="right_attach">2</property>
-		  <property name="top_attach">0</property>
-		  <property name="bottom_attach">1</property>
-		  <property name="x_options">fill</property>
-		  <property name="y_options"></property>
-		</packing>
-	      </child>
-
-	      <child>
-		<widget class="GtkComboBox" id="billable menu">
-		  <property name="visible">True</property>
-		  <property name="tooltip" translatable="yes">How should this task be billed?  &quot;Billable&quot; means bill to the customer in the normal fashion.   &quot;Not Billable&quot; means we can't ask for money for this, don't print on the invoice.   &quot;No Charge&quot; means print on the invoice as 'free/no-charge'.</property>
-		  <property name="can_focus">False</property>
-		  <property name="items" translatable="yes"/>
-		</widget>
-		<packing>
-		  <property name="left_attach">1</property>
-		  <property name="right_attach">2</property>
-		  <property name="top_attach">1</property>
-		  <property name="bottom_attach">2</property>
-		  <property name="x_options">fill</property>
-		  <property name="y_options"></property>
-		</packing>
-	      </child>
-
-	      <child>
-		<widget class="GtkComboBox" id="billrate menu">
-		  <property name="visible">True</property>
-		  <property name="tooltip" translatable="yes">Fee rate to be charged for this task.</property>
-		  <property name="can_focus">False</property>
-		  <property name="items" translatable="yes"/>
-		</widget>
-		<packing>
-		  <property name="left_attach">1</property>
-		  <property name="right_attach">2</property>
-		  <property name="top_attach">2</property>
-		  <property name="bottom_attach">3</property>
-		  <property name="x_options">fill</property>
-		  <property name="y_options"></property>
-		</packing>
-	      </child>
-
-	      <child>
-		<widget class="GnomeEntry" id="entry4">
-		  <property name="visible">True</property>
-		  <property name="history_id">bill_unit</property>
-		  <property name="max_saved">10</property>
-
-		  <child internal-child="entry">
-		    <widget class="GtkEntry" id="unit box">
-		      <property name="visible">True</property>
-		      <property name="tooltip" translatable="yes">The billed unit of time will be rounded to an integer multiple of this time.</property>
-		      <property name="can_focus">True</property>
-		      <property name="editable">True</property>
-		      <property name="visibility">True</property>
-		      <property name="max_length">0</property>
-		      <property name="text" translatable="yes"></property>
-		      <property name="has_frame">True</property>
-		      <property name="invisible_char" translatable="yes">*</property>
-		      <property name="activates_default">False</property>
-		    </widget>
-		  </child>
-		</widget>
-		<packing>
-		  <property name="left_attach">1</property>
-		  <property name="right_attach">2</property>
-		  <property name="top_attach">3</property>
-		  <property name="bottom_attach">4</property>
-		  <property name="y_options"></property>
-		</packing>
-	      </child>
-	    </widget>
-	    <packing>
-	      <property name="tab_expand">False</property>
-	      <property name="tab_fill">True</property>
-	    </packing>
-	  </child>
-
-	  <child>
-	    <widget class="GtkLabel" id="label9">
-	      <property name="visible">True</property>
-	      <property name="label" translatable="yes">Billing</property>
-	      <property name="use_underline">False</property>
-	      <property name="use_markup">False</property>
-	      <property name="justify">GTK_JUSTIFY_LEFT</property>
-	      <property name="wrap">False</property>
-	      <property name="selectable">False</property>
-	      <property name="xalign">0.5</property>
-	      <property name="yalign">0.5</property>
-	      <property name="xpad">0</property>
-	      <property name="ypad">0</property>
-	    </widget>
-	    <packing>
-	      <property name="type">tab</property>
-	    </packing>
-	  </child>
-	</widget>
-	<packing>
-	  <property name="padding">0</property>
-	  <property name="expand">True</property>
-	  <property name="fill">True</property>
-	</packing>
-      </child>
-    </widget>
-  </child>
-</widget>
-
+  <!-- interface-requires gtk+ 2.24 -->
+  <!-- interface-requires gnome 0.0 -->
+  <!-- interface-requires gnome 0.0 -->
+  <!-- interface-naming-policy toplevel-contextual -->
+  <widget class="GtkDialog" id="Task Properties">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">Diary Notes</property>
+    <property name="type_hint">normal</property>
+    <property name="has_separator">True</property>
+    <child internal-child="vbox">
+      <widget class="GtkVBox" id="dialog-vbox1">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <child internal-child="action_area">
+          <widget class="GtkHButtonBox" id="dialog-action_area1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <widget class="GtkButton" id="help button">
+                <property name="label">gtk-help</property>
+                <property name="response_id">-11</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_action_appearance">False</property>
+                <property name="use_stock">True</property>
+                <signal name="clicked" handler="on_help_button_clicked" swapped="no"/>
+              </widget>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <widget class="GtkButton" id="okbutton1">
+                <property name="label">gtk-ok</property>
+                <property name="response_id">-5</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_action_appearance">False</property>
+                <property name="use_stock">True</property>
+                <signal name="clicked" handler="on_ok_button_clicked" swapped="no"/>
+              </widget>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </widget>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <widget class="GtkNotebook" id="notebook">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <child>
+              <widget class="GtkTable" id="task table">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="border_width">7</property>
+                <property name="n_rows">2</property>
+                <property name="n_columns">2</property>
+                <property name="column_spacing">7</property>
+                <property name="row_spacing">7</property>
+                <child>
+                  <widget class="GtkLabel" id="label1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">Diary Entry:</property>
+                    <property name="justify">center</property>
+                  </widget>
+                  <packing>
+                    <property name="x_options">GTK_FILL</property>
+                    <property name="y_options"/>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="GnomeEntry" id="entry3">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="history_id">task_memo</property>
+                    <property name="max_saved">10</property>
+                    <child internal-child="entry">
+                      <widget class="GtkEntry" id="memo box">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="tooltip" translatable="yes">A short description to attach to this block of time.</property>
+                        <property name="primary_icon_activatable">False</property>
+                        <property name="secondary_icon_activatable">False</property>
+                        <property name="primary_icon_sensitive">True</property>
+                        <property name="secondary_icon_sensitive">True</property>
+                      </widget>
+                    </child>
+                  </widget>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="right_attach">2</property>
+                    <property name="y_options"/>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="GtkLabel" id="label2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">0</property>
+                    <property name="yalign">0</property>
+                    <property name="label" translatable="yes">Notes:</property>
+                  </widget>
+                  <packing>
+                    <property name="top_attach">1</property>
+                    <property name="bottom_attach">2</property>
+                    <property name="x_options">GTK_FILL</property>
+                    <property name="y_options"/>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="GtkScrolledWindow" id="scrolledwindow1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="hscrollbar_policy">never</property>
+                    <property name="vscrollbar_policy">automatic</property>
+                    <property name="shadow_type">in</property>
+                    <child>
+                      <widget class="GtkTextView" id="notes box">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="tooltip" translatable="yes">Type detailed diary entry notes here.</property>
+                        <property name="wrap_mode">word</property>
+                      </widget>
+                    </child>
+                  </widget>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="right_attach">2</property>
+                    <property name="top_attach">1</property>
+                    <property name="bottom_attach">2</property>
+                  </packing>
+                </child>
+              </widget>
+            </child>
+            <child>
+              <widget class="GtkLabel" id="label5">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Diary Notes</property>
+                <property name="justify">center</property>
+              </widget>
+              <packing>
+                <property name="tab_fill">False</property>
+                <property name="type">tab</property>
+              </packing>
+            </child>
+            <child>
+              <widget class="GtkTable" id="table1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="border_width">7</property>
+                <property name="n_rows">4</property>
+                <property name="n_columns">3</property>
+                <property name="column_spacing">7</property>
+                <property name="row_spacing">7</property>
+                <child>
+                  <widget class="GtkLabel" id="label16">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">Billing Status:</property>
+                    <property name="justify">center</property>
+                  </widget>
+                  <packing>
+                    <property name="x_options">GTK_FILL</property>
+                    <property name="y_options"/>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="GtkLabel" id="label15">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">Billable:</property>
+                    <property name="justify">center</property>
+                  </widget>
+                  <packing>
+                    <property name="top_attach">1</property>
+                    <property name="bottom_attach">2</property>
+                    <property name="x_options">GTK_FILL</property>
+                    <property name="y_options"/>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="GtkLabel" id="label14">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">Billing Rate:</property>
+                    <property name="justify">center</property>
+                  </widget>
+                  <packing>
+                    <property name="top_attach">2</property>
+                    <property name="bottom_attach">3</property>
+                    <property name="x_options">GTK_FILL</property>
+                    <property name="y_options"/>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="GtkLabel" id="label12">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">Billing Block:</property>
+                    <property name="justify">center</property>
+                  </widget>
+                  <packing>
+                    <property name="top_attach">3</property>
+                    <property name="bottom_attach">4</property>
+                    <property name="x_options">GTK_FILL</property>
+                    <property name="y_options"/>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="GtkLabel" id="label13">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">minutes</property>
+                    <property name="justify">center</property>
+                  </widget>
+                  <packing>
+                    <property name="left_attach">2</property>
+                    <property name="right_attach">3</property>
+                    <property name="top_attach">3</property>
+                    <property name="bottom_attach">4</property>
+                    <property name="x_options">GTK_FILL</property>
+                    <property name="y_options"/>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="GtkComboBox" id="billstatus menu">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="tooltip" translatable="yes">Is this task ready to be billed to the customer? "Hold" means maybe, but not yet, needs review.   "Bill" means print this on the next invoice.   "Paid" means that it should no longer be included on invoices.</property>
+                    <property name="items" translatable="yes"/>
+                  </widget>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="right_attach">2</property>
+                    <property name="x_options">GTK_FILL</property>
+                    <property name="y_options"/>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="GtkComboBox" id="billable menu">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="tooltip" translatable="yes">How should this task be billed?  "Billable" means bill to the customer in the normal fashion.   "Not Billable" means we can't ask for money for this, don't print on the invoice.   "No Charge" means print on the invoice as 'free/no-charge'.</property>
+                    <property name="items" translatable="yes"/>
+                  </widget>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="right_attach">2</property>
+                    <property name="top_attach">1</property>
+                    <property name="bottom_attach">2</property>
+                    <property name="x_options">GTK_FILL</property>
+                    <property name="y_options"/>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="GtkComboBox" id="billrate menu">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="tooltip" translatable="yes">Fee rate to be charged for this task.</property>
+                    <property name="items" translatable="yes"/>
+                  </widget>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="right_attach">2</property>
+                    <property name="top_attach">2</property>
+                    <property name="bottom_attach">3</property>
+                    <property name="x_options">GTK_FILL</property>
+                    <property name="y_options"/>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="GnomeEntry" id="entry4">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="history_id">bill_unit</property>
+                    <property name="max_saved">10</property>
+                    <child internal-child="entry">
+                      <widget class="GtkEntry" id="unit box">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="tooltip" translatable="yes">The billed unit of time will be rounded to an integer multiple of this time.</property>
+                        <property name="primary_icon_activatable">False</property>
+                        <property name="secondary_icon_activatable">False</property>
+                        <property name="primary_icon_sensitive">True</property>
+                        <property name="secondary_icon_sensitive">True</property>
+                      </widget>
+                    </child>
+                  </widget>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="right_attach">2</property>
+                    <property name="top_attach">3</property>
+                    <property name="bottom_attach">4</property>
+                    <property name="y_options"/>
+                  </packing>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+              </widget>
+              <packing>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <widget class="GtkLabel" id="label9">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Billing</property>
+              </widget>
+              <packing>
+                <property name="position">1</property>
+                <property name="tab_fill">False</property>
+                <property name="type">tab</property>
+              </packing>
+            </child>
+          </widget>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </widget>
+    </child>
+  </widget>
 </glade-interface>
-

--- a/glade/task_properties.glade
+++ b/glade/task_properties.glade
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glade-interface>
   <!-- interface-requires gtk+ 2.24 -->
-  <!-- interface-requires gnome 0.0 -->
-  <!-- interface-requires gnome 0.0 -->
   <!-- interface-naming-policy toplevel-contextual -->
   <widget class="GtkDialog" id="Task Properties">
     <property name="visible">True</property>
@@ -90,22 +88,12 @@
                   </packing>
                 </child>
                 <child>
-                  <widget class="GnomeEntry" id="entry3">
+                  <widget class="GtkComboBox" id="task_memo">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="history_id">task_memo</property>
-                    <property name="max_saved">10</property>
-                    <child internal-child="entry">
-                      <widget class="GtkEntry" id="memo box">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="tooltip" translatable="yes">A short description to attach to this block of time.</property>
-                        <property name="primary_icon_activatable">False</property>
-                        <property name="secondary_icon_activatable">False</property>
-                        <property name="primary_icon_sensitive">True</property>
-                        <property name="secondary_icon_sensitive">True</property>
-                      </widget>
-                    </child>
+                    <property name="tooltip" translatable="yes">A short description to attach to this block of time.</property>
+                    <property name="has_entry">True</property>
+                    <property name="entry_text_column">0</property>
                   </widget>
                   <packing>
                     <property name="left_attach">1</property>
@@ -296,22 +284,12 @@
                   </packing>
                 </child>
                 <child>
-                  <widget class="GnomeEntry" id="entry4">
+                  <widget class="GtkComboBox" id="bill_unit">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="history_id">bill_unit</property>
-                    <property name="max_saved">10</property>
-                    <child internal-child="entry">
-                      <widget class="GtkEntry" id="unit box">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="tooltip" translatable="yes">The billed unit of time will be rounded to an integer multiple of this time.</property>
-                        <property name="primary_icon_activatable">False</property>
-                        <property name="secondary_icon_activatable">False</property>
-                        <property name="primary_icon_sensitive">True</property>
-                        <property name="secondary_icon_sensitive">True</property>
-                      </widget>
-                    </child>
+                    <property name="tooltip" translatable="yes">The billed unit of time will be rounded to an integer multiple of this time.</property>
+                    <property name="has_entry">True</property>
+                    <property name="entry_text_column">0</property>
                   </widget>
                   <packing>
                     <property name="left_attach">1</property>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,6 +50,7 @@ add_executable(${PROJECT_NAME}
     props-task.c
     query.c
     gtt-select-list.c
+    gtt-history-list.c
     status-icon.c
     timer.c
     toolbar.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -43,6 +43,7 @@ gnotime_SOURCES =     \
 	props-task.c       \
 	query.c            \
 	gtt-select-list.c  \
+	gtt-history-list.c  \
 	status-icon.c      \
 	timer.c            \
 	toolbar.c          \
@@ -88,6 +89,7 @@ noinst_HEADERS =      \
 	props-task.h       \
 	query.h            \
 	gtt-select-list.h  \
+	gtt-history-list.h  \
 	status-icon.h      \
 	timer.h            \
 	toolbar.h          \

--- a/src/gtt-gsettings-io-p.h
+++ b/src/gtt-gsettings-io-p.h
@@ -23,10 +23,12 @@
 #include <glib.h>
 
 GSList *gtt_gsettings_get_array_int(GSettings *settings, const gchar *key);
+GSList *gtt_gsettings_get_array_string(GSettings *settings, const gchar *key);
 void gtt_gsettings_get_maybe_string(GSettings *settings, const gchar *key, gchar **value);
 void gtt_gsettings_get_string(GSettings *settings, const gchar *key, gchar **value);
 
 void gtt_gsettings_set_array_int(GSettings *settings, const gchar *key, GSList *value);
+void gtt_gsettings_set_array_string(GSettings *settings, const gchar *key, GSList *value);
 void gtt_gsettings_set_bool(GSettings *settings, const gchar *key, gboolean value);
 void gtt_gsettings_set_int(GSettings *settings, const gchar *key, gint value);
 void gtt_gsettings_set_maybe_string(GSettings *settings, const gchar *key, const gchar *value);

--- a/src/gtt-history-list.c
+++ b/src/gtt-history-list.c
@@ -1,0 +1,149 @@
+/*   History for GtkComboBox (stored in GSettings)
+ *   Copyright (C) 2023 Oskar Berggren
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include "config.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "gtt-gsettings-io-p.h"
+#include "gtt-history-list.h"
+#include "util.h"
+
+#define TEXT_COLUMN_ID 0
+
+
+static GSettings *settings_open_history(const gchar *const history_id)
+{
+    gchar *path = g_strdup_printf("/org/gnotime/app/gtt-entry-histories/history-%s/", history_id);
+
+    GSettings *settings = g_settings_new_with_path("org.gnotime.app.gtt-entry-histories", path);
+
+    g_free(path);
+
+    return settings;
+}
+
+static gboolean is_present_in_list(GSList *gsettings_items, const gchar *item)
+{
+    for (; gsettings_items; gsettings_items = gsettings_items->next)
+    {
+
+        if (strcmp((gchar *) gsettings_items->data, item) == 0)
+        {
+            return TRUE;
+        }
+    }
+
+    return FALSE;
+}
+
+static GSList *copy_model_to_gslist(GtkComboBox *combo_box, GSList *items, gint max_items)
+{
+    GtkTreeModel *model = gtk_combo_box_get_model(combo_box);
+    GtkTreeIter iter;
+    gchar *item;
+    gboolean valid;
+
+    valid = gtk_tree_model_get_iter_first(model, &iter);
+
+    while (valid && max_items > 0)
+    {
+        gtk_tree_model_get(model, &iter, 0, &item, -1);
+
+        if (!is_present_in_list(items, item))
+        {
+            items = g_slist_prepend(items, item);
+            max_items--;
+        }
+
+        valid = gtk_tree_model_iter_next(model, &iter);
+    }
+
+    return items;
+}
+
+static gchar *copy_and_trim(const gchar *str)
+{
+    gchar *result = g_strdup(str);
+
+    g_strstrip(result);
+
+    return result;
+}
+
+/**
+ * @brief Load history item from GSettings as a new model for the combo_box.
+ */
+void gtt_combo_history_list_init(GtkComboBox *combo_box, const gchar *history_id)
+{
+    GtkListStore *store;
+
+    store = gtk_list_store_new(1, G_TYPE_STRING);
+
+    /* Load up items from GSettings into our list model.*/
+    GSettings *settings = settings_open_history(history_id);
+
+    GSList *items = gtt_gsettings_get_array_string(settings, "history");
+    GSList *node = NULL;
+    for (node = items; NULL != node; node = node->next)
+    {
+        gtk_list_store_insert_with_values(
+            store, NULL, G_MAXINT, TEXT_COLUMN_ID, node->data, -1);
+    }
+
+    g_slist_free(items);
+    g_object_unref(settings);
+
+    /* Attach list model. The combo box should be set to display column 0 as text. */
+    gtk_combo_box_set_model(combo_box, GTK_TREE_MODEL(store));
+}
+
+/**
+ * @brief Save combo_box items (and current text) as history in GSettings.
+ */
+void gtt_combo_history_list_save(GtkComboBox *combo_box, const gchar *history_id, gint max_items)
+{
+    GSList *gsettings_items = NULL;
+    gchar *item;
+
+    if (max_items < 1)
+        max_items = 10;
+
+    /* The text from the combo box text entry, which may not be in the model.*/
+    item = copy_and_trim(gtt_combo_entry_get_text(combo_box));
+    if (item && strcmp(item, "") != 0)
+    {
+        gsettings_items = g_slist_prepend(gsettings_items, (gpointer)item);
+        max_items--;
+    }
+
+    /* Then add everything from the model. */
+    gsettings_items = copy_model_to_gslist(combo_box, gsettings_items, max_items);
+
+    gsettings_items = g_slist_reverse(gsettings_items);
+
+    /* Save as array in GSettings. */
+    GSettings *settings = settings_open_history(history_id);
+    gtt_gsettings_set_array_string(settings, "history", gsettings_items);
+
+    g_free(item);
+    g_slist_free(gsettings_items);
+    g_object_unref(settings);
+}
+

--- a/src/gtt-history-list.h
+++ b/src/gtt-history-list.h
@@ -1,0 +1,27 @@
+/*   History for GtkComboBox (stored in GSettings)
+ *   Copyright (C) 2023 Oskar Berggren
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef GTT_HISTORY_LIST_H
+#define GTT_HISTORY_LIST_H
+
+#include <gtk/gtk.h>
+
+void gtt_combo_history_list_init(GtkComboBox *combo_box, const gchar *history_id);
+void gtt_combo_history_list_save(GtkComboBox *combo_box, const gchar *history_id, gint max_items);
+
+#endif /* GTT_HISTORY_LIST_H */

--- a/src/meson.build
+++ b/src/meson.build
@@ -54,6 +54,7 @@ gnotime_srcs = files(
   'gtt-gsettings-io.c',
   'gtt-gsettings-io-p.c',
   'gtt-select-list.c',
+  'gtt-history-list.c',
   'idle-dialog.c',
   'idle-timer.c',
   'journal.c',

--- a/src/props-task.c
+++ b/src/props-task.c
@@ -24,6 +24,7 @@
 
 #include "dialog.h"
 #include "gtt-select-list.h"
+#include "gtt-history-list.h"
 #include "proj.h"
 #include "props-task.h"
 #include "util.h"
@@ -31,6 +32,9 @@
 #include <glib/gi18n.h>
 
 #include <stdlib.h>
+
+#define MEMO_HISTORY_ID "task_memo"
+#define UNIT_HISTORY_ID "bill_unit"
 
 typedef struct PropTaskDlg_s
 {
@@ -80,7 +84,7 @@ static void save_task_notes(GtkWidget *w, PropTaskDlg *dlg)
 
     TSK_SETUP(dlg);
 
-    cstr = gtk_entry_get_text(GTK_ENTRY(gtk_bin_get_child(GTK_BIN(dlg->memo))));
+    cstr = gtt_combo_entry_get_text(dlg->memo);
     if (cstr && cstr[0])
     {
         gtt_task_set_memo(dlg->task, cstr);
@@ -88,8 +92,10 @@ static void save_task_notes(GtkWidget *w, PropTaskDlg *dlg)
     else
     {
         gtt_task_set_memo(dlg->task, "");
-        gtk_entry_set_text(GTK_ENTRY(gtk_bin_get_child(GTK_BIN(dlg->memo))), "");
+        gtt_combo_entry_set_text(dlg->memo, "");
     }
+
+    gtt_combo_history_list_save(dlg->memo, MEMO_HISTORY_ID, -1);
 
     str = xxxgtk_textview_get_text(dlg->notes);
     gtt_task_set_notes(dlg->task, str);
@@ -107,8 +113,10 @@ static void save_task_billinfo(GtkWidget *w, PropTaskDlg *dlg)
 
     TSK_SETUP(dlg);
 
-    ivl = (int) (60.0 * atof(gtk_entry_get_text(GTK_ENTRY(gtk_bin_get_child(GTK_BIN(dlg->unit))))));
+    ivl = (int) (60.0 * atof(gtt_combo_entry_get_text(dlg->unit)));
     gtt_task_set_bill_unit(dlg->task, ivl);
+
+    gtt_combo_history_list_save(dlg->unit, UNIT_HISTORY_ID, -1);
 
     status = (GttBillStatus) gtt_combo_select_list_get_value(dlg->billstatus);
     gtt_task_set_billstatus(dlg->task, status);
@@ -132,12 +140,15 @@ static void do_set_task(GttTask *tsk, PropTaskDlg *dlg)
     GttBillRate rate;
     char buff[132];
 
+    gtt_combo_history_list_init(dlg->memo, MEMO_HISTORY_ID);
+    gtt_combo_history_list_init(dlg->unit, UNIT_HISTORY_ID);
+
     if (!tsk)
     {
         dlg->task = NULL;
-        gtk_entry_set_text(GTK_ENTRY(gtk_bin_get_child(GTK_BIN(dlg->memo))), "");
+        gtt_combo_entry_set_text(dlg->memo, "");
         xxxgtk_textview_set_text(dlg->notes, "");
-        gtk_entry_set_text(GTK_ENTRY(gtk_bin_get_child(GTK_BIN(dlg->unit))), "0.0");
+        gtt_combo_entry_set_text(dlg->unit, "0.0");
         return;
     }
 
@@ -146,11 +157,11 @@ static void do_set_task(GttTask *tsk, PropTaskDlg *dlg)
     dlg->task = tsk;
     TSK_SETUP(dlg);
 
-    gtk_entry_set_text(GTK_ENTRY(gtk_bin_get_child(GTK_BIN(dlg->memo))), gtt_task_get_memo(tsk));
+    gtt_combo_entry_set_text(dlg->memo, gtt_task_get_memo(tsk));
     xxxgtk_textview_set_text(dlg->notes, gtt_task_get_notes(tsk));
 
     g_snprintf(buff, 132, "%g", ((double) gtt_task_get_bill_unit(tsk)) / 60.0);
-    gtk_entry_set_text(GTK_ENTRY(gtk_bin_get_child(GTK_BIN(dlg->unit))), buff);
+    gtt_combo_entry_set_text(dlg->unit, buff);
 
     status = gtt_task_get_billstatus(tsk);
     gtt_combo_select_list_set_active_by_value(dlg->billstatus, status);

--- a/src/util.c
+++ b/src/util.c
@@ -59,6 +59,20 @@ char *xxxgtk_textview_get_text(GtkTextView *text)
     return gtk_text_buffer_get_text(buff, &start, &end, TRUE);
 }
 
+const gchar *gtt_combo_entry_get_text(GtkComboBox *combo_box)
+{
+    GtkEntry *entry = GTK_ENTRY(gtk_bin_get_child(GTK_BIN(combo_box)));
+
+    return gtk_entry_get_text(entry);
+}
+
+void gtt_combo_entry_set_text(GtkComboBox *combo_box, const gchar *str)
+{
+    GtkEntry *entry = GTK_ENTRY(gtk_bin_get_child(GTK_BIN(combo_box)));
+
+    gtk_entry_set_text(entry, str);
+}
+
 /* ============================================================== */
 
 /* Glade loader, it will look in the right directories */

--- a/src/util.h
+++ b/src/util.h
@@ -27,6 +27,9 @@
 void xxxgtk_textview_set_text(GtkTextView *text, const char *str);
 char *xxxgtk_textview_get_text(GtkTextView *text);
 
+const gchar *gtt_combo_entry_get_text(GtkComboBox *combo_box);
+void gtt_combo_entry_set_text(GtkComboBox *combo_box, const gchar *str);
+
 /* Glade loader, it will look in the right directories */
 GladeXML *gtt_glade_xml_new(const char *filename, const char *widget);
 


### PR DESCRIPTION
@markuspg This is an experiment to use GtkComboBox instead of GnomeEntry, plus a couple of helper methods to load and save history.

The first two commits are your changes to extend the GSettings schema and support arrays.

The third commit is just letting Glade rewrite the glade file and target Gtk 2.24 - it looks big because of indenting changes and because Glade no longer writes properties where the value is the default value.

The remaining three commits add helper methods to load and save history, and converts task_properties to use GtkComboBox instead of GnomeEntry, with these helpers.

The code is just a draft to show the idea. There is certainly some clean-up needed, probably some things need to be freed, etc, and probably there could be a few more convenience methods to e.g. avoid the monstrosity of `gtk_entry_get_text(GTK_ENTRY(gtk_bin_get_child(GTK_BIN(dlg->memo))))`.

However, this code does actually already work - including actually loading and saving the history. :)

What do you think of this approach?

The benefit I see is being able to keep more things in Glade/GtkBuilder, and it does not depend on the deprecated GtkCombo.