### PR TITLE
Journal: Convert popup menus to gtkbuilder, removing use of glade

### DIFF
--- a/glade/Makefile.am
+++ b/glade/Makefile.am
@@ -12,7 +12,6 @@ gttglade_DATA =              \
   plugin_editor.glade        \
   prefs.glade                \
   project_properties.glade   \
-  task_popup.glade           \
   task_properties.glade
 
 EXTRA_DIST =          \

--- a/glade/Makefile.am
+++ b/glade/Makefile.am
@@ -6,7 +6,6 @@ gttglade_DATA =              \
   column_menu.glade          \
   idle.glade                 \
   interval_edit.glade        \
-  interval_popup.glade       \
   notes.glade                \
   plugin.glade               \
   plugin_editor.glade        \

--- a/glade/interval_popup.glade
+++ b/glade/interval_popup.glade
@@ -1,182 +1,174 @@
-<?xml version="1.0" standalone="no"?> <!--*- mode: xml -*-->
-<!DOCTYPE glade-interface SYSTEM "http://glade.gnome.org/glade-2.0.dtd">
-
+<?xml version="1.0" encoding="UTF-8"?>
 <glade-interface>
-<requires lib="gnome"/>
-
-<widget class="GtkMenu" id="Interval Popup">
-  <property name="visible">True</property>
-
-  <child>
-    <widget class="GtkImageMenuItem" id="new_interval">
-      <property name="visible">True</property>
-      <property name="label" translatable="yes">New Interval</property>
-      <property name="use_underline">True</property>
-      <signal name="activate" handler="on_new_interval_activate"/>
-
-      <child internal-child="image">
-	<widget class="GtkImage" id="image14">
-	  <property name="visible">True</property>
-	  <property name="stock">gtk-new</property>
-	  <property name="icon_size">1</property>
-	  <property name="xalign">0.5</property>
-	  <property name="yalign">0.5</property>
-	  <property name="xpad">0</property>
-	  <property name="ypad">0</property>
-	</widget>
-      </child>
-    </widget>
-  </child>
-
-  <child>
-    <widget class="GtkMenuItem" id="edit">
-      <property name="visible">True</property>
-      <property name="label" translatable="yes">Edit Interval</property>
-      <property name="use_underline">True</property>
-      <signal name="activate" handler="on_edit_activate"/>
-    </widget>
-  </child>
-
-  <child>
-    <widget class="GtkImageMenuItem" id="delete">
-      <property name="visible">True</property>
-      <property name="label" translatable="yes">Delete Interval</property>
-      <property name="use_underline">True</property>
-      <signal name="activate" handler="on_delete_activate"/>
-
-      <child internal-child="image">
-	<widget class="GtkImage" id="image15">
-	  <property name="visible">True</property>
-	  <property name="stock">gtk-cut</property>
-	  <property name="icon_size">1</property>
-	  <property name="xalign">0.5</property>
-	  <property name="yalign">0.5</property>
-	  <property name="xpad">0</property>
-	  <property name="ypad">0</property>
-	</widget>
-      </child>
-    </widget>
-  </child>
-
-  <child>
-    <widget class="GtkMenuItem" id="separator1">
-      <property name="visible">True</property>
-    </widget>
-  </child>
-
-  <child>
-    <widget class="GtkMenuItem" id="merge_up">
-      <property name="visible">True</property>
-      <property name="label" translatable="yes">Merge Up</property>
-      <property name="use_underline">True</property>
-      <signal name="activate" handler="on_merge_up_activate"/>
-    </widget>
-  </child>
-
-  <child>
-    <widget class="GtkMenuItem" id="merge_down">
-      <property name="visible">True</property>
-      <property name="label" translatable="yes">Merge Down</property>
-      <property name="use_underline">True</property>
-      <signal name="activate" handler="on_merge_down_activate"/>
-    </widget>
-  </child>
-
-  <child>
-    <widget class="GtkMenuItem" id="separator2">
-      <property name="visible">True</property>
-    </widget>
-  </child>
-
-  <child>
-    <widget class="GtkImageMenuItem" id="move_up">
-      <property name="visible">True</property>
-      <property name="label" translatable="yes">Move Up</property>
-      <property name="use_underline">True</property>
-      <signal name="activate" handler="on_move_up_activate" last_modification_time="Fri, 07 May 2004 15:24:49 GMT"/>
-
-      <child internal-child="image">
-	<widget class="GtkImage" id="image16">
-	  <property name="visible">True</property>
-	  <property name="stock">gtk-go-up</property>
-	  <property name="icon_size">1</property>
-	  <property name="xalign">0.5</property>
-	  <property name="yalign">0.5</property>
-	  <property name="xpad">0</property>
-	  <property name="ypad">0</property>
-	</widget>
-      </child>
-    </widget>
-  </child>
-
-  <child>
-    <widget class="GtkImageMenuItem" id="move_down">
-      <property name="visible">True</property>
-      <property name="label" translatable="yes">Move Down</property>
-      <property name="use_underline">True</property>
-      <signal name="activate" handler="on_move_down_activate" last_modification_time="Fri, 07 May 2004 15:24:49 GMT"/>
-
-      <child internal-child="image">
-	<widget class="GtkImage" id="image17">
-	  <property name="visible">True</property>
-	  <property name="stock">gtk-go-down</property>
-	  <property name="icon_size">1</property>
-	  <property name="xalign">0.5</property>
-	  <property name="yalign">0.5</property>
-	  <property name="xpad">0</property>
-	  <property name="ypad">0</property>
-	</widget>
-      </child>
-    </widget>
-  </child>
-
-  <child>
-    <widget class="GtkMenuItem" id="separator3">
-      <property name="visible">True</property>
-    </widget>
-  </child>
-
-  <child>
-    <widget class="GtkImageMenuItem" id="insert_memo">
-      <property name="visible">True</property>
-      <property name="label" translatable="yes">Insert Diary Entry</property>
-      <property name="use_underline">True</property>
-      <signal name="activate" handler="on_insert_memo_activate"/>
-
-      <child internal-child="image">
-	<widget class="GtkImage" id="image18">
-	  <property name="visible">True</property>
-	  <property name="stock">gtk-new</property>
-	  <property name="icon_size">1</property>
-	  <property name="xalign">0.5</property>
-	  <property name="yalign">0.5</property>
-	  <property name="xpad">0</property>
-	  <property name="ypad">0</property>
-	</widget>
-      </child>
-    </widget>
-  </child>
-
-  <child>
-    <widget class="GtkImageMenuItem" id="paste_memo">
-      <property name="visible">True</property>
-      <property name="label" translatable="yes">Paste Diary Entry</property>
-      <property name="use_underline">True</property>
-      <signal name="activate" handler="on_paste_memo_activate"/>
-
-      <child internal-child="image">
-	<widget class="GtkImage" id="image19">
-	  <property name="visible">True</property>
-	  <property name="stock">gtk-paste</property>
-	  <property name="icon_size">1</property>
-	  <property name="xalign">0.5</property>
-	  <property name="yalign">0.5</property>
-	  <property name="xpad">0</property>
-	  <property name="ypad">0</property>
-	</widget>
-      </child>
-    </widget>
-  </child>
-</widget>
-
+  <!-- interface-requires gtk+ 2.24 -->
+  <!-- interface-naming-policy toplevel-contextual -->
+  <widget class="GtkMenu" id="Interval Popup">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <child>
+      <widget class="GtkImageMenuItem" id="new_interval">
+        <property name="label" translatable="yes">New Interval</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_action_appearance">False</property>
+        <property name="use_underline">True</property>
+        <property name="use_stock">False</property>
+        <signal name="activate" handler="on_new_interval_activate" swapped="no"/>
+        <child internal-child="image">
+          <widget class="GtkImage" id="image14">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="stock">gtk-new</property>
+            <property name="icon-size">1</property>
+          </widget>
+        </child>
+      </widget>
+    </child>
+    <child>
+      <widget class="GtkMenuItem" id="edit">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_action_appearance">False</property>
+        <property name="label" translatable="yes">Edit Interval</property>
+        <property name="use_underline">True</property>
+        <signal name="activate" handler="on_edit_activate" swapped="no"/>
+      </widget>
+    </child>
+    <child>
+      <widget class="GtkImageMenuItem" id="delete">
+        <property name="label" translatable="yes">Delete Interval</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_action_appearance">False</property>
+        <property name="use_underline">True</property>
+        <property name="use_stock">False</property>
+        <signal name="activate" handler="on_delete_activate" swapped="no"/>
+        <child internal-child="image">
+          <widget class="GtkImage" id="image15">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="stock">gtk-cut</property>
+            <property name="icon-size">1</property>
+          </widget>
+        </child>
+      </widget>
+    </child>
+    <child>
+      <widget class="GtkMenuItem" id="separator1">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_action_appearance">False</property>
+      </widget>
+    </child>
+    <child>
+      <widget class="GtkMenuItem" id="merge_up">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_action_appearance">False</property>
+        <property name="label" translatable="yes">Merge Up</property>
+        <property name="use_underline">True</property>
+        <signal name="activate" handler="on_merge_up_activate" swapped="no"/>
+      </widget>
+    </child>
+    <child>
+      <widget class="GtkMenuItem" id="merge_down">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_action_appearance">False</property>
+        <property name="label" translatable="yes">Merge Down</property>
+        <property name="use_underline">True</property>
+        <signal name="activate" handler="on_merge_down_activate" swapped="no"/>
+      </widget>
+    </child>
+    <child>
+      <widget class="GtkMenuItem" id="separator2">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_action_appearance">False</property>
+      </widget>
+    </child>
+    <child>
+      <widget class="GtkImageMenuItem" id="move_up">
+        <property name="label" translatable="yes">Move Up</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_action_appearance">False</property>
+        <property name="use_underline">True</property>
+        <property name="use_stock">False</property>
+        <signal name="activate" handler="on_move_up_activate" swapped="no"/>
+        <child internal-child="image">
+          <widget class="GtkImage" id="image16">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="stock">gtk-go-up</property>
+            <property name="icon-size">1</property>
+          </widget>
+        </child>
+      </widget>
+    </child>
+    <child>
+      <widget class="GtkImageMenuItem" id="move_down">
+        <property name="label" translatable="yes">Move Down</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_action_appearance">False</property>
+        <property name="use_underline">True</property>
+        <property name="use_stock">False</property>
+        <signal name="activate" handler="on_move_down_activate" swapped="no"/>
+        <child internal-child="image">
+          <widget class="GtkImage" id="image17">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="stock">gtk-go-down</property>
+            <property name="icon-size">1</property>
+          </widget>
+        </child>
+      </widget>
+    </child>
+    <child>
+      <widget class="GtkMenuItem" id="separator3">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_action_appearance">False</property>
+      </widget>
+    </child>
+    <child>
+      <widget class="GtkImageMenuItem" id="insert_memo">
+        <property name="label" translatable="yes">Insert Diary Entry</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_action_appearance">False</property>
+        <property name="use_underline">True</property>
+        <property name="use_stock">False</property>
+        <signal name="activate" handler="on_insert_memo_activate" swapped="no"/>
+        <child internal-child="image">
+          <widget class="GtkImage" id="image18">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="stock">gtk-new</property>
+            <property name="icon-size">1</property>
+          </widget>
+        </child>
+      </widget>
+    </child>
+    <child>
+      <widget class="GtkImageMenuItem" id="paste_memo">
+        <property name="label" translatable="yes">Paste Diary Entry</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_action_appearance">False</property>
+        <property name="use_underline">True</property>
+        <property name="use_stock">False</property>
+        <signal name="activate" handler="on_paste_memo_activate" swapped="no"/>
+        <child internal-child="image">
+          <widget class="GtkImage" id="image19">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="stock">gtk-paste</property>
+            <property name="icon-size">1</property>
+          </widget>
+        </child>
+      </widget>
+    </child>
+  </widget>
 </glade-interface>

--- a/glade/task_popup.glade
+++ b/glade/task_popup.glade
@@ -1,164 +1,149 @@
-<?xml version="1.0" standalone="no"?> <!--*- mode: xml -*-->
-<!DOCTYPE glade-interface SYSTEM "http://glade.gnome.org/glade-2.0.dtd">
-
+<?xml version="1.0" encoding="UTF-8"?>
 <glade-interface>
-<requires lib="gnome"/>
-
-<widget class="GtkMenu" id="Task Popup">
-  <property name="visible">True</property>
-
-  <child>
-    <widget class="GtkImageMenuItem" id="new_task">
-      <property name="visible">True</property>
-      <property name="label" translatable="yes">_New Diary Entry</property>
-      <property name="use_underline">True</property>
-      <signal name="activate" handler="on_new_task_activate"/>
-
-      <child internal-child="image">
-	<widget class="GtkImage" id="image17">
-	  <property name="visible">True</property>
-	  <property name="stock">gtk-new</property>
-	  <property name="icon_size">1</property>
-	  <property name="xalign">0.5</property>
-	  <property name="yalign">0.5</property>
-	  <property name="xpad">0</property>
-	  <property name="ypad">0</property>
-	</widget>
-      </child>
-    </widget>
-  </child>
-
-  <child>
-    <widget class="GtkImageMenuItem" id="edit_task">
-      <property name="visible">True</property>
-      <property name="label" translatable="yes">_Edit Diary Entry</property>
-      <property name="use_underline">True</property>
-      <signal name="activate" handler="on_edit_task_activate"/>
-
-      <child internal-child="image">
-	<widget class="GtkImage" id="image18">
-	  <property name="visible">True</property>
-	  <property name="stock">gtk-add</property>
-	  <property name="icon_size">1</property>
-	  <property name="xalign">0.5</property>
-	  <property name="yalign">0.5</property>
-	  <property name="xpad">0</property>
-	  <property name="ypad">0</property>
-	</widget>
-      </child>
-    </widget>
-  </child>
-
-  <child>
-    <widget class="GtkImageMenuItem" id="delete_memo">
-      <property name="visible">True</property>
-      <property name="label" translatable="yes">_Cut Diary Entry</property>
-      <property name="use_underline">True</property>
-      <signal name="activate" handler="on_delete_memo_activate"/>
-
-      <child internal-child="image">
-	<widget class="GtkImage" id="image19">
-	  <property name="visible">True</property>
-	  <property name="stock">gtk-cut</property>
-	  <property name="icon_size">1</property>
-	  <property name="xalign">0.5</property>
-	  <property name="yalign">0.5</property>
-	  <property name="xpad">0</property>
-	  <property name="ypad">0</property>
-	</widget>
-      </child>
-    </widget>
-  </child>
-
-  <child>
-    <widget class="GtkImageMenuItem" id="delete_times">
-      <property name="visible">True</property>
-      <property name="label" translatable="yes">Cut Entry &amp; _Times</property>
-      <property name="use_underline">True</property>
-      <signal name="activate" handler="on_delete_times_activate"/>
-
-      <child internal-child="image">
-	<widget class="GtkImage" id="image20">
-	  <property name="visible">True</property>
-	  <property name="stock">gtk-cut</property>
-	  <property name="icon_size">1</property>
-	  <property name="xalign">0.5</property>
-	  <property name="yalign">0.5</property>
-	  <property name="xpad">0</property>
-	  <property name="ypad">0</property>
-	</widget>
-      </child>
-    </widget>
-  </child>
-
-  <child>
-    <widget class="GtkImageMenuItem" id="copy">
-      <property name="visible">True</property>
-      <property name="label" translatable="yes">Copy Diary Entry</property>
-      <property name="use_underline">True</property>
-      <signal name="activate" handler="on_copy_activate" last_modification_time="Mon, 26 Apr 2004 14:09:42 GMT"/>
-
-      <child internal-child="image">
-	<widget class="GtkImage" id="image21">
-	  <property name="visible">True</property>
-	  <property name="stock">gtk-copy</property>
-	  <property name="icon_size">1</property>
-	  <property name="xalign">0.5</property>
-	  <property name="yalign">0.5</property>
-	  <property name="xpad">0</property>
-	  <property name="ypad">0</property>
-	</widget>
-      </child>
-    </widget>
-  </child>
-
-  <child>
-    <widget class="GtkImageMenuItem" id="paste">
-      <property name="visible">True</property>
-      <property name="label" translatable="yes">_Paste Diary Entry</property>
-      <property name="use_underline">True</property>
-      <signal name="activate" handler="on_paste_activate"/>
-
-      <child internal-child="image">
-	<widget class="GtkImage" id="image22">
-	  <property name="visible">True</property>
-	  <property name="stock">gtk-paste</property>
-	  <property name="icon_size">1</property>
-	  <property name="xalign">0.5</property>
-	  <property name="yalign">0.5</property>
-	  <property name="xpad">0</property>
-	  <property name="ypad">0</property>
-	</widget>
-      </child>
-    </widget>
-  </child>
-
-  <child>
-    <widget class="GtkMenuItem" id="separator1">
-      <property name="visible">True</property>
-    </widget>
-  </child>
-
-  <child>
-    <widget class="GtkImageMenuItem" id="new_interval">
-      <property name="visible">True</property>
-      <property name="label" translatable="yes">New Time Interval</property>
-      <property name="use_underline">True</property>
-      <signal name="activate" handler="on_new_interval_activate"/>
-
-      <child internal-child="image">
-	<widget class="GtkImage" id="image23">
-	  <property name="visible">True</property>
-	  <property name="stock">gtk-new</property>
-	  <property name="icon_size">1</property>
-	  <property name="xalign">0.5</property>
-	  <property name="yalign">0.5</property>
-	  <property name="xpad">0</property>
-	  <property name="ypad">0</property>
-	</widget>
-      </child>
-    </widget>
-  </child>
-</widget>
-
+  <!-- interface-requires gtk+ 2.24 -->
+  <!-- interface-naming-policy toplevel-contextual -->
+  <widget class="GtkMenu" id="Task Popup">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <child>
+      <widget class="GtkImageMenuItem" id="new_task">
+        <property name="label" translatable="yes">_New Diary Entry</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_action_appearance">False</property>
+        <property name="use_underline">True</property>
+        <property name="use_stock">False</property>
+        <signal name="activate" handler="on_new_task_activate" swapped="no"/>
+        <child internal-child="image">
+          <widget class="GtkImage" id="image17">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="stock">gtk-new</property>
+            <property name="icon-size">1</property>
+          </widget>
+        </child>
+      </widget>
+    </child>
+    <child>
+      <widget class="GtkImageMenuItem" id="edit_task">
+        <property name="label" translatable="yes">_Edit Diary Entry</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_action_appearance">False</property>
+        <property name="use_underline">True</property>
+        <property name="use_stock">False</property>
+        <signal name="activate" handler="on_edit_task_activate" swapped="no"/>
+        <child internal-child="image">
+          <widget class="GtkImage" id="image18">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="stock">gtk-add</property>
+            <property name="icon-size">1</property>
+          </widget>
+        </child>
+      </widget>
+    </child>
+    <child>
+      <widget class="GtkImageMenuItem" id="delete_memo">
+        <property name="label" translatable="yes">_Cut Diary Entry</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_action_appearance">False</property>
+        <property name="use_underline">True</property>
+        <property name="use_stock">False</property>
+        <signal name="activate" handler="on_delete_memo_activate" swapped="no"/>
+        <child internal-child="image">
+          <widget class="GtkImage" id="image19">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="stock">gtk-cut</property>
+            <property name="icon-size">1</property>
+          </widget>
+        </child>
+      </widget>
+    </child>
+    <child>
+      <widget class="GtkImageMenuItem" id="delete_times">
+        <property name="label" translatable="yes">Cut Entry &amp; _Times</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_action_appearance">False</property>
+        <property name="use_underline">True</property>
+        <property name="use_stock">False</property>
+        <signal name="activate" handler="on_delete_times_activate" swapped="no"/>
+        <child internal-child="image">
+          <widget class="GtkImage" id="image20">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="stock">gtk-cut</property>
+            <property name="icon-size">1</property>
+          </widget>
+        </child>
+      </widget>
+    </child>
+    <child>
+      <widget class="GtkImageMenuItem" id="copy">
+        <property name="label" translatable="yes">Copy Diary Entry</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_action_appearance">False</property>
+        <property name="use_underline">True</property>
+        <property name="use_stock">False</property>
+        <signal name="activate" handler="on_copy_activate" swapped="no"/>
+        <child internal-child="image">
+          <widget class="GtkImage" id="image21">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="stock">gtk-copy</property>
+            <property name="icon-size">1</property>
+          </widget>
+        </child>
+      </widget>
+    </child>
+    <child>
+      <widget class="GtkImageMenuItem" id="paste">
+        <property name="label" translatable="yes">_Paste Diary Entry</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_action_appearance">False</property>
+        <property name="use_underline">True</property>
+        <property name="use_stock">False</property>
+        <signal name="activate" handler="on_paste_activate" swapped="no"/>
+        <child internal-child="image">
+          <widget class="GtkImage" id="image22">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="stock">gtk-paste</property>
+            <property name="icon-size">1</property>
+          </widget>
+        </child>
+      </widget>
+    </child>
+    <child>
+      <widget class="GtkMenuItem" id="separator1">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_action_appearance">False</property>
+      </widget>
+    </child>
+    <child>
+      <widget class="GtkImageMenuItem" id="new_interval">
+        <property name="label" translatable="yes">New Time Interval</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_action_appearance">False</property>
+        <property name="use_underline">True</property>
+        <property name="use_stock">False</property>
+        <signal name="activate" handler="on_new_interval_activate" swapped="no"/>
+        <child internal-child="image">
+          <widget class="GtkImage" id="image23">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="stock">gtk-new</property>
+            <property name="icon-size">1</property>
+          </widget>
+        </child>
+      </widget>
+    </child>
+  </widget>
 </glade-interface>

--- a/src/journal.c
+++ b/src/journal.c
@@ -1184,6 +1184,39 @@ static void connect_signals_cb(
     }
 }
 
+static void connect_signals_task_popup_cb(
+    GtkBuilder *builder, GObject *object, const gchar *signal_name, const gchar *handler_name,
+    GObject *connect_object, GConnectFlags flags, gpointer user_data
+)
+{
+    // Alternatives to this structure is to export callbacks as global symbols (GModule),
+    // or, from Gtk 3.10, it's possible to register the callback using
+    // gtk_builder_add_callback_symbol() before calling gtk_builder_connect_signals().
+    // The latter approach would be more concise. Sticking with simplistic brute-force
+    // approach for now.
+
+    if (g_strcmp0(handler_name, "on_new_task_activate") == 0)
+        g_signal_connect(object, signal_name, G_CALLBACK(task_new_task_clicked_cb), user_data);
+
+    if (g_strcmp0(handler_name, "on_edit_task_activate") == 0)
+        g_signal_connect(object, signal_name, G_CALLBACK(task_edit_task_clicked_cb), user_data);
+
+    if (g_strcmp0(handler_name, "on_delete_memo_activate") == 0)
+        g_signal_connect(object, signal_name, G_CALLBACK(task_delete_memo_clicked_cb), user_data);
+
+    if (g_strcmp0(handler_name, "on_delete_times_activate") == 0)
+        g_signal_connect(object, signal_name, G_CALLBACK(task_delete_times_clicked_cb), user_data);
+
+    if (g_strcmp0(handler_name, "on_copy_activate") == 0)
+        g_signal_connect(object, signal_name, G_CALLBACK(task_copy_clicked_cb), user_data);
+
+    if (g_strcmp0(handler_name, "on_paste_activate") == 0)
+        g_signal_connect(object, signal_name, G_CALLBACK(task_paste_clicked_cb), user_data);
+
+    if (g_strcmp0(handler_name, "on_new_interval_activate") == 0)
+        g_signal_connect(object, signal_name, G_CALLBACK(task_new_interval_cb), user_data);
+}
+
 /* ============================================================== */
 
 static void do_show_report(
@@ -1303,39 +1336,13 @@ static void do_show_report(
     /* This is the popup menu that says 'edit/delete/merge' */
     /* for tasks */
 
-    glxml = gtt_glade_xml_new("glade/task_popup.glade", "Task Popup");
-    wig->task_popup = glade_xml_get_widget(glxml, "Task Popup");
-    wig->task_delete_memo = glade_xml_get_widget(glxml, "delete_memo");
-    wig->task_paste = glade_xml_get_widget(glxml, "paste");
+    builder = gtt_builder_new_from_file("ui/task_popup.ui");
+    wig->task_popup = GTK_WIDGET(gtk_builder_get_object(builder, "Task Popup"));
+    wig->task_delete_memo = GTK_WIDGET(gtk_builder_get_object(builder, "delete_memo"));
+    wig->task_paste = GTK_WIDGET(gtk_builder_get_object(builder, "paste"));
     wig->task = NULL;
 
-    glade_xml_signal_connect_data(
-        glxml, "on_new_task_activate", GTK_SIGNAL_FUNC(task_new_task_clicked_cb), wig
-    );
-
-    glade_xml_signal_connect_data(
-        glxml, "on_edit_task_activate", GTK_SIGNAL_FUNC(task_edit_task_clicked_cb), wig
-    );
-
-    glade_xml_signal_connect_data(
-        glxml, "on_delete_memo_activate", GTK_SIGNAL_FUNC(task_delete_memo_clicked_cb), wig
-    );
-
-    glade_xml_signal_connect_data(
-        glxml, "on_delete_times_activate", GTK_SIGNAL_FUNC(task_delete_times_clicked_cb), wig
-    );
-
-    glade_xml_signal_connect_data(
-        glxml, "on_copy_activate", GTK_SIGNAL_FUNC(task_copy_clicked_cb), wig
-    );
-
-    glade_xml_signal_connect_data(
-        glxml, "on_paste_activate", GTK_SIGNAL_FUNC(task_paste_clicked_cb), wig
-    );
-
-    glade_xml_signal_connect_data(
-        glxml, "on_new_interval_activate", GTK_SIGNAL_FUNC(task_new_interval_cb), wig
-    );
+    gtk_builder_connect_signals_full(builder, connect_signals_task_popup_cb, wig);
 
     /* ---------------------------------------------------- */
     wig->hover_help_window = NULL;

--- a/src/journal.c
+++ b/src/journal.c
@@ -20,7 +20,6 @@
 
 #include "config.h"
 
-#include <glade/glade.h>
 #include <gnome.h>
 #include <gtkhtml/gtkhtml.h>
 #include <sched.h>

--- a/src/journal.c
+++ b/src/journal.c
@@ -1184,6 +1184,39 @@ static void connect_signals_cb(
     }
 }
 
+static void connect_signals_interval_popup_cb(
+    GtkBuilder *builder, GObject *object, const gchar *signal_name, const gchar *handler_name,
+    GObject *connect_object, GConnectFlags flags, gpointer user_data
+)
+{
+    if (g_strcmp0(handler_name, "on_new_interval_activate") == 0)
+        g_signal_connect(object, signal_name, G_CALLBACK(interval_new_clicked_cb), user_data);
+
+    if (g_strcmp0(handler_name, "on_edit_activate") == 0)
+        g_signal_connect(object, signal_name, G_CALLBACK(interval_edit_clicked_cb), user_data);
+
+    if (g_strcmp0(handler_name, "on_delete_activate") == 0)
+        g_signal_connect(object, signal_name, G_CALLBACK(interval_delete_clicked_cb), user_data);
+
+    if (g_strcmp0(handler_name, "on_merge_up_activate") == 0)
+        g_signal_connect(object, signal_name, G_CALLBACK(interval_merge_up_clicked_cb), user_data);
+
+    if (g_strcmp0(handler_name, "on_merge_down_activate") == 0)
+        g_signal_connect(object, signal_name, G_CALLBACK(interval_merge_down_clicked_cb), user_data);
+
+    if (g_strcmp0(handler_name, "on_move_up_activate") == 0)
+        g_signal_connect(object, signal_name, G_CALLBACK(interval_move_up_clicked_cb), user_data);
+
+    if (g_strcmp0(handler_name, "on_move_down_activate") == 0)
+        g_signal_connect(object, signal_name, G_CALLBACK(interval_move_down_clicked_cb), user_data);
+
+    if (g_strcmp0(handler_name, "on_insert_memo_activate") == 0)
+        g_signal_connect(object, signal_name, G_CALLBACK(interval_insert_memo_cb), user_data);
+
+    if (g_strcmp0(handler_name, "on_paste_memo_activate") == 0)
+        g_signal_connect(object, signal_name, G_CALLBACK(interval_paste_memo_cb), user_data);
+}
+
 static void connect_signals_task_popup_cb(
     GtkBuilder *builder, GObject *object, const gchar *signal_name, const gchar *handler_name,
     GObject *connect_object, GConnectFlags flags, gpointer user_data
@@ -1225,7 +1258,6 @@ static void do_show_report(
 )
 {
     GtkWidget *jnl_top, *jnl_viewport;
-    GladeXML *glxml;
     GtkBuilder *builder;
     Wiggy *wig;
 
@@ -1287,50 +1319,16 @@ static void do_show_report(
     /* This is the popup menu that says 'edit/delete/merge' */
     /* for intervals */
 
-    glxml = gtt_glade_xml_new("glade/interval_popup.glade", "Interval Popup");
-    wig->interval_popup = glade_xml_get_widget(glxml, "Interval Popup");
-    wig->interval_paste = glade_xml_get_widget(glxml, "paste_memo");
-    wig->interval_merge_up = glade_xml_get_widget(glxml, "merge_up");
-    wig->interval_merge_down = glade_xml_get_widget(glxml, "merge_down");
-    wig->interval_move_up = glade_xml_get_widget(glxml, "move_up");
-    wig->interval_move_down = glade_xml_get_widget(glxml, "move_down");
+    builder = gtt_builder_new_from_file("ui/interval_popup.ui");
+    wig->interval_popup = GTK_WIDGET(gtk_builder_get_object(builder, "Interval Popup"));
+    wig->interval_paste = GTK_WIDGET(gtk_builder_get_object(builder, "paste_memo"));
+    wig->interval_merge_up = GTK_WIDGET(gtk_builder_get_object(builder, "merge_up"));
+    wig->interval_merge_down = GTK_WIDGET(gtk_builder_get_object(builder, "merge_down"));
+    wig->interval_move_up = GTK_WIDGET(gtk_builder_get_object(builder, "move_up"));
+    wig->interval_move_down = GTK_WIDGET(gtk_builder_get_object(builder, "move_down"));
     wig->interval = NULL;
 
-    glade_xml_signal_connect_data(
-        glxml, "on_new_interval_activate", GTK_SIGNAL_FUNC(interval_new_clicked_cb), wig
-    );
-
-    glade_xml_signal_connect_data(
-        glxml, "on_edit_activate", GTK_SIGNAL_FUNC(interval_edit_clicked_cb), wig
-    );
-
-    glade_xml_signal_connect_data(
-        glxml, "on_delete_activate", GTK_SIGNAL_FUNC(interval_delete_clicked_cb), wig
-    );
-
-    glade_xml_signal_connect_data(
-        glxml, "on_merge_up_activate", GTK_SIGNAL_FUNC(interval_merge_up_clicked_cb), wig
-    );
-
-    glade_xml_signal_connect_data(
-        glxml, "on_merge_down_activate", GTK_SIGNAL_FUNC(interval_merge_down_clicked_cb), wig
-    );
-
-    glade_xml_signal_connect_data(
-        glxml, "on_move_up_activate", GTK_SIGNAL_FUNC(interval_move_up_clicked_cb), wig
-    );
-
-    glade_xml_signal_connect_data(
-        glxml, "on_move_down_activate", GTK_SIGNAL_FUNC(interval_move_down_clicked_cb), wig
-    );
-
-    glade_xml_signal_connect_data(
-        glxml, "on_insert_memo_activate", GTK_SIGNAL_FUNC(interval_insert_memo_cb), wig
-    );
-
-    glade_xml_signal_connect_data(
-        glxml, "on_paste_memo_activate", GTK_SIGNAL_FUNC(interval_paste_memo_cb), wig
-    );
+    gtk_builder_connect_signals_full(builder, connect_signals_interval_popup_cb, wig);
 
     /* ---------------------------------------------------- */
     /* This is the popup menu that says 'edit/delete/merge' */

--- a/ui/Makefile.am
+++ b/ui/Makefile.am
@@ -2,7 +2,8 @@
 gttuidir = $(datadir)/gnotime/ui
 
 gttui_DATA =                 \
-  journal.ui
+  journal.ui                 \
+  task_popup.ui
 
 EXTRA_DIST =          \
    $(gttui_DATA)

--- a/ui/Makefile.am
+++ b/ui/Makefile.am
@@ -2,6 +2,7 @@
 gttuidir = $(datadir)/gnotime/ui
 
 gttui_DATA =                 \
+  interval_popup.ui          \
   journal.ui                 \
   task_popup.ui
 

--- a/ui/interval_popup.ui
+++ b/ui/interval_popup.ui
@@ -1,174 +1,168 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glade-interface>
-  <!-- interface-requires gtk+ 2.24 -->
+<interface>
+  <requires lib="gtk+" version="2.24"/>
   <!-- interface-naming-policy toplevel-contextual -->
-  <widget class="GtkMenu" id="Interval Popup">
+  <object class="GtkMenu" id="Interval Popup">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <child>
-      <widget class="GtkImageMenuItem" id="new_interval">
+      <object class="GtkImageMenuItem" id="new_interval">
         <property name="label" translatable="yes">New Interval</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_underline">True</property>
+        <property name="image">image14</property>
         <property name="use_stock">False</property>
         <signal name="activate" handler="on_new_interval_activate" swapped="no"/>
-        <child internal-child="image">
-          <widget class="GtkImage" id="image14">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="stock">gtk-new</property>
-            <property name="icon-size">1</property>
-          </widget>
-        </child>
-      </widget>
+      </object>
     </child>
     <child>
-      <widget class="GtkMenuItem" id="edit">
+      <object class="GtkMenuItem" id="edit">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="label" translatable="yes">Edit Interval</property>
         <property name="use_underline">True</property>
         <signal name="activate" handler="on_edit_activate" swapped="no"/>
-      </widget>
+      </object>
     </child>
     <child>
-      <widget class="GtkImageMenuItem" id="delete">
+      <object class="GtkImageMenuItem" id="delete">
         <property name="label" translatable="yes">Delete Interval</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_underline">True</property>
+        <property name="image">image15</property>
         <property name="use_stock">False</property>
         <signal name="activate" handler="on_delete_activate" swapped="no"/>
-        <child internal-child="image">
-          <widget class="GtkImage" id="image15">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="stock">gtk-cut</property>
-            <property name="icon-size">1</property>
-          </widget>
-        </child>
-      </widget>
+      </object>
     </child>
     <child>
-      <widget class="GtkMenuItem" id="separator1">
+      <object class="GtkMenuItem" id="separator1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
-      </widget>
+      </object>
     </child>
     <child>
-      <widget class="GtkMenuItem" id="merge_up">
+      <object class="GtkMenuItem" id="merge_up">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="label" translatable="yes">Merge Up</property>
         <property name="use_underline">True</property>
         <signal name="activate" handler="on_merge_up_activate" swapped="no"/>
-      </widget>
+      </object>
     </child>
     <child>
-      <widget class="GtkMenuItem" id="merge_down">
+      <object class="GtkMenuItem" id="merge_down">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="label" translatable="yes">Merge Down</property>
         <property name="use_underline">True</property>
         <signal name="activate" handler="on_merge_down_activate" swapped="no"/>
-      </widget>
+      </object>
     </child>
     <child>
-      <widget class="GtkMenuItem" id="separator2">
+      <object class="GtkMenuItem" id="separator2">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
-      </widget>
+      </object>
     </child>
     <child>
-      <widget class="GtkImageMenuItem" id="move_up">
+      <object class="GtkImageMenuItem" id="move_up">
         <property name="label" translatable="yes">Move Up</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_underline">True</property>
+        <property name="image">image16</property>
         <property name="use_stock">False</property>
         <signal name="activate" handler="on_move_up_activate" swapped="no"/>
-        <child internal-child="image">
-          <widget class="GtkImage" id="image16">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="stock">gtk-go-up</property>
-            <property name="icon-size">1</property>
-          </widget>
-        </child>
-      </widget>
+      </object>
     </child>
     <child>
-      <widget class="GtkImageMenuItem" id="move_down">
+      <object class="GtkImageMenuItem" id="move_down">
         <property name="label" translatable="yes">Move Down</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_underline">True</property>
+        <property name="image">image17</property>
         <property name="use_stock">False</property>
         <signal name="activate" handler="on_move_down_activate" swapped="no"/>
-        <child internal-child="image">
-          <widget class="GtkImage" id="image17">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="stock">gtk-go-down</property>
-            <property name="icon-size">1</property>
-          </widget>
-        </child>
-      </widget>
+      </object>
     </child>
     <child>
-      <widget class="GtkMenuItem" id="separator3">
+      <object class="GtkMenuItem" id="separator3">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
-      </widget>
+      </object>
     </child>
     <child>
-      <widget class="GtkImageMenuItem" id="insert_memo">
+      <object class="GtkImageMenuItem" id="insert_memo">
         <property name="label" translatable="yes">Insert Diary Entry</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_underline">True</property>
+        <property name="image">image18</property>
         <property name="use_stock">False</property>
         <signal name="activate" handler="on_insert_memo_activate" swapped="no"/>
-        <child internal-child="image">
-          <widget class="GtkImage" id="image18">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="stock">gtk-new</property>
-            <property name="icon-size">1</property>
-          </widget>
-        </child>
-      </widget>
+      </object>
     </child>
     <child>
-      <widget class="GtkImageMenuItem" id="paste_memo">
+      <object class="GtkImageMenuItem" id="paste_memo">
         <property name="label" translatable="yes">Paste Diary Entry</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_underline">True</property>
+        <property name="image">image19</property>
         <property name="use_stock">False</property>
         <signal name="activate" handler="on_paste_memo_activate" swapped="no"/>
-        <child internal-child="image">
-          <widget class="GtkImage" id="image19">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="stock">gtk-paste</property>
-            <property name="icon-size">1</property>
-          </widget>
-        </child>
-      </widget>
+      </object>
     </child>
-  </widget>
-</glade-interface>
+  </object>
+  <object class="GtkImage" id="image14">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-new</property>
+    <property name="icon-size">1</property>
+  </object>
+  <object class="GtkImage" id="image15">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-cut</property>
+    <property name="icon-size">1</property>
+  </object>
+  <object class="GtkImage" id="image16">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-go-up</property>
+    <property name="icon-size">1</property>
+  </object>
+  <object class="GtkImage" id="image17">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-go-down</property>
+    <property name="icon-size">1</property>
+  </object>
+  <object class="GtkImage" id="image18">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-new</property>
+    <property name="icon-size">1</property>
+  </object>
+  <object class="GtkImage" id="image19">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-paste</property>
+    <property name="icon-size">1</property>
+  </object>
+</interface>

--- a/ui/task_popup.ui
+++ b/ui/task_popup.ui
@@ -1,149 +1,142 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glade-interface>
-  <!-- interface-requires gtk+ 2.24 -->
+<interface>
+  <requires lib="gtk+" version="2.24"/>
   <!-- interface-naming-policy toplevel-contextual -->
-  <widget class="GtkMenu" id="Task Popup">
+  <object class="GtkMenu" id="Task Popup">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <child>
-      <widget class="GtkImageMenuItem" id="new_task">
+      <object class="GtkImageMenuItem" id="new_task">
         <property name="label" translatable="yes">_New Diary Entry</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_underline">True</property>
+        <property name="image">image17</property>
         <property name="use_stock">False</property>
         <signal name="activate" handler="on_new_task_activate" swapped="no"/>
-        <child internal-child="image">
-          <widget class="GtkImage" id="image17">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="stock">gtk-new</property>
-            <property name="icon-size">1</property>
-          </widget>
-        </child>
-      </widget>
+      </object>
     </child>
     <child>
-      <widget class="GtkImageMenuItem" id="edit_task">
+      <object class="GtkImageMenuItem" id="edit_task">
         <property name="label" translatable="yes">_Edit Diary Entry</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_underline">True</property>
+        <property name="image">image18</property>
         <property name="use_stock">False</property>
         <signal name="activate" handler="on_edit_task_activate" swapped="no"/>
-        <child internal-child="image">
-          <widget class="GtkImage" id="image18">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="stock">gtk-add</property>
-            <property name="icon-size">1</property>
-          </widget>
-        </child>
-      </widget>
+      </object>
     </child>
     <child>
-      <widget class="GtkImageMenuItem" id="delete_memo">
+      <object class="GtkImageMenuItem" id="delete_memo">
         <property name="label" translatable="yes">_Cut Diary Entry</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_underline">True</property>
+        <property name="image">image19</property>
         <property name="use_stock">False</property>
         <signal name="activate" handler="on_delete_memo_activate" swapped="no"/>
-        <child internal-child="image">
-          <widget class="GtkImage" id="image19">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="stock">gtk-cut</property>
-            <property name="icon-size">1</property>
-          </widget>
-        </child>
-      </widget>
+      </object>
     </child>
     <child>
-      <widget class="GtkImageMenuItem" id="delete_times">
+      <object class="GtkImageMenuItem" id="delete_times">
         <property name="label" translatable="yes">Cut Entry &amp; _Times</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_underline">True</property>
+        <property name="image">image20</property>
         <property name="use_stock">False</property>
         <signal name="activate" handler="on_delete_times_activate" swapped="no"/>
-        <child internal-child="image">
-          <widget class="GtkImage" id="image20">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="stock">gtk-cut</property>
-            <property name="icon-size">1</property>
-          </widget>
-        </child>
-      </widget>
+      </object>
     </child>
     <child>
-      <widget class="GtkImageMenuItem" id="copy">
+      <object class="GtkImageMenuItem" id="copy">
         <property name="label" translatable="yes">Copy Diary Entry</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_underline">True</property>
+        <property name="image">image21</property>
         <property name="use_stock">False</property>
         <signal name="activate" handler="on_copy_activate" swapped="no"/>
-        <child internal-child="image">
-          <widget class="GtkImage" id="image21">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="stock">gtk-copy</property>
-            <property name="icon-size">1</property>
-          </widget>
-        </child>
-      </widget>
+      </object>
     </child>
     <child>
-      <widget class="GtkImageMenuItem" id="paste">
+      <object class="GtkImageMenuItem" id="paste">
         <property name="label" translatable="yes">_Paste Diary Entry</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_underline">True</property>
+        <property name="image">image22</property>
         <property name="use_stock">False</property>
         <signal name="activate" handler="on_paste_activate" swapped="no"/>
-        <child internal-child="image">
-          <widget class="GtkImage" id="image22">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="stock">gtk-paste</property>
-            <property name="icon-size">1</property>
-          </widget>
-        </child>
-      </widget>
+      </object>
     </child>
     <child>
-      <widget class="GtkMenuItem" id="separator1">
+      <object class="GtkMenuItem" id="separator1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
-      </widget>
+      </object>
     </child>
     <child>
-      <widget class="GtkImageMenuItem" id="new_interval">
+      <object class="GtkImageMenuItem" id="new_interval">
         <property name="label" translatable="yes">New Time Interval</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_underline">True</property>
+        <property name="image">image23</property>
         <property name="use_stock">False</property>
         <signal name="activate" handler="on_new_interval_activate" swapped="no"/>
-        <child internal-child="image">
-          <widget class="GtkImage" id="image23">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="stock">gtk-new</property>
-            <property name="icon-size">1</property>
-          </widget>
-        </child>
-      </widget>
+      </object>
     </child>
-  </widget>
-</glade-interface>
+  </object>
+  <object class="GtkImage" id="image17">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-new</property>
+    <property name="icon-size">1</property>
+  </object>
+  <object class="GtkImage" id="image18">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-add</property>
+    <property name="icon-size">1</property>
+  </object>
+  <object class="GtkImage" id="image19">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-cut</property>
+    <property name="icon-size">1</property>
+  </object>
+  <object class="GtkImage" id="image20">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-cut</property>
+    <property name="icon-size">1</property>
+  </object>
+  <object class="GtkImage" id="image21">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-copy</property>
+    <property name="icon-size">1</property>
+  </object>
+  <object class="GtkImage" id="image22">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-paste</property>
+    <property name="icon-size">1</property>
+  </object>
+  <object class="GtkImage" id="image23">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-new</property>
+    <property name="icon-size">1</property>
+  </object>
+</interface>


### PR DESCRIPTION
This converts the two glade-defined popup menus in the journal to gtkbuilder format, making the journal no longer require libglade.

The first two commits are meant as an equivalent refresh to Gtk 2.24 glade format, followed by two commits to convert to GtkBuilder format including related code changes.